### PR TITLE
HOUSNAV-19: Side Modal Skeleton

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -6,26 +6,11 @@ import { URL_WALKTHROUGH_HREF } from "@repo/constants/src/urls";
 import ModalSide from "@repo/ui/modal-side";
 
 export default function Page(): JSX.Element {
-  const sections = [
-    { number: "9.9.9", header: "Egress from Dwelling Units", content: "" },
-    { number: "9.9.9.1", header: "Travel Limit to Exits or Egress Doors", content: "Except as provided in Sentences (2) and (3), every dwelling unit containing more than 1 storey shall have exits or egress doors located so that it shall not be necessary to travel up or down more than 1 storey to reach a level served by..." },
-    { number: "9.9.9.2", header: "Two Separate Exits", content: "Except as provided in Sentence (2) and Sentence 9.9.7.3(1), where an egress door from a dwelling unit opens onto a public corridor or exterior passageway..." },
-    { number: "9.9.9.2", header: "Two Separate Exits", content: "Except as provided in Sentence (2) and Sentence 9.9.7.3(1), where an egress door from a dwelling unit opens onto a public corridor or exterior passageway..." },
-    { number: "9.9.9.2", header: "Two Separate Exits", content: "Except as provided in Sentence (2) and Sentence 9.9.7.3(1), where an egress door from a dwelling unit opens onto a public corridor or exterior passageway..." },
-    { number: "9.9.9.2", header: "Two Separate Exits", content: "Except as provided in Sentence (2) and Sentence 9.9.7.3(1), where an egress door from a dwelling unit opens onto a public corridor or exterior passageway..." },
-    { number: "9.9.9.2", header: "Two Separate Exits", content: "Except as provided in Sentence (2) and Sentence 9.9.7.3(1), where an egress door from a dwelling unit opens onto a public corridor or exterior passageway..." },
-    { number: "9.9.9.2", header: "Two Separate Exits", content: "Except as provided in Sentence (2) and Sentence 9.9.7.3(1), where an egress door from a dwelling unit opens onto a public corridor or exterior passageway..." },
-    { number: "9.9.9.2", header: "Two Separate Exits", content: "Except as provided in Sentence (2) and Sentence 9.9.7.3(1), where an egress door from a dwelling unit opens onto a public corridor or exterior passageway..." },
-    // Add more sections as needed
-  ];
   return (
     <div className="u-container">
       <p>
         <Link href={`${URL_WALKTHROUGH_HREF}/9.9.9/`}>Walkthrough 9.9.9</Link>
       </p>
-      <div>
-      <ModalSide sections={sections}/>
-      </div>
     </div>
   );
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -3,13 +3,29 @@ import { JSX } from "react";
 // repo
 import Link from "@repo/ui/link";
 import { URL_WALKTHROUGH_HREF } from "@repo/constants/src/urls";
+import ModalSide from "@repo/ui/modal-side";
 
 export default function Page(): JSX.Element {
+  const sections = [
+    { number: "9.9.9", header: "Egress from Dwelling Units", content: "" },
+    { number: "9.9.9.1", header: "Travel Limit to Exits or Egress Doors", content: "Except as provided in Sentences (2) and (3), every dwelling unit containing more than 1 storey shall have exits or egress doors located so that it shall not be necessary to travel up or down more than 1 storey to reach a level served by..." },
+    { number: "9.9.9.2", header: "Two Separate Exits", content: "Except as provided in Sentence (2) and Sentence 9.9.7.3(1), where an egress door from a dwelling unit opens onto a public corridor or exterior passageway..." },
+    { number: "9.9.9.2", header: "Two Separate Exits", content: "Except as provided in Sentence (2) and Sentence 9.9.7.3(1), where an egress door from a dwelling unit opens onto a public corridor or exterior passageway..." },
+    { number: "9.9.9.2", header: "Two Separate Exits", content: "Except as provided in Sentence (2) and Sentence 9.9.7.3(1), where an egress door from a dwelling unit opens onto a public corridor or exterior passageway..." },
+    { number: "9.9.9.2", header: "Two Separate Exits", content: "Except as provided in Sentence (2) and Sentence 9.9.7.3(1), where an egress door from a dwelling unit opens onto a public corridor or exterior passageway..." },
+    { number: "9.9.9.2", header: "Two Separate Exits", content: "Except as provided in Sentence (2) and Sentence 9.9.7.3(1), where an egress door from a dwelling unit opens onto a public corridor or exterior passageway..." },
+    { number: "9.9.9.2", header: "Two Separate Exits", content: "Except as provided in Sentence (2) and Sentence 9.9.7.3(1), where an egress door from a dwelling unit opens onto a public corridor or exterior passageway..." },
+    { number: "9.9.9.2", header: "Two Separate Exits", content: "Except as provided in Sentence (2) and Sentence 9.9.7.3(1), where an egress door from a dwelling unit opens onto a public corridor or exterior passageway..." },
+    // Add more sections as needed
+  ];
   return (
     <div className="u-container">
       <p>
         <Link href={`${URL_WALKTHROUGH_HREF}/9.9.9/`}>Walkthrough 9.9.9</Link>
       </p>
+      <div>
+      <ModalSide sections={sections}/>
+      </div>
     </div>
   );
 }

--- a/apps/web/components/defined-term/DefinedTerm.test.tsx
+++ b/apps/web/components/defined-term/DefinedTerm.test.tsx
@@ -5,19 +5,44 @@ import { render } from "@testing-library/react";
 import {
   GET_TESTID_BUTTON,
   TESTID_DEFINED_TERM,
+  TESTID_MODAL_SIDE,
 } from "@repo/constants/src/testids";
 // local
 import DefinedTerm from "./DefinedTerm";
+import userEvent from "@testing-library/user-event";
 
 describe("DefinedTerm", () => {
   it("renders with data-term attribute", () => {
     const testTerm = "test-term";
     const { getByTestId } = render(
-      <DefinedTerm term={testTerm}>Test Term</DefinedTerm>,
+      <DefinedTerm term={testTerm}>Test Term</DefinedTerm>
     );
     const button = getByTestId(
-      GET_TESTID_BUTTON(`${TESTID_DEFINED_TERM}-${testTerm}`),
+      GET_TESTID_BUTTON(`${TESTID_DEFINED_TERM}-${testTerm}`)
     );
     expect(button).toHaveAttribute("data-term", "test-term");
+  });
+
+  it("opens and closes model when defined-term clicked", async () => {
+    window.HTMLElement.prototype.scrollIntoView = function () {};
+
+    const testTerm = "test-term";
+    const { getByTestId } = render(
+      <DefinedTerm term={testTerm}>Test Term</DefinedTerm>
+    );
+    const button = getByTestId(
+      GET_TESTID_BUTTON(`${TESTID_DEFINED_TERM}-${testTerm}`)
+    );
+
+    await userEvent.click(button);
+    const modal = getByTestId(TESTID_MODAL_SIDE);
+    expect(modal).toBeInTheDocument();
+
+    const closeButton = getByTestId(
+      GET_TESTID_BUTTON(`${TESTID_MODAL_SIDE}-close-button`)
+    );
+
+    await userEvent.click(closeButton);
+    expect(modal).not.toBeInTheDocument();
   });
 });

--- a/apps/web/components/defined-term/DefinedTerm.tsx
+++ b/apps/web/components/defined-term/DefinedTerm.tsx
@@ -1,7 +1,9 @@
 // repo
 import Button, { ButtonProps } from "@repo/ui/button";
 import { TESTID_DEFINED_TERM } from "@repo/constants/src/testids";
+import { GLOSSARY_SECTIONS, GLOSSARY_TERMS } from "../../../web/tests/mockData";
 import Tooltip from "@repo/ui/tooltip";
+import ModalSide from "@repo/ui/modal-side";
 
 export interface DefinedTermProps extends Omit<ButtonProps, "variant"> {
   term: string;
@@ -14,23 +16,32 @@ export default function DefinedTerm({
   ...props
 }: DefinedTermProps) {
   // TODO: Add glossary term functionality
-  const mockGlossary = {
-    default: { tooltipContent: "Default Tooltip" },
-  };
 
-  return (
+  const button = (
+    <Button
+      variant="glossary"
+      data-term={term}
+      data-testid={`${testid}-${term}`}
+      {...props}
+    >
+      {children}
+    </Button>
+  );
+
+  const tooltipButton = (
     <Tooltip
-      tooltipContent={mockGlossary.default.tooltipContent}
-      triggerContent={
-        <Button
-          variant="glossary"
-          data-term={term}
-          data-testid={`${testid}-${term}`}
-          {...props}
-        >
-          {children}
-        </Button>
-      }
+      tooltipContent={GLOSSARY_TERMS.default.tooltipContent}
+      triggerContent={button}
     ></Tooltip>
+  );
+
+  // TODO: Matt or Nicholas, add correct section for customHandler
+  const randomSection = Math.floor(Math.random() * 10) + 1;
+  return (
+    <ModalSide
+      triggerContent={tooltipButton}
+      sections={GLOSSARY_SECTIONS}
+      scrollToSection={`9.9.9.${randomSection}`}
+    />
   );
 }

--- a/apps/web/tests/mockData.ts
+++ b/apps/web/tests/mockData.ts
@@ -1,0 +1,119 @@
+export const GLOSSARY_TERMS = {
+  default: { tooltipContent: "Default Tooltip" },
+};
+
+export const GLOSSARY_SECTIONS = [
+  {
+    number: "9.9.9",
+    header: "Egress from Dwelling Units",
+    content: "",
+  },
+  {
+    number: "9.9.9.1",
+    header: "Travel Limit to Exits or Egress Doors",
+    content:
+      "Except as provided in Sentences (2) and (3), every <defined-term-modal term='dwelling unit'>dwelling unit</defined-term-modal> containing more than 1 storey shall have exits or egress doors located so that it shall not be necessary to travel up or down more than 1 storey to reach a level served by...",
+  },
+  {
+    number: "9.9.9.2",
+    header: "Two Separate Exits",
+    content:
+      "Except as provided in Sentence (2) and Sentence 9.9.7.3(1), where an egress door from a <defined-term-modal term='dwelling unit'>dwelling unit</defined-term-modal> opens onto a public corridor or exterior passageway...",
+  },
+  {
+    number: "9.9.9.3",
+    header: "Two Separate Exits",
+    content:
+      "Except as provided in Sentence (2) and Sentence 9.9.7.3(1), where an egress door from a <defined-term-modal term='dwelling unit'>dwelling unit</defined-term-modal> opens onto a public corridor or exterior passageway...",
+  },
+  {
+    number: "9.9.9.4",
+    header: "Two Separate Exits",
+    content:
+      "Except as provided in Sentence (2) and Sentence 9.9.7.3(1), where an egress door from a <defined-term-modal term='dwelling unit'>dwelling unit</defined-term-modal> opens onto a public corridor or exterior passageway...",
+  },
+  {
+    number: "9.9.9.5",
+    header: "Two Separate Exits",
+    content:
+      "Except as provided in Sentence (2) and Sentence 9.9.7.3(1), where an egress door from a <defined-term-modal term='dwelling unit'>dwelling unit</defined-term-modal> opens onto a public corridor or exterior passageway...",
+  },
+  {
+    number: "9.9.9.6",
+    header: "Two Separate Exits",
+    content:
+      "Except as provided in Sentence (2) and Sentence 9.9.7.3(1), where an egress door from a <defined-term-modal term='dwelling unit'>dwelling unit</defined-term-modal> opens onto a public corridor or exterior passageway...",
+  },
+  {
+    number: "9.9.9.7",
+    header: "Two Separate Exits",
+    content:
+      "Except as provided in Sentence (2) and Sentence 9.9.7.3(1), where an egress door from a <defined-term-modal term='dwelling unit'>dwelling unit</defined-term-modal> opens onto a public corridor or exterior passageway...",
+  },
+  {
+    number: "9.9.9.8",
+    header: "Two Separate Exits",
+    content:
+      "Except as provided in Sentence (2) and Sentence 9.9.7.3(1), where an egress door from a <defined-term-modal term='dwelling unit'>dwelling unit</defined-term-modal> opens onto a public corridor or exterior passageway...",
+  },
+  {
+    number: "9.9.9.9",
+    header: "Two Separate Exits",
+    content:
+      "Except as provided in Sentence (2) and Sentence 9.9.7.3(1), where an egress door from a <defined-term-modal term='dwelling unit'>dwelling unit</defined-term-modal> opens onto a public corridor or exterior passageway...",
+  },
+  {
+    number: "9.9.9.10",
+    header: "Travel Limit to Exits or Egress Doors",
+    content:
+      "Except as provided in Sentences (2) and (3), every <defined-term-modal term='dwelling unit'>dwelling unit</defined-term-modal> containing more than 1 storey shall have exits or egress doors located so that it shall not be necessary to travel up or down more than 1 storey to reach a level served by...",
+  },
+  {
+    number: "9.9.9.20",
+    header: "Two Separate Exits",
+    content:
+      "Except as provided in Sentence (2) and Sentence 9.9.7.3(1), where an egress door from a <defined-term-modal term='dwelling unit'>dwelling unit</defined-term-modal> opens onto a public corridor or exterior passageway...",
+  },
+  {
+    number: "9.9.9.30",
+    header: "Two Separate Exits",
+    content:
+      "Except as provided in Sentence (2) and Sentence 9.9.7.3(1), where an egress door from a <defined-term-modal term='dwelling unit'>dwelling unit</defined-term-modal> opens onto a public corridor or exterior passageway...",
+  },
+  {
+    number: "9.9.9.40",
+    header: "Two Separate Exits",
+    content:
+      "Except as provided in Sentence (2) and Sentence 9.9.7.3(1), where an egress door from a <defined-term-modal term='dwelling unit'>dwelling unit</defined-term-modal> opens onto a public corridor or exterior passageway...",
+  },
+  {
+    number: "9.9.9.50",
+    header: "Two Separate Exits",
+    content:
+      "Except as provided in Sentence (2) and Sentence 9.9.7.3(1), where an egress door from a <defined-term-modal term='dwelling unit'>dwelling unit</defined-term-modal> opens onto a public corridor or exterior passageway...",
+  },
+  {
+    number: "9.9.9.60",
+    header: "Two Separate Exits",
+    content:
+      "Except as provided in Sentence (2) and Sentence 9.9.7.3(1), where an egress door from a <defined-term-modal term='dwelling unit'>dwelling unit</defined-term-modal> opens onto a public corridor or exterior passageway...",
+  },
+  {
+    number: "9.9.9.70",
+    header: "Two Separate Exits",
+    content:
+      "Except as provided in Sentence (2) and Sentence 9.9.7.3(1), where an egress door from a <defined-term-modal term='dwelling unit'>dwelling unit</defined-term-modal> opens onto a public corridor or exterior passageway...",
+  },
+  {
+    number: "9.9.9.80",
+    header: "Two Separate Exits",
+    content:
+      "Except as provided in Sentence (2) and Sentence 9.9.7.3(1), where an egress door from a <defined-term-modal term='dwelling unit'>dwelling unit</defined-term-modal> opens onto a public corridor or exterior passageway...",
+  },
+  {
+    number: "9.9.9.90",
+    header: "Two Separate Exits",
+    content:
+      "Except as provided in Sentence (2) and Sentence 9.9.7.3(1), where an egress door from a <defined-term-modal term='dwelling unit'>dwelling unit</defined-term-modal> opens onto a public corridor or exterior passageway...",
+  },
+];

--- a/apps/web/utils/string.tsx
+++ b/apps/web/utils/string.tsx
@@ -10,19 +10,22 @@ import parse, {
 import DefinedTerm, {
   DefinedTermProps,
 } from "../components/defined-term/DefinedTerm";
+import Button from "@repo/ui/button";
 
 // Define custom components for html-react-parser
 const definedTermName = "defined-term";
-type CustomComponentTypes = typeof definedTermName;
+const definedTermModal = "defined-term-modal";
+type CustomComponentTypes = typeof definedTermName | typeof definedTermModal;
 type CustomComponentProps = DefinedTermProps;
 const customComponents: Record<
   CustomComponentTypes,
   FunctionComponent<CustomComponentProps>
 > = {
   [definedTermName]: DefinedTerm,
+  [definedTermModal]: Button,
 };
 
-export const parseStringToComponents = (html: string) => {
+export const parseStringToComponents = (html: string, customHandler?: any) => {
   const options = {
     replace: (domNode: DOMNode) => {
       if (domNode instanceof Element && domNode.attribs) {
@@ -41,6 +44,22 @@ export const parseStringToComponents = (html: string) => {
                 </DefinedTermComponent>
               );
             }
+          }
+          case definedTermModal: {
+            // TODO: Matt or Nicholas, add correct section for customHandler
+            const randomSection = Math.floor(Math.random() * 10) + 1;
+            return (
+              <Button
+                variant="glossary"
+                onPress={
+                  customHandler
+                    ? () => customHandler(`9.9.9.${randomSection}`)
+                    : () => {}
+                }
+              >
+                {domToReact(domNode.children as DOMNode[])}
+              </Button>
+            );
           }
         }
       }

--- a/apps/web/utils/string.tsx
+++ b/apps/web/utils/string.tsx
@@ -11,6 +11,8 @@ import DefinedTerm, {
   DefinedTermProps,
 } from "../components/defined-term/DefinedTerm";
 import Button from "@repo/ui/button";
+import Tooltip from "@repo/ui/tooltip";
+import { GLOSSARY_TERMS } from "../tests/mockData";
 
 // Define custom components for html-react-parser
 const definedTermName = "defined-term";
@@ -49,16 +51,21 @@ export const parseStringToComponents = (html: string, customHandler?: any) => {
             // TODO: Matt or Nicholas, add correct section for customHandler
             const randomSection = Math.floor(Math.random() * 10) + 1;
             return (
-              <Button
-                variant="glossary"
-                onPress={
-                  customHandler
-                    ? () => customHandler(`9.9.9.${randomSection}`)
-                    : () => {}
+              <Tooltip
+                tooltipContent={GLOSSARY_TERMS.default.tooltipContent}
+                triggerContent={
+                  <Button
+                    variant="glossary"
+                    onPress={
+                      customHandler
+                        ? () => customHandler(`9.9.9.${randomSection}`)
+                        : () => {}
+                    }
+                  >
+                    {domToReact(domNode.children as DOMNode[])}
+                  </Button>
                 }
-              >
-                {domToReact(domNode.children as DOMNode[])}
-              </Button>
+              ></Tooltip>
             );
           }
         }

--- a/apps/web/utils/string.tsx
+++ b/apps/web/utils/string.tsx
@@ -32,21 +32,23 @@ export const parseStringToComponents = (html: string, customHandler?: any) => {
     replace: (domNode: DOMNode) => {
       if (domNode instanceof Element && domNode.attribs) {
         switch (domNode.name) {
-          case definedTermName: {
-            const DefinedTermComponent = customComponents[definedTermName];
-            const props = attributesToProps(domNode.attribs);
+          case definedTermName:
+            {
+              const DefinedTermComponent = customComponents[definedTermName];
+              const props = attributesToProps(domNode.attribs);
 
-            if (DefinedTermComponent) {
-              return (
-                <DefinedTermComponent
-                  {...(props as unknown as DefinedTermProps)}
-                  key={domNode.attribs.key}
-                >
-                  {domToReact(domNode.children as DOMNode[], options)}
-                </DefinedTermComponent>
-              );
+              if (DefinedTermComponent) {
+                return (
+                  <DefinedTermComponent
+                    {...(props as unknown as DefinedTermProps)}
+                    key={domNode.attribs.key}
+                  >
+                    {domToReact(domNode.children as DOMNode[], options)}
+                  </DefinedTermComponent>
+                );
+              }
             }
-          }
+            break;
           case definedTermModal: {
             // TODO: Matt or Nicholas, add correct section for customHandler
             const randomSection = Math.floor(Math.random() * 10) + 1;

--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -1,1 +1,1 @@
-export const IMAGES_BASE_PATH = '/assets/images';
+export const IMAGES_BASE_PATH = "/assets/images";

--- a/packages/constants/src/testids.ts
+++ b/packages/constants/src/testids.ts
@@ -30,3 +30,4 @@ export const TESTID_HEADER_MOBILE_NAV = "header-mobile-nav";
 export const TESTID_HEADER_MOBILE_NAV_BUTTON = "header-mobile-nav-button";
 export const GET_TESTID_HEADER_NAV_ITEM = (title: string) =>
   `header-nav-item-${title}`;
+export const TESTID_MODAL_SIDE = "modal-side";

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,6 +5,7 @@
   "exports": {
     "./image": "./src/image/Image.tsx",
     "./tooltip": "./src/tooltip/Tooltip.tsx",
+    "./modal-side": "./src/modal-side/ModalSide.tsx",
     "./checkbox-group": "./src/checkbox-group/CheckboxGroup.tsx",
     "./header": "./src/header/Header.tsx",
     "./input-error": "./src/input-error/InputError.tsx",

--- a/packages/ui/src/modal-side/ModalSide.css
+++ b/packages/ui/src/modal-side/ModalSide.css
@@ -1,0 +1,135 @@
+.react-aria-Dialog {
+  outline: none;
+}
+
+.my-overlay {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1000;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  background: #00000030;
+  
+  &[data-entering] {
+    animation: mymodal-blur 300ms;
+  }
+
+  &[data-exiting] {
+    animation: mymodal-blur 300ms reverse ease-in;
+  }
+}
+
+.my-modal {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  width: 60%;
+  outline: none;
+  border-left: 1px solid var(--border-color);
+  box-shadow: -8px 0 20px rgba(0 0 0 / 0.1);
+  background: #ffffff;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  outline: 'none';
+  padding: 40px;
+  bor
+  &[data-entering] {
+    animation: mymodal-slide 300ms;
+  }
+
+  &[data-exiting] {
+    animation: mymodal-slide 300ms reverse ease-in;
+  }
+}
+.my-modal:focus {
+  box-shadow: -8px 0 20px rgb(135, 13, 13);
+}
+
+.close-button {
+  position: fixed;
+  top: 10px;
+  right: 20px;
+  z-index: 1001;
+}
+
+.modal-header {
+  height: 40px; /* This provides the padding space below the fixed close button */
+}
+
+.modal-content {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  margin-top: 50px; /* Adjust to ensure content starts below the fixed close button */
+  outline: none !important;
+  border: none !important;
+}
+
+.modal-section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.section-header-line {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  align-items: center;
+  gap: 10px;
+}
+
+.section-content-line {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  align-items: center;
+  gap: 10px;
+}
+
+.section-number {
+  grid-column: span 1;
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.section-header {
+  grid-column: span 4;
+  font-size: 1.2rem;
+  font-weight: bold;
+}
+
+.section-content {
+  grid-column: span 4 / 6; 
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+/* Remove the border around the content when the modal is focused */
+.my-modal:focus {
+  outline: none;
+}
+
+@keyframes mymodal-blur {
+  from {
+    background: rgba(129, 129, 129, 0);
+  }
+
+  to {
+    background: rgba(129, 129, 129, 0.3);
+  }
+}
+
+@keyframes mymodal-slide {
+  from {
+    transform: translateX(100%);
+  }
+
+  to {
+    transform: translateX(0);
+  }
+}

--- a/packages/ui/src/modal-side/ModalSide.css
+++ b/packages/ui/src/modal-side/ModalSide.css
@@ -1,8 +1,8 @@
-.react-aria-Dialog {
+.ui-ModalSide--AriaDialog {
   outline: none;
 }
 
-.my-overlay {
+.ui-ModalSide--Overlay {
   position: fixed;
   top: 0;
   right: 0;
@@ -12,124 +12,130 @@
   display: flex;
   justify-content: flex-end;
   align-items: center;
-  background: #00000030;
-  
-  &[data-entering] {
-    animation: mymodal-blur 300ms;
-  }
-
-  &[data-exiting] {
-    animation: mymodal-blur 300ms reverse ease-in;
-  }
+  background: var(--theme-black-opacity-40);
 }
 
-.my-modal {
+.ui-ModalSide--Modal {
   position: fixed;
   top: 0;
   bottom: 0;
   right: 0;
   width: 60%;
   outline: none;
-  border-left: 1px solid var(--border-color);
-  box-shadow: -8px 0 20px rgba(0 0 0 / 0.1);
-  background: #ffffff;
+  border-left: var(--layout-border-width-small) solid
+    var(--surface-color-border-default);
+  box-shadow: -8px 0 20px var(--surface-opacity-10);
+  background: var(--theme-gray-white);
   display: flex;
   flex-direction: column;
-  overflow-y: auto;
-  outline: 'none';
-  padding: 40px;
-  bor
+  padding: var(--layout-padding-large);
+
   &[data-entering] {
-    animation: mymodal-slide 300ms;
+    animation: modal-slide-in 300ms reverse ease-in;
   }
 
   &[data-exiting] {
-    animation: mymodal-slide 300ms reverse ease-in;
+    animation: modal-slide-out 300ms reverse ease-in;
   }
 }
-.my-modal:focus {
-  box-shadow: -8px 0 20px rgb(135, 13, 13);
-}
 
-.close-button {
+.ui-ModalSide--CloseButton {
   position: fixed;
-  top: 10px;
-  right: 20px;
+  color: var(--icons-color-primary) !important;
+  top: var(--layout-padding-medium);
+  right: var(--layout-padding-large);
   z-index: 1001;
 }
 
-.modal-header {
-  height: 40px; /* This provides the padding space below the fixed close button */
+.ui-ModalSide--Header {
+  position: fixed;
+  text-align: right;
+  top: 0;
+  right: var(--layout-padding-medium);
+  background-color: var(--theme-gray-white);
 }
 
-.modal-content {
+.ui-ModalSide--Content {
   display: flex;
   flex-direction: column;
-  gap: 20px;
-  margin-top: 50px; /* Adjust to ensure content starts below the fixed close button */
-  outline: none !important;
-  border: none !important;
+  gap: var(--layout-padding-medium);
+  margin-top: 50px;
+  padding: var(--layout-padding-small);
+  overflow-y: scroll;
+  height: 100vh;
 }
 
-.modal-section {
+.ui-ModalSide--Section {
   display: flex;
   flex-direction: column;
-  gap: 10px;
 }
 
-.section-header-line {
+.ui-ModalSide--SectionHeaderLine {
   display: grid;
   grid-template-columns: repeat(5, 1fr);
   align-items: center;
-  gap: 10px;
 }
 
-.section-content-line {
+.ui-ModalSide--SectionContentLine {
   display: grid;
   grid-template-columns: repeat(5, 1fr);
   align-items: center;
-  gap: 10px;
 }
 
-.section-number {
+.ui-ModalSide--SectionNumber {
   grid-column: span 1;
-  font-size: 1.5rem;
-  font-weight: bold;
+  text-align: center;
+  font-size: var(--typography-font-size-h5);
+  font-weight: var(--typography-font-weights-bold);
 }
 
-.section-header {
+.ui-ModalSide--SectionHeader {
   grid-column: span 4;
-  font-size: 1.2rem;
-  font-weight: bold;
+  font-size: var(--typography-font-size-large-body);
+  font-weight: var(--typography-font-weights-bold);
 }
 
-.section-content {
-  grid-column: span 4 / 6; 
-  font-size: 1rem;
-  line-height: 1.5;
+.ui-ModalSide--SectionContent {
+  grid-column: span 4 / 6;
+  font-size: var(--typography-font-size-body);
+  line-height: var(--typography-line-heights-dense);
+  padding: var(--layout-margin-large);
+  padding-top: 0;
+  margin-top: 1px;
 }
 
-/* Remove the border around the content when the modal is focused */
-.my-modal:focus {
-  outline: none;
+.ui-ModalSide--SectionHighlighted {
+  border-radius: var(--layout-margin-small, 8px);
+  border: 1px solid var(--support-borderColor-info, #053662);
+  background: var(--support-surfaceColor-info, #f7f9fc);
 }
 
-@keyframes mymodal-blur {
-  from {
-    background: rgba(129, 129, 129, 0);
-  }
-
-  to {
-    background: rgba(129, 129, 129, 0.3);
-  }
-}
-
-@keyframes mymodal-slide {
+@keyframes modal-slide-out {
   from {
     transform: translateX(100%);
   }
 
   to {
     transform: translateX(0);
+  }
+}
+
+@keyframes modal-slide-in {
+  from {
+    transform: translateX(0);
+  }
+
+  to {
+    transform: translateX(100%);
+  }
+}
+
+/* DESKTOP - 912px */
+@media (max-width: 57rem) {
+  .ui-ModalSide--Modal {
+    width: 100%;
+  }
+  .ui-ModalSide--Header {
+    width: 100%;
   }
 }

--- a/packages/ui/src/modal-side/ModalSide.css
+++ b/packages/ui/src/modal-side/ModalSide.css
@@ -61,6 +61,7 @@
   gap: var(--layout-padding-medium);
   margin-top: 50px;
   padding: var(--layout-padding-small);
+  padding-bottom: 75px;
   overflow-y: scroll;
   height: 100vh;
 }

--- a/packages/ui/src/modal-side/ModalSide.tsx
+++ b/packages/ui/src/modal-side/ModalSide.tsx
@@ -1,0 +1,51 @@
+"use client";
+import { Dialog, DialogTrigger, Heading, Modal, ModalOverlay} from 'react-aria-components';
+
+
+import "./ModalSide.css";
+import Icon from '../icon/Icon';
+import Button from '../button/Button';
+
+export interface ModalSideProps {
+  sections: { number: string, header: string, content: string }[];
+}
+
+export default function ModalSide({sections, ...props }: ModalSideProps) {
+  return (
+    <DialogTrigger >
+    <Button>Open modal</Button>
+
+    <ModalOverlay className="my-overlay" >
+      <Modal className="my-modal" isKeyboardDismissDisabled>
+        <Dialog className="react-aria-Dialog">
+          {({ close }) => <>
+            <Button
+              isIconButton
+              variant="secondary"
+              className="close-button"
+              onPress={close}
+            >
+              <Icon type="close" />
+            </Button>
+            <div className="modal-header"></div>
+            <div className="modal-content">
+              {sections.map((section, index) => (
+                <div key={index} className="modal-section">
+                  <div className="section-header-line">
+                    <Heading level={3} className="section-number">{section.number}</Heading>
+                    <Heading className="section-header">{section.header}</Heading>
+                  </div>
+                  <div className="section-content-line">
+                    <p className="section-content">{section.content}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </>}
+        </Dialog>
+      </Modal>
+    </ModalOverlay>
+  </DialogTrigger>
+
+  );
+}

--- a/packages/ui/src/modal-side/ModalSide.tsx
+++ b/packages/ui/src/modal-side/ModalSide.tsx
@@ -74,7 +74,7 @@ export default function ModalSide({
                     <Icon type="close" />
                   </Button>
                 </header>
-                <main className="ui-ModalSide--Content">
+                <div className="ui-ModalSide--Content">
                   {sections.map((section, index) => (
                     <section
                       key={index}
@@ -108,7 +108,7 @@ export default function ModalSide({
                       </article>
                     </section>
                   ))}
-                </main>
+                </div>
               </>
             )}
           </Dialog>

--- a/packages/ui/src/modal-side/ModalSide.tsx
+++ b/packages/ui/src/modal-side/ModalSide.tsx
@@ -1,51 +1,119 @@
 "use client";
-import { Dialog, DialogTrigger, Heading, Modal, ModalOverlay} from 'react-aria-components';
 
+import { useEffect, useRef, ReactNode, useState } from "react";
+import {
+  Dialog,
+  DialogTrigger,
+  Heading,
+  Modal,
+  ModalOverlay,
+} from "react-aria-components";
+
+import { TESTID_MODAL_SIDE } from "@repo/constants/src/testids";
 
 import "./ModalSide.css";
-import Icon from '../icon/Icon';
-import Button from '../button/Button';
+import Icon from "../icon/Icon";
+import Button from "../button/Button";
+import { parseStringToComponents } from "web/utils/string";
 
 export interface ModalSideProps {
-  sections: { number: string, header: string, content: string }[];
+  triggerContent: ReactNode;
+  sections: { number: string; header: string; content: string }[];
+  scrollToSection?: string;
+  "data-testid"?: string;
 }
 
-export default function ModalSide({sections, ...props }: ModalSideProps) {
+export default function ModalSide({
+  triggerContent,
+  sections,
+  scrollToSection,
+  "data-testid": testid = TESTID_MODAL_SIDE,
+  ...props
+}: ModalSideProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [focusSection, setFocusSection] = useState(scrollToSection);
+  const [highlightedSection, setHighlightedSection] = useState<string | null>(
+    null
+  );
+
+  const modalRef = useRef<HTMLDivElement>(null);
+  const sectionRefs = useRef<{ [key: string]: HTMLDivElement | null }>({});
+
+  useEffect(() => {
+    if (focusSection && sectionRefs.current[focusSection]) {
+      const sectionElement = sectionRefs.current[focusSection];
+      sectionElement?.scrollIntoView({
+        behavior: "instant",
+        block: "center",
+      });
+      setHighlightedSection(focusSection);
+    }
+  }, [isOpen, focusSection]);
+
   return (
-    <DialogTrigger >
-    <Button>Open modal</Button>
+    <DialogTrigger onOpenChange={setIsOpen}>
+      {triggerContent}
 
-    <ModalOverlay className="my-overlay" >
-      <Modal className="my-modal" isKeyboardDismissDisabled>
-        <Dialog className="react-aria-Dialog">
-          {({ close }) => <>
-            <Button
-              isIconButton
-              variant="secondary"
-              className="close-button"
-              onPress={close}
-            >
-              <Icon type="close" />
-            </Button>
-            <div className="modal-header"></div>
-            <div className="modal-content">
-              {sections.map((section, index) => (
-                <div key={index} className="modal-section">
-                  <div className="section-header-line">
-                    <Heading level={3} className="section-number">{section.number}</Heading>
-                    <Heading className="section-header">{section.header}</Heading>
-                  </div>
-                  <div className="section-content-line">
-                    <p className="section-content">{section.content}</p>
-                  </div>
+      <ModalOverlay className="ui-ModalSide--Overlay">
+        <Modal
+          className="ui-ModalSide--Modal"
+          ref={modalRef}
+          data-testid={testid}
+        >
+          <Dialog className="ui-ModalSide--AriaDialog">
+            {({ close }) => (
+              <>
+                <div className="ui-ModalSide--Header">
+                  <Button
+                    isIconButton
+                    variant="tertiary"
+                    className="ui-ModalSide--CloseButton"
+                    onPress={close}
+                    data-testid={`${testid}-close-button`}
+                  >
+                    <Icon type="close" />
+                  </Button>
                 </div>
-              ))}
-            </div>
-          </>}
-        </Dialog>
-      </Modal>
-    </ModalOverlay>
-  </DialogTrigger>
-
+                <div className="ui-ModalSide--Content">
+                  {sections.map((section, index) => (
+                    <div
+                      key={index}
+                      ref={(el) => {
+                        sectionRefs.current[section.number] = el;
+                      }}
+                      className={`ui-ModalSide--Section ${
+                        highlightedSection == section.number
+                          ? "ui-ModalSide--SectionHighlighted"
+                          : ""
+                      }`}
+                    >
+                      <div className="ui-ModalSide--SectionHeaderLine">
+                        <Heading
+                          level={3}
+                          className="ui-ModalSide--SectionNumber"
+                        >
+                          {section.number}
+                        </Heading>
+                        <Heading className="ui-ModalSide--SectionHeader">
+                          {section.header}
+                        </Heading>
+                      </div>
+                      <div className="ui-ModalSide--SectionContentLine">
+                        <p className="ui-ModalSide--SectionContent">
+                          {parseStringToComponents(
+                            section.content,
+                            setFocusSection
+                          )}
+                        </p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </>
+            )}
+          </Dialog>
+        </Modal>
+      </ModalOverlay>
+    </DialogTrigger>
   );
 }

--- a/packages/ui/src/modal-side/ModalSide.tsx
+++ b/packages/ui/src/modal-side/ModalSide.tsx
@@ -37,7 +37,7 @@ export default function ModalSide({
   );
 
   const modalRef = useRef<HTMLDivElement>(null);
-  const sectionRefs = useRef<{ [key: string]: HTMLDivElement | null }>({});
+  const sectionRefs = useRef<{ [key: string]: HTMLElement | null }>({});
 
   useEffect(() => {
     if (focusSection && sectionRefs.current[focusSection]) {
@@ -63,7 +63,7 @@ export default function ModalSide({
           <Dialog className="ui-ModalSide--AriaDialog">
             {({ close }) => (
               <>
-                <div className="ui-ModalSide--Header">
+                <header className="ui-ModalSide--Header">
                   <Button
                     isIconButton
                     variant="tertiary"
@@ -73,10 +73,10 @@ export default function ModalSide({
                   >
                     <Icon type="close" />
                   </Button>
-                </div>
-                <div className="ui-ModalSide--Content">
+                </header>
+                <main className="ui-ModalSide--Content">
                   {sections.map((section, index) => (
-                    <div
+                    <section
                       key={index}
                       ref={(el) => {
                         sectionRefs.current[section.number] = el;
@@ -87,7 +87,7 @@ export default function ModalSide({
                           : ""
                       }`}
                     >
-                      <div className="ui-ModalSide--SectionHeaderLine">
+                      <header className="ui-ModalSide--SectionHeaderLine">
                         <Heading
                           level={3}
                           className="ui-ModalSide--SectionNumber"
@@ -97,18 +97,18 @@ export default function ModalSide({
                         <Heading className="ui-ModalSide--SectionHeader">
                           {section.header}
                         </Heading>
-                      </div>
-                      <div className="ui-ModalSide--SectionContentLine">
+                      </header>
+                      <article className="ui-ModalSide--SectionContentLine">
                         <p className="ui-ModalSide--SectionContent">
                           {parseStringToComponents(
                             section.content,
                             setFocusSection
                           )}
                         </p>
-                      </div>
-                    </div>
+                      </article>
+                    </section>
                   ))}
-                </div>
+                </main>
               </>
             )}
           </Dialog>

--- a/packages/ui/src/tooltip/Tooltip.tsx
+++ b/packages/ui/src/tooltip/Tooltip.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { ReactNode } from "react";
 
 import {

--- a/packages/ui/src/variables.css
+++ b/packages/ui/src/variables.css
@@ -263,3 +263,8 @@
     --question-container-max-width: 53.5rem; /* 856px */
   }
 }
+
+/* CUSTOM */
+:root {
+  --theme-black-opacity-40: #00000040;
+}


### PR DESCRIPTION
<!-- You may remove any sections that are not applicable -->

[HOUSNAV-19](https://hous-bssb.atlassian.net/browse/HOUSNAV-19)

## Overview & Purpose
<!-- Please describe the purpose of your changes. Please also include relevant motivation and context. -->
Add Modal popup on side of screen when user clicks a defined term. 

## Summary of Changes
<!-- Please include a HIGH LEVEL overview of the code changes. (Added xyz fields to table, modified function to handle x case instead of y case, etc. )  -->
- Adds `ModalSide` component
- Implements `ModalSide` component for all defined terms
- Adds `definedTermModal` case when parsing components to prevent infinite loop of opening modals and enable scrolling to sections within the modal when open
- Adds `--theme-black-opacity-40`
- Adds dummy data for how we can potentially implement this modal

## Testing
<!-- Please include steps to test out the changes/fixes if applicable OR context notes to help get env in a state to test-->
- Click any defined term. 
    - Note the sections that the terms navigate to are randomly generated right now 
  
![Screenshot 2024-06-12 at 12 35 59 PM](https://github.com/bcgov/House-Innovations-HOUSNAV/assets/7059124/272202b3-f0f3-41c4-ade1-044771ceee06)

https://github.com/bcgov/House-Innovations-HOUSNAV/assets/7059124/ef51b20f-5eb2-45a0-a97a-2b9922a8f072


## Notes & Resources
<!-- Please include any additional notes necessary to review PR and/or relevant links (documentation, stack overflow, etc.) that helped you arrive at your solution. -->
- This ticket didn't technically include css formatting for the data in the modal so it's currently a "rough draft" for the CSS.
    - It should be completed with this ticket: https://hous-bssb.atlassian.net/jira/software/c/projects/HOUSNAV/boards/3/backlog?selectedIssue=HOUSNAV-71 
https://react-spectrum.adobe.com/react-aria/Modal.html#modal