### PR TITLE
HOUSNAV-25: Fix answer typo in P02

### DIFF
--- a/packages/data/walkthroughs/9.9.9.json
+++ b/packages/data/walkthroughs/9.9.9.json
@@ -138,11 +138,11 @@
           "answerValue": "10"
         },
         {
-          "answerDisplayText": "The project will involve work necessary to ensure safety parts affect but not directly involved in an <defined-term>alteration</defined-term> to the <defined-term>building</defined-term>.",
+          "answerDisplayText": "The project will involve work necessary to ensure safety in parts affected but not directly involved in an <defined-term>alteration</defined-term> to the <defined-term>building</defined-term>.",
           "answerValue": "11"
         },
         {
-          "answerDisplayText": "The project will involve work necessary to ensure safety parts affect but not directly involved in an <defined-term>addition</defined-term> to the <defined-term>building</defined-term>.",
+          "answerDisplayText": "The project will involve work necessary to ensure safety in parts affected but not directly involved in an <defined-term>addition</defined-term> to the <defined-term>building</defined-term>.",
           "answerValue": "12"
         },
         {


### PR DESCRIPTION
[HOUSNAV-25](https://hous-bssb.atlassian.net/browse/HOUSNAV-25)

## Overview & Purpose
Fix a typo in P02 data surfaced while testing HOUSENAV-25.


## Notes & Resources
Text updated based on the [feasibility report](https://docs.google.com/document/d/1SyyWZDszGOrnM-Qv8BYWUMO6guO9DmBj5O_IJrOpsgk/edit).