### PR TITLE
Housnav-73: Image loading bug (Pt 2)

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -53,6 +53,7 @@ COPY --from=installer /app/apps/web/package.json .
 # https://nextjs.org/docs/advanced-features/output-file-tracing
 COPY --from=installer --chown=nextjs:nodejs /app/apps/web/.next/standalone ./
 COPY --from=installer --chown=nextjs:nodejs /app/apps/web/.next/static ./apps/web/.next/static
+COPY --from=installer --chown=nextjs:nodejs /app/apps/web/public ./apps/web/public
 
 CMD node apps/web/server.js
 # -----/Runner Stage------- #

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -12,7 +12,6 @@ module.exports = {
     ];
   },
   images: {
-    unoptimized: true,
     remotePatterns: [
       {
         protocol: "https",


### PR DESCRIPTION
<!-- You may remove any sections that are not applicable -->

[HOUSNAV-73](https://hous-bssb.atlassian.net/browse/HOUSNAV-73)

## Overview & Purpose
<!-- Please describe the purpose of your changes. Please also include relevant motivation and context. -->
Ensure public directory is in docker image

## Summary of Changes
<!-- Please include a HIGH LEVEL overview of the code changes. (Added xyz fields to table, modified function to handle x case instead of y case, etc. )  -->
- Added `COPY` step to ensure public folder is copied from the next build and installer
- Removed `unoptimized: true` as it's not needed 

## Testing
<!-- Please include steps to test out the changes/fixes if applicable OR context notes to help get env in a state to test-->
Tested via running docker locally, inspecting the image and determining that the `public` directory was not there. Then after adding the copy line in the dockerfile it's working with a local docker build.

Before:
![Screenshot 2024-06-14 at 9 34 42 AM](https://github.com/bcgov/House-Innovations-HOUSNAV/assets/7059124/cadcf673-290f-4bd8-baf4-0fcfca7594b2)

After:
![Screenshot 2024-06-14 at 9 35 16 AM](https://github.com/bcgov/House-Innovations-HOUSNAV/assets/7059124/015142e9-7b88-4480-8f24-ae76c19e33e2)
