### PR TITLE
HOUSNAV-73: Image loading bug

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -12,6 +12,7 @@ module.exports = {
     ];
   },
   images: {
+    unoptimized: true,
     remotePatterns: [
       {
         protocol: "https",

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -11,4 +11,12 @@ module.exports = {
       },
     ];
   },
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "**.gov.bc.ca",
+      },
+    ],
+  },
 };

--- a/packages/ui/src/image/Image.tsx
+++ b/packages/ui/src/image/Image.tsx
@@ -1,16 +1,9 @@
-import React from "react";
+import NextImage, { ImageProps } from "next/image";
 
 import { IMAGES_BASE_PATH } from "@repo/constants/src/constants";
 
-export interface ImageProps
-  extends Pick<
-    React.ImgHTMLAttributes<HTMLImageElement>,
-    "id" | "className" | "alt" | "height" | "width"
-  > {
-  src: string;
-}
+export default function Image({ src, ...props }: ImageProps) {
+  const url = src.toString().includes("/") ? src : `${IMAGES_BASE_PATH}/${src}`;
 
-export default function Image({ src, alt = "", ...props }: ImageProps) {
-  const url = src.includes("/") ? src : `${IMAGES_BASE_PATH}/${src}`;
-  return <img src={url} {...props} alt={alt} />;
+  return <NextImage src={url} {...props} />;
 }

--- a/packages/ui/src/tooltip/Tooltip.tsx
+++ b/packages/ui/src/tooltip/Tooltip.tsx
@@ -28,7 +28,13 @@ export default function Tooltip({
         placement="bottom"
         aria-live="polite"
       >
-        <Image src="tooltip-triangle.svg" className={"ui-Tooltip--Triangle"} />
+        <Image
+          src="tooltip-triangle.svg"
+          alt="tooltip trigger pointer"
+          className={"ui-Tooltip--Triangle"}
+          width="25"
+          height="12"
+        />
         <div className="ui-Tooltip--Content">{tooltipContent}</div>
       </AriaTooltip>
     </TooltipTrigger>


### PR DESCRIPTION
<!-- You may remove any sections that are not applicable -->

[HOUSNAV-73](https://hous-bssb.atlassian.net/browse/HOUSNAV-73)

## Bug Overview
<!-- Please describe the purpose of your changes. Please also include relevant motivation and context. -->
Image assets were not loading in development environment

## Summary of Changes
<!-- Please include a HIGH LEVEL overview of the code changes. (Added xyz fields to table, modified function to handle x case instead of y case, etc. )  -->
- Use next js `Image` component
- Specify `whitelisted` domains to load image urls

## Testing
<!-- Please include steps to test out the changes/fixes if applicable OR context notes to help get env in a state to test-->
- Have not tested this nor am I sure how since it's a dev only issue :) 

## Notes & Resources
<!-- Please include any additional notes necessary to review PR and/or relevant links (documentation, stack overflow, etc.) that helped you arrive at your solution. -->
https://nextjs.org/docs/app/api-reference/components/image
https://github.com/vercel/next.js/issues/48077
