### PR TITLE
HOUSNAV-45: adding code references to walkthrough 9.9.9

### DIFF
--- a/apps/web/components/question/Question.test.tsx
+++ b/apps/web/components/question/Question.test.tsx
@@ -117,7 +117,10 @@ describe("Question", () => {
 
     // add questionCodeReference if it does not exist in questionData
     if (!questionInfo.questionData.questionCodeReference) {
-      questionInfo.questionData.questionCodeReference = "code reference";
+      questionInfo.questionData.questionCodeReference = {
+        displayString: "code reference",
+        codeNumber: "1",
+      };
     }
 
     // mock setQuestion function and render component

--- a/apps/web/components/question/Question.test.tsx
+++ b/apps/web/components/question/Question.test.tsx
@@ -133,8 +133,11 @@ describe("Question", () => {
       />,
     );
 
-    // expect code reference
+    // expect code reference and that it contains the displayString
     expect(getByTestId(TESTID_QUESTION_CODE_REFERENCE)).toBeInTheDocument();
+    expect(getByTestId(TESTID_QUESTION_CODE_REFERENCE)).toHaveTextContent(
+      questionInfo.questionData.questionCodeReference.displayString,
+    );
   });
   /*
    * QuestionMultiChoiceMultiple

--- a/apps/web/components/question/Question.tsx
+++ b/apps/web/components/question/Question.tsx
@@ -120,8 +120,8 @@ export default function Question({
           className="web-Question--Reference"
           data-testid={TESTID_QUESTION_CODE_REFERENCE}
         >
-          {/* TODO - setup code reference once we have a question with one */}
-          Reference: <Button variant="code">Vol 2, Section 9.9.9.1</Button>
+          Reference:{" "}
+          <Button variant="code">{questionCodeReference.displayString}</Button>
         </p>
       )}
       <Form onSubmit={handleSubmit} className="web-Question--Form">

--- a/packages/data/src/useWalkthroughData.ts
+++ b/packages/data/src/useWalkthroughData.ts
@@ -53,9 +53,14 @@ interface VariableToSet {
   };
 }
 
+type QuestionCodeReferenceType = {
+  displayString: string;
+  codeNumber: string;
+};
+
 interface QuestionBaseData {
   questionText: string;
-  questionCodeReference?: string;
+  questionCodeReference?: QuestionCodeReferenceType;
   possibleAnswers: PossibleAnswer[];
   nextNavigationLogic: NextNavigationLogic[];
 }

--- a/packages/data/walkthroughs/9.9.9.json
+++ b/packages/data/walkthroughs/9.9.9.json
@@ -425,6 +425,10 @@
     "P1": {
       "walkthroughItemType": "multiChoice",
       "questionText": "Is this location a <defined-term>dwelling unit</defined-term>?",
+      "questionCodeReference": {
+        "displayString": "Vol 2, Section 9.9.9.1",
+        "codeNumber": "V2-9.9.9.1"
+      },
       "possibleAnswers": [
         {
           "answerDisplayText": "Yes",
@@ -451,6 +455,10 @@
     "P2": {
       "walkthroughItemType": "multiChoice",
       "questionText": "How many <defined-term>storeys</defined-term> does this <defined-term>dwelling unit</defined-term> have?",
+      "questionCodeReference": {
+        "displayString": "Vol 2, Section 9.9.9.1",
+        "codeNumber": "V2-9.9.9.1"
+      },
       "possibleAnswers": [
         {
           "answerDisplayText": "1 storey",
@@ -504,6 +512,10 @@
       "walkthroughItemType": "multiChoiceMultiple",
       "answersAreDynamic": true,
       "questionText": "Which <defined-term>storeys</defined-term> within the <defined-term>dwelling unit</defined-term> are provided with an egress or <defined-term>exit</defined-term> doors?",
+      "questionCodeReference": {
+        "displayString": "Vol 2, Section 9.9.9.1",
+        "codeNumber": "V2-9.9.9.1"
+      },
       "possibleAnswers": [
         {
           "answerDisplayText": "<defined-term>Basement</defined-term>",
@@ -710,6 +722,10 @@
       "walkthroughItemType": "multiChoiceMultiple",
       "answersAreDynamic": true,
       "questionText": "Which level(s) of the <defined-term>dwelling unit</defined-term> have access to a balcony?",
+      "questionCodeReference": {
+        "displayString": "Vol 2, Section 9.9.9.1",
+        "codeNumber": "V2-9.9.9.1"
+      },
       "possibleAnswers": [
         {
           "answerDisplayText": "<defined-term>Basement</defined-term>",
@@ -766,6 +782,10 @@
     "P6": {
       "walkthroughItemType": "multiChoice",
       "questionText": "Is this <defined-term>dwelling unit</defined-term> above another <defined-term>dwelling unit</defined-term>?",
+      "questionCodeReference": {
+        "displayString": "Vol 2, Section 9.9.9.1",
+        "codeNumber": "V2-9.9.9.1"
+      },
       "possibleAnswers": [
         {
           "answerDisplayText": "Yes",
@@ -792,6 +812,10 @@
     "P7": {
       "walkthroughItemType": "multiChoiceMultiple",
       "questionText": "Which level(s) of the <defined-term>dwelling unit</defined-term> have access to an openable window that is at least 1m high and 0.55m wide?",
+      "questionCodeReference": {
+        "displayString": "Vol 2, Section 9.9.9.1",
+        "codeNumber": "V2-9.9.9.1"
+      },
       "answersAreDynamic": true,
       "possibleAnswers": [
         {
@@ -1151,6 +1175,10 @@
       "walkthroughItemType": "multiChoiceMultiple",
       "answersAreDynamic": true,
       "questionText": "Which level(s) of the <defined-term>dwelling unit</defined-term> have less than 1m of the finish floor level and less than 7m above adjacent ground level?",
+      "questionCodeReference": {
+        "displayString": "Vol 2, Section 9.9.9.1",
+        "codeNumber": "V2-9.9.9.1"
+      },
       "possibleAnswers": [
         {
           "answerDisplayText": "<defined-term>Basement</defined-term>",
@@ -1380,6 +1408,10 @@
       "walkthroughItemType": "multiChoiceMultiple",
       "answersAreDynamic": true,
       "questionText": "On which level(s) is the door an egress door to a <defined-term>public corridor</defined-term>, enclosed <defined-term>exit</defined-term> stair, or passageway?" ,
+      "questionCodeReference": {
+        "displayString": "Vol 2, Section 9.9.9.1",
+        "codeNumber": "V2-9.9.9.1"
+      },
       "possibleAnswers": [
         {
           "answerDisplayText": "<defined-term>Basement</defined-term>",
@@ -1437,6 +1469,10 @@
       "walkthroughItemType": "multiChoiceMultiple",
       "answersAreDynamic": true,
       "questionText": "On which level(s) is the egress door an <defined-term>exit</defined-term> doorway not more than 1.5m above adjacent ground level?",
+      "questionCodeReference": {
+        "displayString": "Vol 2, Section 9.9.9.1",
+        "codeNumber": "V2-9.9.9.1"
+      },
       "possibleAnswers": [
         {
           "answerDisplayText": "<defined-term>Basement</defined-term>",
@@ -1559,6 +1595,10 @@
     "P11": {
       "walkthroughItemType": "multiChoice",
       "questionText": "How many <defined-term>dwelling units</defined-term> are in this <defined-term>building</defined-term>?",
+      "questionCodeReference": {
+        "displayString": "Vol 2, Section 9.9.9.2",
+        "codeNumber": "V2-9.9.9.2"
+      },
       "possibleAnswers": [
         {
           "answerDisplayText": "1-2",
@@ -1579,6 +1619,10 @@
     "P12": {
       "walkthroughItemType": "multiChoice",
       "questionText": "Is this <defined-term>dwelling unit</defined-term> provided with at least two separate <defined-term>means of egress</defined-term>?",
+      "questionCodeReference": {
+        "displayString": "Vol 2, Section 9.9.9.2",
+        "codeNumber": "V2-9.9.9.2"
+      },
       "possibleAnswers": [
         {
           "answerDisplayText": "Yes",
@@ -1605,6 +1649,10 @@
     "P13": {
       "walkthroughItemType": "multiChoice",
       "questionText": "Does this <defined-term>dwelling unit</defined-term>’s egress door open onto a <defined-term>public corridor</defined-term> or an exterior passageway?",
+      "questionCodeReference": {
+        "displayString": "Vol 2, Section 9.9.9.2",
+        "codeNumber": "V2-9.9.9.2"
+      },
       "possibleAnswers": [
         {
           "answerDisplayText": "Yes",
@@ -1631,6 +1679,10 @@
     "P14": {
       "walkthroughItemType": "multiChoice",
       "questionText": "Where the egress door opens onto the corridor or exterior passageway, is it possible to go in opposite directions to 2 separate <defined-term>exits</defined-term>?",
+      "questionCodeReference": {
+        "displayString": "Vol 2, Section 9.9.9.2",
+        "codeNumber": "V2-9.9.9.2"
+      },
       "possibleAnswers": [
         {
           "answerDisplayText": "Yes",
@@ -1663,6 +1715,10 @@
     "P15": {
       "walkthroughItemType": "multiChoice",
       "questionText": "Does the egress door of this <defined-term>dwelling unit</defined-term> open onto a corridor that meets the requirements of Sentence 9.9.7.3.(1)?",
+      "questionCodeReference": {
+        "displayString": "Vol 2, Section 9.9.9.2",
+        "codeNumber": "V2-9.9.9.2"
+      },
       "possibleAnswers": [
         {
           "answerDisplayText": "Yes",
@@ -1689,6 +1745,10 @@
     "P16": {
       "walkthroughItemType": "multiChoice",
       "questionText": "Is the <defined-term>building</defined-term> <defined-term>sprinklered</defined-term>?",
+      "questionCodeReference": {
+        "displayString": "Vol 2, Section 9.9.9.2",
+        "codeNumber": "V2-9.9.9.2"
+      },
       "possibleAnswers": [
         {
           "answerDisplayText": "Yes",
@@ -1715,6 +1775,10 @@
     "P17": {
       "walkthroughItemType": "multiChoice",
       "questionText": "Does this <defined-term>building</defined-term> meet the definition of a <defined-term>secondary suite</defined-term>?",
+      "questionCodeReference": {
+        "displayString": "Vol 2, Section 9.9.9.2",
+        "codeNumber": "V2-9.9.9.2"
+      },
       "possibleAnswers": [
         {
           "answerDisplayText": "Yes",
@@ -1817,6 +1881,10 @@
     "P18": {
       "walkthroughItemType": "multiChoice",
       "questionText": "Is this <defined-term>dwelling unit</defined-term> located above another <defined-term>dwelling unit</defined-term> or common space?",
+      "questionCodeReference": {
+        "displayString": "Vol 2, Section 9.9.9.3",
+        "codeNumber": "V2-9.9.9.3"
+      },
       "possibleAnswers": [
         {
           "answerDisplayText": "Yes",
@@ -1843,6 +1911,10 @@
     "P19": {
       "walkthroughItemType": "multiChoice",
       "questionText": "Does the egress door of this <defined-term>dwelling unit</defined-term> open onto a shared egress facility (corridor, passageway, stair, <defined-term>ramp</defined-term>, etc.) that is served by a single stair or <defined-term>ramp</defined-term>?",
+      "questionCodeReference": {
+        "displayString": "Vol 2, Section 9.9.9.3",
+        "codeNumber": "V2-9.9.9.3"
+      },
       "possibleAnswers": [
         {
           "answerDisplayText": "Yes",
@@ -1919,6 +1991,10 @@
     "P20": {
       "walkthroughItemType": "multiChoice",
       "questionText": "Does the egress door of this <defined-term>dwelling unit</defined-term> open onto an <defined-term>exit</defined-term> stair, <defined-term>public corridor</defined-term>, exterior passageway, or balcony, that serves more than one <defined-term>suite</defined-term>?",
+      "questionCodeReference": {
+        "displayString": "Vol 2, Section 9.9.9.3",
+        "codeNumber": "V2-9.9.9.3"
+      },
       "possibleAnswers": [
         {
           "answerDisplayText": "Yes",
@@ -1945,6 +2021,10 @@
     "P21": {
       "walkthroughItemType": "multiChoice",
       "questionText": "The egress door of the <defined-term>dwelling unit</defined-term> opens onto ...",
+      "questionCodeReference": {
+        "displayString": "Vol 2, Section 9.9.9.3",
+        "codeNumber": "V2-9.9.9.3"
+      },
       "possibleAnswers": [
         {
           "answerDisplayText": "An <defined-term>exit</defined-term> stairway",
@@ -1987,6 +2067,10 @@
     "P22": {
       "walkthroughItemType": "multiChoice",
       "questionText": "Is the <defined-term>public corridor</defined-term> served by a single <defined-term>exit</defined-term>?",
+      "questionCodeReference": {
+        "displayString": "Vol 2, Section 9.9.9.3",
+        "codeNumber": "V2-9.9.9.3"
+      },
       "possibleAnswers": [
         {
           "answerDisplayText": "Yes",
@@ -2013,6 +2097,10 @@
     "P23": {
       "walkthroughItemType": "multiChoice",
       "questionText": "Is the <answer-value answer='P21'/> served by a single <defined-term>exit</defined-term> stairway or <defined-term>ramp</defined-term>?",
+      "questionCodeReference": {
+        "displayString": "Vol 2, Section 9.9.9.3",
+        "codeNumber": "V2-9.9.9.3"
+      },
       "possibleAnswers": [
         {
           "answerDisplayText": "Yes",
@@ -2039,6 +2127,10 @@
     "P24": {
       "walkthroughItemType": "multiChoice",
       "questionText": "Is the <answer-value answer='P21'/> no more than 1.5m above adjacent ground level?",
+      "questionCodeReference": {
+        "displayString": "Vol 2, Section 9.9.9.3",
+        "codeNumber": "V2-9.9.9.3"
+      },
       "possibleAnswers": [
         {
           "answerDisplayText": "Yes",


### PR DESCRIPTION
**Purpose**
Adding JSON data for each question for the number code of the building code that is references. This is the data needed to accomplish this part of the design for each question:
![Screenshot 2024-06-04 at 2 28 35 PM](https://github.com/bcgov/House-Innovations-HOUSNAV/assets/41478918/429d537e-898d-4749-9060-ac350df9e552)

**Notes**
1. Not all questions will have this, since the intro set of question (P01-P08) don't fully encompass a numbered part of the building code and the SME didn't feel comfortable pointing to one.
2. Actual functionality will come later