### PR TITLE
HOUSNAV-63: Change walkthrough tests to be data driven

### DIFF
--- a/apps/web/cypress/e2e/walkthroughs.cy.ts
+++ b/apps/web/cypress/e2e/walkthroughs.cy.ts
@@ -1,22 +1,25 @@
-import {
-  GET_TESTID_RADIO,
-  GET_TESTID_CHECKBOX_GROUP,
-  TESTID_WALKTHROUGH_FOOTER_NEXT,
-} from "@repo/constants/src/testids";
+import { TESTID_WALKTHROUGH_FOOTER_NEXT } from "@repo/constants/src/testids";
+
+import { walkthroughs } from "../fixtures/test-data.json";
 
 describe("walkthrough 1", () => {
   beforeEach(() => {
     cy.visit("/walkthrough/9.9.9");
   });
 
-  it("can be navigated", () => {
-    // select and submit an answer for the first question
-    // TODO - randomize which answer is selected
-    cy.getByTestID(GET_TESTID_RADIO("P01", "notSure")).click();
-    cy.getByGeneralTestID(TESTID_WALKTHROUGH_FOOTER_NEXT).click();
-
-    // confirm we are showing the second question
-    cy.getByTestID(GET_TESTID_CHECKBOX_GROUP("P02"));
+  //Test all walkthroughs defined in test data
+  walkthroughs.forEach((walkthrough) => {
+    it(walkthrough.title, () => {
+      walkthrough.steps.forEach((step) => {
+        // TODO - use test ids
+        // select and submit an answer for the given question
+        cy.getByTestID(`${step.type}-${step.question}-${step.answer}`).click();
+        cy.getByGeneralTestID(TESTID_WALKTHROUGH_FOOTER_NEXT).click();
+      });
+      if (walkthrough.result) {
+        cy.contains(walkthrough.result);
+      }
+    });
   });
 
   it("default state should be accessible", () => {

--- a/apps/web/cypress/fixtures/test-data.json
+++ b/apps/web/cypress/fixtures/test-data.json
@@ -1,0 +1,37 @@
+{
+    "walkthroughs": [
+        {
+            "id": 1,
+            "title": "Partial walkthrough",
+            "steps": [
+                {
+                    "question": "P01",
+                    "type": "radio",
+                    "answer": "yes"
+                },
+                {
+                    "question": "P04",
+                    "type": "radio",
+                    "answer": "false"
+                },
+                {
+                    "question": "P05",
+                    "type": "radio",
+                    "answer": "true"
+                }
+            ]
+        },
+        {
+            "id": 2,
+            "title": "Code does not apply",
+            "steps": [
+                {
+                    "question": "P01",
+                    "type": "radio",
+                    "answer": "no"
+                }
+            ],
+            "result": "You have selected an answer that indicates that the BC Building Code 2024 does not apply to this structure. This tool is used to assist building code users in determining the applicable requirements for their building, as such all structures that are not governed by the BC Building Code 2024 are beyond the scope of this tool."
+        }
+    ]
+}


### PR DESCRIPTION
<!-- You may remove any sections that are not applicable -->

[HOUSNAV-63](https://hous-bssb.atlassian.net/browse/HOUSNAV-63)

## Overview & Purpose
Make it easy to add UI tests for specific walkthroughs.

## Summary of Changes
Add a data fixture that can easily describe a walkthrough. Add the first two walkthrough tests.

## Testing
I plan to add more walkthroughs to help aid in my manual testing. Later, we may only run a subset of walkthroughs in our testing we do on CI.

## Notes & Resources
Note that this JSON should be created based off of the [feasibility report](https://docs.google.com/document/d/1SyyWZDszGOrnM-Qv8BYWUMO6guO9DmBj5O_IJrOpsgk/edit) and my [workflow diagram](https://www.figma.com/board/FsRgRERlMQHxtiYBS7bniX/Workflow-1?node-id=0-1&t=F6qR41RrZ6wfheYJ-0) and not off of the existing 9.9.9 json.

Will add another PR with more flows if we like this pattern. 