### PR TITLE
Housnav-21: Walkthrough Card Component

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -10,21 +10,24 @@ import {
 
 export default function Page(): JSX.Element {
   return (
-    <div className="u-container ">
-      {Walkthroughs.map((walkthrough: string) => {
-        const data = WalkthroughJSONData[walkthrough]?.info;
-        const canDisplayCard =
-          data && data.title && data.subtitle && data.description;
-        return (
-          canDisplayCard && (
-            <WalkthroughCard
-              id={walkthrough}
-              data={data}
-              href={`${URL_WALKTHROUGH_HREF}/${walkthrough}/`}
-            />
-          )
-        );
-      })}
+    <div className="u-container">
+      <div>
+        {Object.entries(WalkthroughJSONData).map(([id, data]) => {
+          const info = data.info;
+          const canDisplayCard =
+            info && info.title && info.subtitle && info.description;
+          return (
+            canDisplayCard && (
+              <WalkthroughCard
+                key={id}
+                id={id}
+                data={info}
+                href={`${URL_WALKTHROUGH_HREF}/${id}/`}
+              />
+            )
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -9,9 +9,7 @@ export default function Page(): JSX.Element {
     <div className="u-container">
       <div>
         {Object.entries(WalkthroughJSONData).map(([id, { info }]) => {
-          return (
-            <WalkthroughCard key={id} id={id} data={info} walkthroughId={id} />
-          );
+          return <WalkthroughCard key={id} data={info} walkthroughId={id} />;
         })}
       </div>
     </div>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,9 +1,8 @@
 // 3rd party
 import { JSX } from "react";
 // repo
-import { URL_WALKTHROUGH_HREF } from "@repo/constants/src/urls";
 import WalkthroughCard from "@repo/ui/walkthrough-card";
-import { WalkthroughJSONData } from "../../../packages/data/src/useWalkthroughData";
+import { WalkthroughJSONData } from "@repo/data/useWalkthroughData";
 
 export default function Page(): JSX.Element {
   return (
@@ -11,11 +10,7 @@ export default function Page(): JSX.Element {
       <div>
         {Object.entries(WalkthroughJSONData).map(([id, { info }]) => {
           return (
-            <WalkthroughCard
-              id={id}
-              data={info}
-              href={`${URL_WALKTHROUGH_HREF}/${id}/`}
-            />
+            <WalkthroughCard key={id} id={id} data={info} walkthroughId={id} />
           );
         })}
       </div>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,15 +1,30 @@
 // 3rd party
 import { JSX } from "react";
 // repo
-import Link from "@repo/ui/link";
 import { URL_WALKTHROUGH_HREF } from "@repo/constants/src/urls";
+import WalkthroughCard from "@repo/ui/walkthrough-card";
+import {
+  Walkthroughs,
+  WalkthroughJSONData,
+} from "../../../packages/data/src/useWalkthroughData";
 
 export default function Page(): JSX.Element {
   return (
-    <div className="u-container">
-      <p>
-        <Link href={`${URL_WALKTHROUGH_HREF}/9.9.9/`}>Walkthrough 9.9.9</Link>
-      </p>
+    <div className="u-container ">
+      {Walkthroughs.map((walkthrough: string) => {
+        const data = WalkthroughJSONData[walkthrough]?.info;
+        const canDisplayCard =
+          data && data.title && data.subtitle && data.description;
+        return (
+          canDisplayCard && (
+            <WalkthroughCard
+              id={walkthrough}
+              data={data}
+              href={`${URL_WALKTHROUGH_HREF}/${walkthrough}/`}
+            />
+          )
+        );
+      })}
     </div>
   );
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -3,28 +3,19 @@ import { JSX } from "react";
 // repo
 import { URL_WALKTHROUGH_HREF } from "@repo/constants/src/urls";
 import WalkthroughCard from "@repo/ui/walkthrough-card";
-import {
-  Walkthroughs,
-  WalkthroughJSONData,
-} from "../../../packages/data/src/useWalkthroughData";
+import { WalkthroughJSONData } from "../../../packages/data/src/useWalkthroughData";
 
 export default function Page(): JSX.Element {
   return (
     <div className="u-container">
       <div>
-        {Object.entries(WalkthroughJSONData).map(([id, data]) => {
-          const info = data.info;
-          const canDisplayCard =
-            info && info.title && info.subtitle && info.description;
+        {Object.entries(WalkthroughJSONData).map(([id, { info }]) => {
           return (
-            canDisplayCard && (
-              <WalkthroughCard
-                key={id}
-                id={id}
-                data={info}
-                href={`${URL_WALKTHROUGH_HREF}/${id}/`}
-              />
-            )
+            <WalkthroughCard
+              id={id}
+              data={info}
+              href={`${URL_WALKTHROUGH_HREF}/${id}/`}
+            />
           );
         })}
       </div>

--- a/apps/web/utils/string.tsx
+++ b/apps/web/utils/string.tsx
@@ -26,10 +26,11 @@ const customComponents: Record<
   [definedTermName]: DefinedTerm,
   [definedTermModal]: Button,
 };
+type CustomHandler = (section: string) => void;
 
 export const parseStringToComponents = (
   html: string,
-  customHandler?: (location: string) => void,
+  customHandler?: CustomHandler
 ) => {
   const options = {
     replace: (domNode: DOMNode) => {

--- a/apps/web/utils/string.tsx
+++ b/apps/web/utils/string.tsx
@@ -30,7 +30,7 @@ type CustomHandler = (section: string) => void;
 
 export const parseStringToComponents = (
   html: string,
-  customHandler?: CustomHandler
+  customHandler?: CustomHandler,
 ) => {
   const options = {
     replace: (domNode: DOMNode) => {

--- a/packages/constants/src/testids.ts
+++ b/packages/constants/src/testids.ts
@@ -31,3 +31,4 @@ export const TESTID_HEADER_MOBILE_NAV_BUTTON = "header-mobile-nav-button";
 export const GET_TESTID_HEADER_NAV_ITEM = (title: string) =>
   `header-nav-item-${title}`;
 export const TESTID_MODAL_SIDE = "modal-side";
+export const TESTID_WALTHROUGH_CARD = "walkthrough-card";

--- a/packages/data/src/useWalkthroughData.ts
+++ b/packages/data/src/useWalkthroughData.ts
@@ -1,6 +1,6 @@
 import testCase999 from "../walkthroughs/9.9.9.json";
 
-export const Walkthroughs = ["9.9.9"];
+type Walkthroughs = "9.9.9";
 
 interface UseWalkthroughDataProps {
   /*
@@ -162,7 +162,7 @@ export interface WalkthroughJSONType {
   };
 }
 
-export const WalkthroughJSONData: Record<string, WalkthroughJSONType> = {
+export const WalkthroughJSONData: Record<Walkthroughs, WalkthroughJSONType> = {
   "9.9.9": testCase999,
 };
 
@@ -173,7 +173,7 @@ export default function useWalkthroughData({
     throw new Error("No id provided");
   }
 
-  const data = WalkthroughJSONData[id];
+  const data = WalkthroughJSONData[id as Walkthroughs];
   if (!data) {
     throw new Error(`No data found for walkthrough ${id}`);
   }

--- a/packages/data/src/useWalkthroughData.ts
+++ b/packages/data/src/useWalkthroughData.ts
@@ -108,7 +108,7 @@ export interface QuestionMultipleChoiceData extends QuestionBaseData {
 
 export const WalkthroughItemTypeMultiChoiceMultiple = "multiChoiceMultiple";
 export const isWalkthroughItemTypeMultiChoiceMultiple = (
-  walkthroughItemType: string
+  walkthroughItemType: string,
 ) => walkthroughItemType === WalkthroughItemTypeMultiChoiceMultiple;
 export interface QuestionMultipleChoiceSelectMultipleData
   extends QuestionBaseData {
@@ -169,10 +169,6 @@ export const WalkthroughJSONData: Record<Walkthroughs, WalkthroughJSONType> = {
 export default function useWalkthroughData({
   id,
 }: UseWalkthroughDataProps): WalkthroughJSONType {
-  if (!id) {
-    throw new Error("No id provided");
-  }
-
   const data = WalkthroughJSONData[id as Walkthroughs];
   if (!data) {
     throw new Error(`No data found for walkthrough ${id}`);

--- a/packages/data/src/useWalkthroughData.ts
+++ b/packages/data/src/useWalkthroughData.ts
@@ -1,6 +1,6 @@
 import testCase999 from "../walkthroughs/9.9.9.json";
 
-type Walkthroughs = "9.9.9";
+export const Walkthroughs = ["9.9.9"];
 
 interface UseWalkthroughDataProps {
   /*
@@ -108,7 +108,7 @@ export interface QuestionMultipleChoiceData extends QuestionBaseData {
 
 export const WalkthroughItemTypeMultiChoiceMultiple = "multiChoiceMultiple";
 export const isWalkthroughItemTypeMultiChoiceMultiple = (
-  walkthroughItemType: string,
+  walkthroughItemType: string
 ) => walkthroughItemType === WalkthroughItemTypeMultiChoiceMultiple;
 export interface QuestionMultipleChoiceSelectMultipleData
   extends QuestionBaseData {
@@ -138,15 +138,19 @@ interface SectionData {
   sectionQuestions: string[];
 }
 
+export interface WalkthroughInfo {
+  title: string;
+  subtitle: string;
+  description: string;
+  startingSectionId: StartingSectionIdType;
+}
+
 export type StartingSectionIdType = string;
 export type QuestionDisplayData =
   | QuestionMultipleChoiceData
   | QuestionMultipleChoiceSelectMultipleData;
 export interface WalkthroughJSONType {
-  info: {
-    title: string;
-    startingSectionId: StartingSectionIdType;
-  };
+  info: WalkthroughInfo;
   sections: {
     [key: string]: SectionData;
   };
@@ -158,15 +162,21 @@ export interface WalkthroughJSONType {
   };
 }
 
-const WalkthroughJSONData: Record<Walkthroughs, WalkthroughJSONType> = {
+export const WalkthroughJSONData: Record<string, WalkthroughJSONType> = {
   "9.9.9": testCase999,
 };
 
-export default function useWalkthroughData({ id }: UseWalkthroughDataProps) {
-  // check if passed id is a key in WalkthroughJSONData
-  if (!Object.prototype.hasOwnProperty.call(WalkthroughJSONData, id)) {
-    throw new Error(`No data found for walkthrough ${id}`);
-  } else {
-    return WalkthroughJSONData[id as Walkthroughs];
+export default function useWalkthroughData({
+  id,
+}: UseWalkthroughDataProps): WalkthroughJSONType {
+  if (!id) {
+    throw new Error("No id provided");
   }
+
+  const data = WalkthroughJSONData[id];
+  if (!data) {
+    throw new Error(`No data found for walkthrough ${id}`);
+  }
+
+  return data;
 }

--- a/packages/data/walkthroughs/9.9.9.json
+++ b/packages/data/walkthroughs/9.9.9.json
@@ -1,6 +1,8 @@
 {
   "info": {
     "title": "Egress from Dwelling Units",
+    "subtitle": "Volume II - 9.9.9.",
+    "description": "Ensure your dwelling unit has exits or egress doors that pass code.",
     "startingSectionId": "intro"
   },
   "sections": {
@@ -33,27 +35,11 @@
     },
     "9992": {
       "sectionTitle": "9.9.9.2 Two Separate Exits",
-      "sectionQuestions": [
-        "P11",
-        "P12",
-        "P13",
-        "P14",
-        "P15",
-        "P16",
-        "P17"
-      ]
+      "sectionQuestions": ["P11", "P12", "P13", "P14", "P15", "P16", "P17"]
     },
     "9993": {
       "sectionTitle": "9.9.9.3 Shared Egress Facilities",
-      "sectionQuestions": [
-        "P18",
-        "P19",
-        "P20",
-        "P21",
-        "P22",
-        "P23",
-        "P24"
-      ]
+      "sectionQuestions": ["P18", "P19", "P20", "P21", "P22", "P23", "P24"]
     }
   },
   "questions": {
@@ -399,16 +385,7 @@
         {
           "nextLogicType": "containsAny",
           "answerToCheck": "P06",
-          "answerValues": [
-            "A1",
-            "A2",
-            "A3",
-            "A4",
-            "B1",
-            "B2",
-            "B3",
-            "F1"
-          ],
+          "answerValues": ["A1", "A2", "A3", "A4", "B1", "B2", "B3", "F1"],
           "nextNavigateTo": "R05"
         },
         {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "exports": {
+    "./walkthrough-card": "./src/walkthrough-card/WalkthroughCard.tsx",
     "./image": "./src/image/Image.tsx",
     "./tooltip": "./src/tooltip/Tooltip.tsx",
     "./modal-side": "./src/modal-side/ModalSide.tsx",

--- a/packages/ui/src/variables.css
+++ b/packages/ui/src/variables.css
@@ -266,6 +266,10 @@
 
 /* CUSTOM */
 :root {
+  --transition-medium: 300ms;
   --theme-black-opacity-40: #00000040;
   --walkthrough-card-max-width: 27.5rem;
+  --walkthrough-card-title-text-decoration-hidden: underline 1px #00000000;
+  --walkthrough-card-title-text-decoration-color-transition: underline 1px;
+  --walkthrough-card-title-text-underline-offset: 0.2em;
 }

--- a/packages/ui/src/variables.css
+++ b/packages/ui/src/variables.css
@@ -269,6 +269,9 @@
   --transition-medium: 300ms;
   --theme-black-opacity-40: #00000040;
   --walkthrough-card-max-width: 27.5rem;
+  --walkthrough-card-border-transparent: 1px solid #00000000;
+  --walkthrough-card-border-default: 1px solid
+    var(--surface-color-border-default);
   --walkthrough-card-title-text-decoration-hidden: underline 1px #00000000;
   --walkthrough-card-title-text-decoration-color-transition: underline 1px;
   --walkthrough-card-title-text-underline-offset: 0.2em;

--- a/packages/ui/src/variables.css
+++ b/packages/ui/src/variables.css
@@ -267,4 +267,5 @@
 /* CUSTOM */
 :root {
   --theme-black-opacity-40: #00000040;
+  --walkthrough-card-max-width: 27.5rem;
 }

--- a/packages/ui/src/walkthrough-card/WalkthroughCard.css
+++ b/packages/ui/src/walkthrough-card/WalkthroughCard.css
@@ -12,20 +12,24 @@
   gap: var(--layout-margin-medium);
   border: var(--layout-border-width-none);
   text-align: left;
+  transition: box-shadow var(--transition-medium);
 }
 
 .ui-WalkthroughCard--Title {
   color: var(--support-border-color-info);
   font: var(--typography-bold-h5);
+  text-decoration: var(--walkthrough-card-title-text-decoration-hidden);
+  transition: text-decoration-color var(--transition-medium);
+  text-underline-offset: var(--walkthrough-card-title-text-underline-offset);
 }
+
 .ui-WalkthroughCard--CardContainer:hover {
   cursor: pointer;
   box-shadow: var(--surface-shadow-medium), var(--surface-shadow-medium);
 }
 
 .ui-WalkthroughCard--CardContainer:hover .ui-WalkthroughCard--Title {
-  text-decoration: underline;
-  text-decoration-thickness: 1px;
+  text-decoration-color: var(--support-border-color-info);
 }
 
 .ui-WalkthroughCard--Subtitle {

--- a/packages/ui/src/walkthrough-card/WalkthroughCard.css
+++ b/packages/ui/src/walkthrough-card/WalkthroughCard.css
@@ -1,34 +1,38 @@
 .ui-WalkthroughCard--CardContainer {
   display: flex;
   border-radius: var(--layout-border-radius-xlarge);
-  box-shadow: var(--surface-shadow-none), var(--surface-shadow-none);
+  box-shadow: var(--surface-shadow-medium), var(--surface-shadow-medium);
   background-color: var(--surface-color-background-white);
   max-width: var(--walkthrough-card-max-width);
   flex-direction: column;
-  font-size: 14px;
   color: var(--support-border-color-info);
   padding: var(--layout-padding-large);
-  margin: var(--layout-margin-medium);
-  gap: var(--layout-margin-medium);
   border: var(--layout-border-width-none);
   text-align: left;
   transition: box-shadow var(--transition-medium);
+  text-decoration: none;
 }
 
 .ui-WalkthroughCard--Title {
   color: var(--support-border-color-info);
-  font: var(--typography-bold-h5);
+  font: var(--typography-bold-h4);
   text-decoration: var(--walkthrough-card-title-text-decoration-hidden);
   transition: text-decoration-color var(--transition-medium);
   text-underline-offset: var(--walkthrough-card-title-text-underline-offset);
 }
 
-.ui-WalkthroughCard--CardContainer:hover {
+.ui-WalkthroughCard--CardContainer[data-hovered] {
   cursor: pointer;
-  box-shadow: var(--surface-shadow-medium), var(--surface-shadow-medium);
+  box-shadow: var(--surface-shadow-large), var(--surface-shadow-large);
+  border: 1px solid var(--surface-color-border-default);
 }
 
-.ui-WalkthroughCard--CardContainer:hover .ui-WalkthroughCard--Title {
+/* Remove border when card is clicked */
+.ui-WalkthroughCard--CardContainer[data-focused] {
+  outline: none;
+}
+
+.ui-WalkthroughCard--CardContainer[data-hovered] .ui-WalkthroughCard--Title {
   text-decoration-color: var(--support-border-color-info);
 }
 

--- a/packages/ui/src/walkthrough-card/WalkthroughCard.css
+++ b/packages/ui/src/walkthrough-card/WalkthroughCard.css
@@ -1,53 +1,42 @@
-.card-container {
-  justify-content: space-between;
-  border-radius: 8px;
-  box-shadow:
-    0px 1.2px 3.6px 0px rgba(0, 0, 0, 0.1),
-    0px 6.4px 14.4px 0px rgba(0, 0, 0, 0.13);
-  background-color: #fff;
+.ui-WalkthroughCard--CardContainer {
   display: flex;
-  max-width: 428px;
+  border-radius: var(--layout-border-radius-xlarge);
+  box-shadow: var(--surface-shadow-none), var(--surface-shadow-none);
+  background-color: var(--surface-color-background-white);
+  max-width: var(--walkthrough-card-max-width);
   flex-direction: column;
   font-size: 14px;
   color: var(--support-border-color-info);
-  font-weight: 400;
-  line-height: 150%;
-  padding: 24px;
+  padding: var(--layout-padding-large);
   margin: var(--layout-margin-medium);
   gap: var(--layout-margin-medium);
-  border: none;
+  border: var(--layout-border-width-none);
   text-align: left;
 }
 
-.title {
+.ui-WalkthroughCard--Title {
   color: var(--support-border-color-info);
   font: var(--typography-bold-h5);
 }
-.card-container:hover {
+.ui-WalkthroughCard--CardContainer:hover {
   cursor: pointer;
-  box-shadow:
-    0px 1.2px 3.6px 0px rgba(0, 0, 0, 0.2),
-    0px 6.4px 14.4px 0px rgba(0, 0, 0, 0.23);
+  box-shadow: var(--surface-shadow-medium), var(--surface-shadow-medium);
 }
 
-.card-container:hover .title {
+.ui-WalkthroughCard--CardContainer:hover .ui-WalkthroughCard--Title {
   text-decoration: underline;
   text-decoration-thickness: 1px;
-  white-space: normal;
-  height: auto;
 }
 
-.subtitle {
+.ui-WalkthroughCard--Subtitle {
   font: var(--typography-regular-label);
   color: var(--support-border-color-info);
-  border: 1px solid var(--theme-blue-90);
+  border: var(--layout-border-width-small) solid var(--theme-blue-90);
   border-radius: var(--layout-border-radius-small);
-  padding: 2px 8px;
-  display: inline;
-  margin-top: 8px;
+  padding: var(--layout-padding-xxsmall) var(--layout-padding-xsmall);
 }
 
-.description {
+.ui-WalkthroughCard--Description {
   font: var(--typography-regular-body);
   color: var(--typography-color-primary);
 }

--- a/packages/ui/src/walkthrough-card/WalkthroughCard.css
+++ b/packages/ui/src/walkthrough-card/WalkthroughCard.css
@@ -1,0 +1,53 @@
+.card-container {
+  justify-content: space-between;
+  border-radius: 8px;
+  box-shadow:
+    0px 1.2px 3.6px 0px rgba(0, 0, 0, 0.1),
+    0px 6.4px 14.4px 0px rgba(0, 0, 0, 0.13);
+  background-color: #fff;
+  display: flex;
+  max-width: 428px;
+  flex-direction: column;
+  font-size: 14px;
+  color: var(--support-border-color-info);
+  font-weight: 400;
+  line-height: 150%;
+  padding: 24px;
+  margin: var(--layout-margin-medium);
+  gap: var(--layout-margin-medium);
+  border: none;
+  text-align: left;
+}
+
+.title {
+  color: var(--support-border-color-info);
+  font: var(--typography-bold-h5);
+}
+.card-container:hover {
+  cursor: pointer;
+  box-shadow:
+    0px 1.2px 3.6px 0px rgba(0, 0, 0, 0.2),
+    0px 6.4px 14.4px 0px rgba(0, 0, 0, 0.23);
+}
+
+.card-container:hover .title {
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  white-space: normal;
+  height: auto;
+}
+
+.subtitle {
+  font: var(--typography-regular-label);
+  color: var(--support-border-color-info);
+  border: 1px solid var(--theme-blue-90);
+  border-radius: var(--layout-border-radius-small);
+  padding: 2px 8px;
+  display: inline;
+  margin-top: 8px;
+}
+
+.description {
+  font: var(--typography-regular-body);
+  color: var(--typography-color-primary);
+}

--- a/packages/ui/src/walkthrough-card/WalkthroughCard.css
+++ b/packages/ui/src/walkthrough-card/WalkthroughCard.css
@@ -1,5 +1,6 @@
 .ui-WalkthroughCard--CardContainer {
   display: flex;
+  border: var(--walkthrough-card-border-transparent);
   border-radius: var(--layout-border-radius-xlarge);
   box-shadow: var(--surface-shadow-medium), var(--surface-shadow-medium);
   background-color: var(--surface-color-background-white);
@@ -7,9 +8,10 @@
   flex-direction: column;
   color: var(--support-border-color-info);
   padding: var(--layout-padding-large);
-  border: var(--layout-border-width-none);
   text-align: left;
-  transition: box-shadow var(--transition-medium);
+  transition:
+    box-shadow var(--transition-medium),
+    border-color var(--transition-medium);
   text-decoration: none;
 }
 
@@ -24,12 +26,11 @@
 .ui-WalkthroughCard--CardContainer[data-hovered] {
   cursor: pointer;
   box-shadow: var(--surface-shadow-large), var(--surface-shadow-large);
-  border: 1px solid var(--surface-color-border-default);
+  border: var(--walkthrough-card-border-default);
 }
-
-/* Remove border when card is clicked */
-.ui-WalkthroughCard--CardContainer[data-focused] {
-  outline: none;
+.ui-WalkthroughCard--CardContainer[data-focus-visible] {
+  outline: var(--layout-border-width-medium) solid
+    var(--surface-color-border-active);
 }
 
 .ui-WalkthroughCard--CardContainer[data-hovered] .ui-WalkthroughCard--Title {
@@ -42,6 +43,7 @@
   border: var(--layout-border-width-small) solid var(--theme-blue-90);
   border-radius: var(--layout-border-radius-small);
   padding: var(--layout-padding-xxsmall) var(--layout-padding-xsmall);
+  width: fit-content;
 }
 
 .ui-WalkthroughCard--Description {

--- a/packages/ui/src/walkthrough-card/WalkthroughCard.test.tsx
+++ b/packages/ui/src/walkthrough-card/WalkthroughCard.test.tsx
@@ -1,6 +1,5 @@
 // 3rd party
-import { describe, expect, it, vi } from "vitest";
-import { useRouter } from "next/navigation";
+import { describe, expect, it } from "vitest";
 import userEvent from "@testing-library/user-event";
 
 // local
@@ -8,11 +7,10 @@ import { renderWithWalkthroughProvider } from "../../../../apps/web/tests/utils"
 import WalkthroughCard from "./WalkthroughCard";
 import { WalkthroughJSONData } from "../../../../packages/data/src/useWalkthroughData";
 import { URL_WALKTHROUGH_HREF } from "@repo/constants/src/urls";
+import { pushMock } from "../../tests/setup";
 
 describe("WalkthroughCard", () => {
   const testWalkthroughId = "9.9.9";
-  const pushMock = vi.fn();
-  (useRouter as any).mockReturnValue({ push: pushMock });
 
   it("renders WalkthroughCard", async () => {
     const { getByText } = renderWithWalkthroughProvider({
@@ -31,7 +29,7 @@ describe("WalkthroughCard", () => {
   });
 
   it("renders and navigates correctly on click", async () => {
-    const { getByText, getByRole } = renderWithWalkthroughProvider({
+    const { getByRole } = renderWithWalkthroughProvider({
       ui: (
         <WalkthroughCard
           id={testWalkthroughId}

--- a/packages/ui/src/walkthrough-card/WalkthroughCard.test.tsx
+++ b/packages/ui/src/walkthrough-card/WalkthroughCard.test.tsx
@@ -1,0 +1,50 @@
+// 3rd party
+import { describe, expect, it, vi } from "vitest";
+import { useRouter } from "next/navigation";
+import userEvent from "@testing-library/user-event";
+
+// local
+import { renderWithWalkthroughProvider } from "../../../../apps/web/tests/utils";
+import WalkthroughCard from "./WalkthroughCard";
+import { WalkthroughJSONData } from "../../../../packages/data/src/useWalkthroughData";
+import { URL_WALKTHROUGH_HREF } from "@repo/constants/src/urls";
+
+describe("WalkthroughCard", () => {
+  const testWalkthroughId = "9.9.9";
+  const pushMock = vi.fn();
+  (useRouter as any).mockReturnValue({ push: pushMock });
+
+  it("renders WalkthroughCard", async () => {
+    const { getByText } = renderWithWalkthroughProvider({
+      ui: (
+        <WalkthroughCard
+          id={testWalkthroughId}
+          data={WalkthroughJSONData[testWalkthroughId].info}
+          href={`${URL_WALKTHROUGH_HREF}/${testWalkthroughId}/`}
+        />
+      ),
+    });
+
+    expect(
+      getByText(WalkthroughJSONData[testWalkthroughId].info.title)
+    ).toBeInTheDocument();
+  });
+
+  it("renders and navigates correctly on click", async () => {
+    const { getByText, getByRole } = renderWithWalkthroughProvider({
+      ui: (
+        <WalkthroughCard
+          id={testWalkthroughId}
+          data={WalkthroughJSONData[testWalkthroughId].info}
+          href={`${URL_WALKTHROUGH_HREF}/${testWalkthroughId}/`}
+        />
+      ),
+    });
+
+    await userEvent.click(getByRole("button"));
+
+    expect(pushMock).toHaveBeenCalledWith(
+      `${URL_WALKTHROUGH_HREF}/${testWalkthroughId}/`
+    );
+  });
+});

--- a/packages/ui/src/walkthrough-card/WalkthroughCard.test.tsx
+++ b/packages/ui/src/walkthrough-card/WalkthroughCard.test.tsx
@@ -6,43 +6,38 @@ import { renderWithWalkthroughProvider } from "../../../../apps/web/tests/utils"
 import WalkthroughCard from "./WalkthroughCard";
 import { WalkthroughJSONData } from "@repo/data/useWalkthroughData";
 import { URL_WALKTHROUGH_HREF } from "@repo/constants/src/urls";
+import { TESTID_WALTHROUGH_CARD } from "@repo/constants/src/testids";
 
 describe("WalkthroughCard", () => {
   const testWalkthroughId = "9.9.9";
 
   it("renders WalkthroughCard", async () => {
-    const { getByRole } = renderWithWalkthroughProvider({
+    const { getByTestId } = renderWithWalkthroughProvider({
       ui: (
         <WalkthroughCard
           key={testWalkthroughId}
-          id={testWalkthroughId}
           data={WalkthroughJSONData[testWalkthroughId].info}
           walkthroughId={`${testWalkthroughId}/`}
         />
       ),
     });
 
-    const linkElement = getByRole("link", {
-      name: `${testWalkthroughId}-walkthrough-card`,
-    });
+    const linkElement = getByTestId(TESTID_WALTHROUGH_CARD);
     expect(linkElement).toBeInTheDocument();
   });
 
-  it("renders and navigates correctly on click", async () => {
-    const { getByRole } = renderWithWalkthroughProvider({
+  it("renders and has correct href value", async () => {
+    const { getByTestId } = renderWithWalkthroughProvider({
       ui: (
         <WalkthroughCard
           key={testWalkthroughId}
-          id={testWalkthroughId}
           data={WalkthroughJSONData[testWalkthroughId].info}
           walkthroughId={`${testWalkthroughId}`}
         />
       ),
     });
 
-    const linkElement = getByRole("link", {
-      name: `${testWalkthroughId}-walkthrough-card`,
-    });
+    const linkElement = getByTestId(TESTID_WALTHROUGH_CARD);
     expect(linkElement).toBeInTheDocument();
     expect(linkElement).toHaveAttribute(
       "href",

--- a/packages/ui/src/walkthrough-card/WalkthroughCard.test.tsx
+++ b/packages/ui/src/walkthrough-card/WalkthroughCard.test.tsx
@@ -1,48 +1,52 @@
 // 3rd party
 import { describe, expect, it } from "vitest";
-import userEvent from "@testing-library/user-event";
 
 // local
 import { renderWithWalkthroughProvider } from "../../../../apps/web/tests/utils";
 import WalkthroughCard from "./WalkthroughCard";
-import { WalkthroughJSONData } from "../../../../packages/data/src/useWalkthroughData";
+import { WalkthroughJSONData } from "@repo/data/useWalkthroughData";
 import { URL_WALKTHROUGH_HREF } from "@repo/constants/src/urls";
-import { pushMock } from "../../tests/setup";
 
 describe("WalkthroughCard", () => {
   const testWalkthroughId = "9.9.9";
 
   it("renders WalkthroughCard", async () => {
-    const { getByText } = renderWithWalkthroughProvider({
+    const { getByRole } = renderWithWalkthroughProvider({
       ui: (
         <WalkthroughCard
+          key={testWalkthroughId}
           id={testWalkthroughId}
           data={WalkthroughJSONData[testWalkthroughId].info}
-          href={`${URL_WALKTHROUGH_HREF}/${testWalkthroughId}/`}
+          walkthroughId={`${testWalkthroughId}/`}
         />
       ),
     });
 
-    expect(
-      getByText(WalkthroughJSONData[testWalkthroughId].info.title)
-    ).toBeInTheDocument();
+    const linkElement = getByRole("link", {
+      name: `${testWalkthroughId}-walkthrough-card`,
+    });
+    expect(linkElement).toBeInTheDocument();
   });
 
   it("renders and navigates correctly on click", async () => {
     const { getByRole } = renderWithWalkthroughProvider({
       ui: (
         <WalkthroughCard
+          key={testWalkthroughId}
           id={testWalkthroughId}
           data={WalkthroughJSONData[testWalkthroughId].info}
-          href={`${URL_WALKTHROUGH_HREF}/${testWalkthroughId}/`}
+          walkthroughId={`${testWalkthroughId}`}
         />
       ),
     });
 
-    await userEvent.click(getByRole("button"));
-
-    expect(pushMock).toHaveBeenCalledWith(
-      `${URL_WALKTHROUGH_HREF}/${testWalkthroughId}/`
+    const linkElement = getByRole("link", {
+      name: `${testWalkthroughId}-walkthrough-card`,
+    });
+    expect(linkElement).toBeInTheDocument();
+    expect(linkElement).toHaveAttribute(
+      "href",
+      `${URL_WALKTHROUGH_HREF}/${testWalkthroughId}`,
     );
   });
 });

--- a/packages/ui/src/walkthrough-card/WalkthroughCard.tsx
+++ b/packages/ui/src/walkthrough-card/WalkthroughCard.tsx
@@ -1,47 +1,39 @@
 "use client";
-import { useRouter } from "next/navigation";
 
-import { Button } from "react-aria-components";
+// 3rd party
+import {
+  Link as ReactAriaLink,
+  LinkProps as ReactAriaLinkProps,
+} from "react-aria-components";
 
-import { WalkthroughInfo } from "../../../data/src/useWalkthroughData";
-
+import { WalkthroughInfo } from "@repo/data/useWalkthroughData";
+import { URL_WALKTHROUGH_HREF } from "@repo/constants/src/urls";
 import "./WalkthroughCard.css";
 
-export interface WalkthroughCardProps {
+export interface WalkthroughCardProps extends ReactAriaLinkProps {
   id: string;
   data: WalkthroughInfo;
-  href?: string;
+  walkthroughId: string;
 }
 
 export default function WalkthroughCard({
   id,
   data,
-  href,
+  walkthroughId,
 }: WalkthroughCardProps) {
-  const router = useRouter();
-
-  const handleClick = () => {
-    if (href) router.push(href);
-  };
-
-  const canDisplayCard =
-    data && data.title && data.subtitle && data.description;
-
-  if (!canDisplayCard) return null;
-
   return (
-    <Button
+    <ReactAriaLink
       className="ui-WalkthroughCard--CardContainer"
-      onPress={handleClick}
+      href={`${URL_WALKTHROUGH_HREF}/${walkthroughId}`}
       aria-label={`${id}-walkthrough-card`}
     >
-      <header className="ui-WalkthroughCard--Title">{data.title}</header>
       <article>
+        <header className="ui-WalkthroughCard--Title">{data.title}</header>
         <span className="ui-WalkthroughCard--Subtitle">{data.subtitle}</span>
+        <section className="ui-WalkthroughCard--Description">
+          {data.description}
+        </section>
       </article>
-      <section className="ui-WalkthroughCard--Description">
-        {data.description}
-      </section>
-    </Button>
+    </ReactAriaLink>
   );
 }

--- a/packages/ui/src/walkthrough-card/WalkthroughCard.tsx
+++ b/packages/ui/src/walkthrough-card/WalkthroughCard.tsx
@@ -1,0 +1,45 @@
+"use client";
+import { useRouter } from "next/navigation";
+
+import { Button } from "react-aria-components";
+
+import { WalkthroughInfo } from "../../../data/src/useWalkthroughData";
+
+import "./WalkthroughCard.css";
+
+export interface WalkthroughCardProps {
+  id: string;
+  data: WalkthroughInfo;
+  href?: string;
+}
+
+export default function WalkthroughCard({
+  id,
+  data,
+  href,
+}: WalkthroughCardProps) {
+  const router = useRouter();
+
+  const handleClick = () => {
+    if (href) router.push(href);
+  };
+
+  const canDisplayCard =
+    data && data.title && data.subtitle && data.description;
+
+  if (!canDisplayCard) return null;
+
+  return (
+    <Button
+      className="card-container"
+      onPress={handleClick}
+      aria-label={`${id}-walkthrough-card`}
+    >
+      <div className="title">{data.title}</div>
+      <div>
+        <div className="subtitle">{data.subtitle}</div>
+      </div>
+      <div className="description">{data.description}</div>
+    </Button>
+  );
+}

--- a/packages/ui/src/walkthrough-card/WalkthroughCard.tsx
+++ b/packages/ui/src/walkthrough-card/WalkthroughCard.tsx
@@ -9,30 +9,32 @@ import {
 import { WalkthroughInfo } from "@repo/data/useWalkthroughData";
 import { URL_WALKTHROUGH_HREF } from "@repo/constants/src/urls";
 import "./WalkthroughCard.css";
+import { TESTID_WALTHROUGH_CARD } from "@repo/constants/src/testids";
 
 export interface WalkthroughCardProps extends ReactAriaLinkProps {
-  id: string;
   data: WalkthroughInfo;
   walkthroughId: string;
+  "data-testid"?: string;
 }
 
 export default function WalkthroughCard({
-  id,
   data,
   walkthroughId,
+  "data-testid": testid = TESTID_WALTHROUGH_CARD,
+  ...props
 }: WalkthroughCardProps) {
   return (
     <ReactAriaLink
       className="ui-WalkthroughCard--CardContainer"
       href={`${URL_WALKTHROUGH_HREF}/${walkthroughId}`}
-      aria-label={`${id}-walkthrough-card`}
+      aria-label={`walkthrough ${walkthroughId} - ${data.title}`}
+      data-testid={testid}
+      {...props}
     >
       <article>
         <header className="ui-WalkthroughCard--Title">{data.title}</header>
-        <span className="ui-WalkthroughCard--Subtitle">{data.subtitle}</span>
-        <section className="ui-WalkthroughCard--Description">
-          {data.description}
-        </section>
+        <p className="ui-WalkthroughCard--Subtitle">{data.subtitle}</p>
+        <p className="ui-WalkthroughCard--Description">{data.description}</p>
       </article>
     </ReactAriaLink>
   );

--- a/packages/ui/src/walkthrough-card/WalkthroughCard.tsx
+++ b/packages/ui/src/walkthrough-card/WalkthroughCard.tsx
@@ -31,15 +31,17 @@ export default function WalkthroughCard({
 
   return (
     <Button
-      className="card-container"
+      className="ui-WalkthroughCard--CardContainer"
       onPress={handleClick}
       aria-label={`${id}-walkthrough-card`}
     >
-      <div className="title">{data.title}</div>
-      <div>
-        <div className="subtitle">{data.subtitle}</div>
-      </div>
-      <div className="description">{data.description}</div>
+      <header className="ui-WalkthroughCard--Title">{data.title}</header>
+      <article>
+        <span className="ui-WalkthroughCard--Subtitle">{data.subtitle}</span>
+      </article>
+      <section className="ui-WalkthroughCard--Description">
+        {data.description}
+      </section>
     </Button>
   );
 }

--- a/packages/ui/tests/setup.ts
+++ b/packages/ui/tests/setup.ts
@@ -9,13 +9,19 @@ afterEach(() => {
   cleanup();
 });
 
+// Mock next/navigation
+const pushMock = vi.fn();
+const replaceMock = vi.fn();
+
 vi.mock("next/navigation", async () => {
   const actual = await vi.importActual("next/navigation");
   return {
     ...actual,
     useRouter: vi.fn(() => ({
-      push: vi.fn(),
-      replace: vi.fn(),
+      push: pushMock,
+      replace: replaceMock,
     })),
   };
 });
+
+export { pushMock, replaceMock };

--- a/packages/ui/tests/setup.ts
+++ b/packages/ui/tests/setup.ts
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import { expect, afterEach } from "vitest";
+import { expect, afterEach, vi } from "vitest";
 import { cleanup } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
 
@@ -7,4 +7,15 @@ expect.extend(matchers);
 
 afterEach(() => {
   cleanup();
+});
+
+vi.mock("next/navigation", async () => {
+  const actual = await vi.importActual("next/navigation");
+  return {
+    ...actual,
+    useRouter: vi.fn(() => ({
+      push: vi.fn(),
+      replace: vi.fn(),
+    })),
+  };
 });

--- a/packages/ui/tests/setup.ts
+++ b/packages/ui/tests/setup.ts
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import { expect, afterEach, vi } from "vitest";
+import { expect, afterEach } from "vitest";
 import { cleanup } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
 
@@ -8,20 +8,3 @@ expect.extend(matchers);
 afterEach(() => {
   cleanup();
 });
-
-// Mock next/navigation
-const pushMock = vi.fn();
-const replaceMock = vi.fn();
-
-vi.mock("next/navigation", async () => {
-  const actual = await vi.importActual("next/navigation");
-  return {
-    ...actual,
-    useRouter: vi.fn(() => ({
-      push: pushMock,
-      replace: replaceMock,
-    })),
-  };
-});
-
-export { pushMock, replaceMock };


### PR DESCRIPTION
<!-- You may remove any sections that are not applicable -->

[HOUSNAV-21](https://hous-bssb.atlassian.net/browse/HOUSNAV-21)

## Overview & Purpose
<!-- Please describe the purpose of your changes. Please also include relevant motivation and context. -->
Add a reusable walkthrough card component to be used through the app. (Home page and end result)

## Summary of Changes
<!-- Please include a HIGH LEVEL overview of the code changes. (Added xyz fields to table, modified function to handle x case instead of y case, etc. )  -->
- Adds `walkthoughCard` component
- Updates the `9.9.9.` walkthrough to add titles and descriptions for the cards
    - Updates the `WalkthroughInfo` accordingly 

## Side Effects
<!-- Any possible side effects? Does this change affect features that are not linked to the direct purpose? -->
- Adjusted `useWalkthroughData` error handling to make it more understandable

## Testing
<!-- Please include steps to test out the changes/fixes if applicable OR context notes to help get env in a state to test-->
- Go to home screen and new card should appear
- It should navigate to the 9.9.9 walkthrough when clicked

https://github.com/bcgov/House-Innovations-HOUSNAV/assets/7059124/52b6de35-7346-4a12-9226-49f6de218863


![Screenshot 2024-06-13 at 9 59 12 AM](https://github.com/bcgov/House-Innovations-HOUSNAV/assets/7059124/88f65fd9-ea2c-4345-ba8b-aff4668c7177)

![Screenshot 2024-06-13 at 9 59 30 AM](https://github.com/bcgov/House-Innovations-HOUSNAV/assets/7059124/e110675c-b14c-4fc7-a095-7ab313b874e1)

