### PR TITLE
Add initial docker build workflow step on PR and main merge

### DIFF
--- a/.github/workflows/docker-build-and-tag.yml
+++ b/.github/workflows/docker-build-and-tag.yml
@@ -27,7 +27,8 @@ jobs:
       - name: Build Docker image with commit hash
         run: docker build -t house-innovations-housnav-web:${{ env.GIT_SHA }} -f apps/web/Dockerfile . --no-cache
 
-      - name: Tag Docker image as latest
+      - name: Tag Docker image as latest for main branch
+        if: github.ref == 'refs/heads/main' && github.event_name == 'pull_request' && github.event.pull_request.merged == true
         run: docker tag house-innovations-housnav-web:${{ env.GIT_SHA }} house-innovations-housnav-web:latest
 
       - name: List Docker images

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,34 @@
+name: Docker Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch: # This allows you to manually trigger the workflow
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Extract Git commit hash
+        id: vars
+        run: echo "GIT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      - name: Build Docker image with commit hash
+        run: docker build -f apps/web/DockerFile -t house-innovations-housnav-web:${{ env.GIT_SHA }} .
+
+      - name: Tag Docker image as latest
+        run: docker tag house-innovations-housnav-web:${{ env.GIT_SHA }} house-innovations-housnav-web:latest
+
+      - name: List Docker images
+        run: docker images

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -25,7 +25,7 @@ jobs:
         run: echo "GIT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Build Docker image with commit hash
-        run: docker build -f apps/web/DockerFile -t house-innovations-housnav-web:${{ env.GIT_SHA }} .
+        run: docker build -t house-innovations-housnav-web:${{ env.GIT_SHA }} -f apps/web/Dockerfile . --no-cache
 
       - name: Tag Docker image as latest
         run: docker tag house-innovations-housnav-web:${{ env.GIT_SHA }} house-innovations-housnav-web:latest

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Extract Git commit hash
         id: vars

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -28,7 +28,7 @@ WORKDIR /app
 COPY .gitignore .gitignore
 COPY --from=builder /app/out/json/ .
 COPY --from=builder /app/out/package-lock.json ./package-lock.json
-RUN npm install --verbose
+RUN npm install
 
 # Build the project
 COPY --from=builder /app/out/full/ .


### PR DESCRIPTION
Add a starter GitHub workflow that does the following:

1. Checkouts out the repository from the current branch/pr
2. Builds the Docker container of the web application for the house-innovations-housnav project and tags it with a unique commit hash.
3. On merge to main, tag build as latest. (We can always change this depending on how we want to deploy, this is just a starting place.)

Testing:
Build details: https://github.com/bcgov/House-Innovations-HOUSNAV/actions/runs/9133784415/job/25117995946?pr=8