### PR TITLE
HOUSENAV-12: Add UI tests to pipeline

### DIFF
--- a/.github/workflows/docker-build-and-tag.yml
+++ b/.github/workflows/docker-build-and-tag.yml
@@ -45,3 +45,14 @@ jobs:
 
       - name: List Docker images
         run: docker images
+  cypress-run:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Cypress run
+        uses: cypress-io/github-action@v6
+        with:
+          build: npm ci
+          start: npm run dev

--- a/.github/workflows/docker-build-and-tag.yml
+++ b/.github/workflows/docker-build-and-tag.yml
@@ -51,8 +51,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Cypress run
-        uses: cypress-io/github-action@v6
-        with:
-          build: npm ci
-          start: npm run dev
+      - run: npm ci
+      - run: npm run dev &
+      - run: npm run e2e

--- a/README.md
+++ b/README.md
@@ -82,10 +82,6 @@ As noted above, this repository uses [Lefthook](https://github.com/evilmartians/
 
 Pre-commit the `format`, `lint`, and `test` turbo tasks will run. This will run any `scripts` called `format`, `lint`, or `test` in any of the workspaces. Look at the `package.json` in each workspace for what executes in each. If there are any errors, the commit will be aborted. (Note: `test` normally includes the vitests.)
 
-#### Post-Commit
-
-Pre-commit the `e2e` turbo task will run. It will run any `scripts` called `e2e` in any of the workspaces. Look at the `package.json` in each workspace for what executes in each. This will normally include the cypress tests. Note: This is purely informational and will not block commit or push. For the web package e2e tests to pass, the web app must be running on localhost:3000.
-
 ## Style Naming Conventions
 
 This project uses a modified version of [BEM](http://getbem.com/naming/) (Block Element Modifier) naming conventions for CSS classes. The naming convention is as follows:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -42,8 +42,3 @@ pre-commit:
       run: npm run lint
     test:
       run: npm run test
-
-post-commit:
-  commands:
-    e2e:
-      run: npm run e2e


### PR DESCRIPTION
[HOUSNAV-12](https://hous-bssb.atlassian.net/browse/HOUSNAV-12)

## Overview & Purpose
Add UI tests to the PR build pipeline so we can confirm they pass before merge.

## Summary of Changes
- Run the UI tests on PRs and main after a successful unit test and docker build.
- Remove git hook that runs UI tests locally.

## Side Effects
Currently I am rebuilding the application directly on github servers. This means that we are building the application twice per run.

This strategy could also cause false positives of test failures or could slow down builds and merges. We will keep a look out for any strange side-effects of attempting to run the tests this way.


## Notes & Resources
- Ideally we would be pointing at the docker build from the previous step. This would keep our tests more consistent (as they would run in a stable environment) and cause our pipeline to take less time/fewer resources (as we currently have to build again in order to run our tests). Follow up ticket: https://hous-bssb.atlassian.net/browse/HOUSNAV-56
- Currently the tests are running on electron. We may want to update them to run on Chrome in the future.