### PR TITLE
HOUSENAV-23: Intro UI Cypress Tests

### DIFF
--- a/apps/web/cypress/e2e/walkthroughs.cy.ts
+++ b/apps/web/cypress/e2e/walkthroughs.cy.ts
@@ -19,10 +19,12 @@ describe("walkthrough 1", () => {
         if (step.type === "radio") {
           cy.getByTestID(GET_TESTID_RADIO(step.question, step.answer)).click();
         } else if (step.type === "checkbox") {
-          // TODO - update the application to not have duplicate test ids on checkboxes
-          cy.getByTestID(GET_TESTID_CHECKBOX(step.question, step.answer))
-            .last()
-            .click({ force: true });
+          step.answer.split(",").forEach((answer) => {
+            // TODO - update the application to not have duplicate test ids on checkboxes
+            cy.getByTestID(GET_TESTID_CHECKBOX(step.question, answer))
+              .last()
+              .click({ force: true });
+          });
         }
         cy.getByGeneralTestID(TESTID_WALKTHROUGH_FOOTER_NEXT).click();
       });

--- a/apps/web/cypress/e2e/walkthroughs.cy.ts
+++ b/apps/web/cypress/e2e/walkthroughs.cy.ts
@@ -1,4 +1,8 @@
-import { TESTID_WALKTHROUGH_FOOTER_NEXT } from "@repo/constants/src/testids";
+import {
+  TESTID_WALKTHROUGH_FOOTER_NEXT,
+  GET_TESTID_CHECKBOX,
+  GET_TESTID_RADIO,
+} from "@repo/constants/src/testids";
 
 import { walkthroughs, results } from "../fixtures/test-data.json";
 
@@ -11,9 +15,15 @@ describe("walkthrough 1", () => {
   walkthroughs.forEach((walkthrough) => {
     it(walkthrough.title, () => {
       walkthrough.steps.forEach((step) => {
-        // TODO - use test ids
         // select and submit an answer for the given question
-        cy.getByTestID(`${step.type}-${step.question}-${step.answer}`).click();
+        if (step.type === "radio") {
+          cy.getByTestID(GET_TESTID_RADIO(step.question, step.answer)).click();
+        } else if (step.type === "checkbox") {
+          // TODO - update the application to not have duplicate test ids on checkboxes
+          cy.getByTestID(GET_TESTID_CHECKBOX(step.question, step.answer))
+            .last()
+            .click({ force: true });
+        }
         cy.getByGeneralTestID(TESTID_WALKTHROUGH_FOOTER_NEXT).click();
       });
       if (walkthrough.result) {

--- a/apps/web/cypress/e2e/walkthroughs.cy.ts
+++ b/apps/web/cypress/e2e/walkthroughs.cy.ts
@@ -20,10 +20,9 @@ describe("walkthrough 1", () => {
           cy.getByTestID(GET_TESTID_RADIO(step.question, step.answer)).click();
         } else if (step.type === "checkbox") {
           step.answer.split(",").forEach((answer) => {
-            // TODO - update the application to not have duplicate test ids on checkboxes
-            cy.getByTestID(GET_TESTID_CHECKBOX(step.question, answer))
-              .last()
-              .click({ force: true });
+            cy.getInputByTestID(
+              GET_TESTID_CHECKBOX(step.question, answer),
+            ).click({ force: true });
           });
         }
         cy.getByGeneralTestID(TESTID_WALKTHROUGH_FOOTER_NEXT).click();
@@ -39,12 +38,12 @@ describe("walkthrough 1", () => {
     cy.getByGeneralTestID(TESTID_WALKTHROUGH_FOOTER_NEXT).click();
 
     // Select both "none" and another option
-    cy.getByTestID(GET_TESTID_CHECKBOX("P02", "17"))
-      .last()
-      .click({ force: true });
-    cy.getByTestID(GET_TESTID_CHECKBOX("P02", "18"))
-      .last()
-      .click({ force: true });
+    cy.getInputByTestID(GET_TESTID_CHECKBOX("P02", "17")).click({
+      force: true,
+    });
+    cy.getInputByTestID(GET_TESTID_CHECKBOX("P02", "18")).click({
+      force: true,
+    });
 
     // Show error message
     cy.getByGeneralTestID(TESTID_WALKTHROUGH_FOOTER_NEXT).click();

--- a/apps/web/cypress/e2e/walkthroughs.cy.ts
+++ b/apps/web/cypress/e2e/walkthroughs.cy.ts
@@ -1,6 +1,6 @@
 import { TESTID_WALKTHROUGH_FOOTER_NEXT } from "@repo/constants/src/testids";
 
-import { walkthroughs } from "../fixtures/test-data.json";
+import { walkthroughs, results } from "../fixtures/test-data.json";
 
 describe("walkthrough 1", () => {
   beforeEach(() => {
@@ -17,7 +17,7 @@ describe("walkthrough 1", () => {
         cy.getByGeneralTestID(TESTID_WALKTHROUGH_FOOTER_NEXT).click();
       });
       if (walkthrough.result) {
-        cy.contains(walkthrough.result);
+        cy.contains(results[walkthrough.result]);
       }
     });
   });

--- a/apps/web/cypress/e2e/walkthroughs.cy.ts
+++ b/apps/web/cypress/e2e/walkthroughs.cy.ts
@@ -34,6 +34,26 @@ describe("walkthrough 1", () => {
     });
   });
 
+  it("error state should be accessible", () => {
+    cy.getByTestID(GET_TESTID_RADIO("P01", "notSure")).click();
+    cy.getByGeneralTestID(TESTID_WALKTHROUGH_FOOTER_NEXT).click();
+
+    // Select both "none" and another option
+    cy.getByTestID(GET_TESTID_CHECKBOX("P02", "17"))
+      .last()
+      .click({ force: true });
+    cy.getByTestID(GET_TESTID_CHECKBOX("P02", "18"))
+      .last()
+      .click({ force: true });
+
+    // Show error message
+    cy.getByGeneralTestID(TESTID_WALKTHROUGH_FOOTER_NEXT).click();
+
+    // Test accessibility
+    cy.injectAxe();
+    cy.checkA11y();
+  });
+
   it("default state should be accessible", () => {
     cy.injectAxe();
     cy.checkA11y();

--- a/apps/web/cypress/fixtures/test-data.json
+++ b/apps/web/cypress/fixtures/test-data.json
@@ -1,8 +1,34 @@
 {
     "walkthroughs": [
         {
-            "id": 1,
-            "title": "Partial walkthrough",
+            "title": "Code does not apply",
+            "steps": [
+                {
+                    "question": "P01",
+                    "type": "radio",
+                    "answer": "no"
+                }
+            ],
+            "result": "R00"
+        },
+        {
+            "title": "Heritage building",
+            "steps": [
+                {
+                    "question": "P01",
+                    "type": "radio",
+                    "answer": "yes"
+                },
+                {
+                    "question": "P04",
+                    "type": "radio",
+                    "answer": "true"
+                }
+            ],
+            "result": "R02"
+        },
+        {
+            "title": "Existing building",
             "steps": [
                 {
                     "question": "P01",
@@ -19,26 +45,239 @@
                     "type": "radio",
                     "answer": "true"
                 }
-            ]
+            ],
+            "result": "R03"
         },
         {
-            "id": 2,
-            "title": "Code does not apply",
+            "title": "Building has no occupancy",
             "steps": [
                 {
                     "question": "P01",
                     "type": "radio",
-                    "answer": "no"
+                    "answer": "yes"
+                },
+                {
+                    "question": "P04",
+                    "type": "radio",
+                    "answer": "false"
+                },
+                {
+                    "question": "P05",
+                    "type": "radio",
+                    "answer": "false"
+                },
+                {
+                    "question": "P06",
+                    "type": "checkbox",
+                    "answer": "none"
                 }
             ],
             "result": "R00"
+        },
+        {
+            "title": "Building includes Group D occupancy",
+            "steps": [
+                {
+                    "question": "P01",
+                    "type": "radio",
+                    "answer": "yes"
+                },
+                {
+                    "question": "P04",
+                    "type": "radio",
+                    "answer": "false"
+                },
+                {
+                    "question": "P05",
+                    "type": "radio",
+                    "answer": "false"
+                },
+                {
+                    "question": "P06",
+                    "type": "checkbox",
+                    "answer": "D"
+                }
+            ],
+            "result": "R04"
+        },
+        {
+            "title": "Building includes Group A1 occupancy",
+            "steps": [
+                {
+                    "question": "P01",
+                    "type": "radio",
+                    "answer": "yes"
+                },
+                {
+                    "question": "P04",
+                    "type": "radio",
+                    "answer": "false"
+                },
+                {
+                    "question": "P05",
+                    "type": "radio",
+                    "answer": "false"
+                },
+                {
+                    "question": "P06",
+                    "type": "checkbox",
+                    "answer": "A1"
+                }
+            ],
+            "result": "R05"
+        },
+        {
+            "title": "Building is larger than 600m^2",
+            "steps": [
+                {
+                    "question": "P01",
+                    "type": "radio",
+                    "answer": "yes"
+                },
+                {
+                    "question": "P04",
+                    "type": "radio",
+                    "answer": "false"
+                },
+                {
+                    "question": "P05",
+                    "type": "radio",
+                    "answer": "false"
+                },
+                {
+                    "question": "P06",
+                    "type": "checkbox",
+                    "answer": "C"
+                },
+                {
+                    "question": "P07",
+                    "type": "radio",
+                    "answer": "true"
+                }
+            ],
+            "result": "R05"
+        },
+        {
+            "title": "Building has 4+ storeys",
+            "steps": [
+                {
+                    "question": "P01",
+                    "type": "radio",
+                    "answer": "yes"
+                },
+                {
+                    "question": "P04",
+                    "type": "radio",
+                    "answer": "false"
+                },
+                {
+                    "question": "P05",
+                    "type": "radio",
+                    "answer": "false"
+                },
+                {
+                    "question": "P06",
+                    "type": "checkbox",
+                    "answer": "C"
+                },
+                {
+                    "question": "P07",
+                    "type": "radio",
+                    "answer": "false"
+                },
+                {
+                    "question": "P08",
+                    "type": "radio",
+                    "answer": "false"
+                }
+
+            ],
+            "result": "R05"
+        },
+        {
+            "title": "Building is not a dwelling unit",
+            "steps": [
+                {
+                    "question": "P01",
+                    "type": "radio",
+                    "answer": "yes"
+                },
+                {
+                    "question": "P04",
+                    "type": "radio",
+                    "answer": "false"
+                },
+                {
+                    "question": "P05",
+                    "type": "radio",
+                    "answer": "false"
+                },
+                {
+                    "question": "P06",
+                    "type": "checkbox",
+                    "answer": "C"
+                },
+                {
+                    "question": "P07",
+                    "type": "radio",
+                    "answer": "false"
+                },
+                {
+                    "question": "P08",
+                    "type": "radio",
+                    "answer": "true"
+                },
+                {
+                    "question": "P1",
+                    "type": "radio",
+                    "answer": "false"
+                }
+            ],
+            "result": "R30"
+        },
+        {
+            "title": "Not sure if code applies, ultimately does not",
+            "steps": [
+                {
+                    "question": "P01",
+                    "type": "radio",
+                    "answer": "notSure"
+                },
+                {
+                    "question": "P02",
+                    "type": "checkbox",
+                    "answer": "18"
+                }
+            ],
+            "result": "R00"
+        },
+        {
+            "title": "Existing building",
+            "steps": [
+                {
+                    "question": "P01",
+                    "type": "radio",
+                    "answer": "yes"
+                },
+                {
+                    "question": "P04",
+                    "type": "radio",
+                    "answer": "false"
+                },
+                {
+                    "question": "P05",
+                    "type": "radio",
+                    "answer": "true"
+                }
+            ],
+            "result": "R03"
         }
     ],
     "results": {
             "R00": "You have selected an answer that indicates that the BC Building Code 2024 does not apply to this structure. This tool is used to assist building code users in determining the applicable requirements for their building, as such all structures that are not governed by the BC Building Code 2024 are beyond the scope of this tool.",
             "R01": "You have selected {values from previous answer}. This indicates that some or all of this structure may not be governed by the BC Building Code 2024. This tool has been designed to assist BC Building Code 2024 users in determining the Building Code requirements for Part 9 buildings. Based on your selection, some or all of your project is beyond the scope of this tool at this time.",
-            "R02": "You have selected an option that indicates that this building is a heritage building. Heritage buildings have alternative measures for Building Code compliance. These alternative measures are beyond the scope of this tool at this time. Please see in Table 1.1.1.1.(5) of Division A - Section 1.1 ‘General’ for more information.",
-            "R03": "You have selected an option that indicates that this building is an alteration to an existing building. Alteration to existing buildings have alternative measures for Building Code compliance. These alternative measures are beyond the scope of this tool at this time. Please see Sentences 1.1.1.1(6) and 1.1.1.2.(1), and Table 1.1.1.1.(6) in Division A - Section 1.1 ‘General’ for more information.",
+            "R02": "You have selected an option that indicates that this building is a heritage building. Heritage buildings have alternative measures for Building Code compliance. These alternative measures are beyond the scope of this tool at this time.",
+            "R03": "You have selected an option that indicates that this building is an alteration to an existing building. Alteration to existing buildings have alternative measures for Building Code compliance. These alternative measures are beyond the scope of this tool at this time.",
             "R04": "Based on the options you have selected this project does not contain a Group C residential occupancy. This tool is design to assist BC Building Code 2024 users in evaluating the prescriptive requirements of the BC Building Code for Part 9 Group C residential occupancy buildings, therefore your project is beyond the scope of this tool at this time.",
             "R05": "Based on the options you have selected; this project is not a Part 9 building. This tool is design to assist BC Building Code 2024 users in evaluating the Acceptable Solutions in Division B of the BC Building Code for Part 9 buildings, therefore your project is beyond the scope of this tool at this time.",
             "R10": "Based on the building characteristics provided, this dwelling unit meets the provision of Subsection 9.9.9. ‘Egress from Dwelling Units’.",

--- a/apps/web/cypress/fixtures/test-data.json
+++ b/apps/web/cypress/fixtures/test-data.json
@@ -267,7 +267,7 @@
                 {
                     "question": "P03",
                     "type": "checkbox",
-                    "answer": "3"
+                    "answer": "3,6"
                 }
             ],
             "result": "R01"

--- a/apps/web/cypress/fixtures/test-data.json
+++ b/apps/web/cypress/fixtures/test-data.json
@@ -236,7 +236,7 @@
             "result": "R30"
         },
         {
-            "title": "Not sure if code applies, ultimately does not",
+            "title": "Not sure if code applies, after one question does not",
             "steps": [
                 {
                     "question": "P01",
@@ -250,6 +250,53 @@
                 }
             ],
             "result": "R00"
+        },
+        {
+            "title": "Not sure if code applies, but is outside scope of this tool",
+            "steps": [
+                {
+                    "question": "P01",
+                    "type": "radio",
+                    "answer": "notSure"
+                },
+                {
+                    "question": "P02",
+                    "type": "checkbox",
+                    "answer": "13"
+                },
+                {
+                    "question": "P03",
+                    "type": "checkbox",
+                    "answer": "3"
+                }
+            ],
+            "result": "R01"
+        },
+        {
+            "title": "Not sure if code applies, is heratage building",
+            "steps": [
+                {
+                    "question": "P01",
+                    "type": "radio",
+                    "answer": "notSure"
+                },
+                {
+                    "question": "P02",
+                    "type": "checkbox",
+                    "answer": "10"
+                },
+                {
+                    "question": "P03",
+                    "type": "checkbox",
+                    "answer": "9"
+                },
+                {
+                    "question": "P04",
+                    "type": "radio",
+                    "answer": "true"
+                }
+            ],
+            "result": "R02"
         },
         {
             "title": "Existing building",
@@ -275,7 +322,7 @@
     ],
     "results": {
             "R00": "You have selected an answer that indicates that the BC Building Code 2024 does not apply to this structure. This tool is used to assist building code users in determining the applicable requirements for their building, as such all structures that are not governed by the BC Building Code 2024 are beyond the scope of this tool.",
-            "R01": "You have selected {values from previous answer}. This indicates that some or all of this structure may not be governed by the BC Building Code 2024. This tool has been designed to assist BC Building Code 2024 users in determining the Building Code requirements for Part 9 buildings. Based on your selection, some or all of your project is beyond the scope of this tool at this time.",
+            "R01": "This indicates that some or all of this structure may not be governed by the BC Building Code 2024. This tool has been designed to assist BC Building Code 2024 users in determining the Building Code requirements for Part 9 buildings. Based on your selection, some or all of your project is beyond the scope of this tool at this time.",
             "R02": "You have selected an option that indicates that this building is a heritage building. Heritage buildings have alternative measures for Building Code compliance. These alternative measures are beyond the scope of this tool at this time.",
             "R03": "You have selected an option that indicates that this building is an alteration to an existing building. Alteration to existing buildings have alternative measures for Building Code compliance. These alternative measures are beyond the scope of this tool at this time.",
             "R04": "Based on the options you have selected this project does not contain a Group C residential occupancy. This tool is design to assist BC Building Code 2024 users in evaluating the prescriptive requirements of the BC Building Code for Part 9 Group C residential occupancy buildings, therefore your project is beyond the scope of this tool at this time.",

--- a/apps/web/cypress/fixtures/test-data.json
+++ b/apps/web/cypress/fixtures/test-data.json
@@ -1,7 +1,7 @@
 {
     "walkthroughs": [
         {
-            "title": "Code does not apply",
+            "title": "code does not apply",
             "steps": [
                 {
                     "question": "P01",
@@ -12,7 +12,7 @@
             "result": "R00"
         },
         {
-            "title": "Heritage building",
+            "title": "heritage building",
             "steps": [
                 {
                     "question": "P01",
@@ -28,7 +28,7 @@
             "result": "R02"
         },
         {
-            "title": "Existing building",
+            "title": "existing building",
             "steps": [
                 {
                     "question": "P01",
@@ -49,7 +49,7 @@
             "result": "R03"
         },
         {
-            "title": "Building has no occupancy",
+            "title": "building has no occupancy",
             "steps": [
                 {
                     "question": "P01",
@@ -75,7 +75,7 @@
             "result": "R00"
         },
         {
-            "title": "Building includes Group D occupancy",
+            "title": "building includes Group D occupancy",
             "steps": [
                 {
                     "question": "P01",
@@ -101,7 +101,7 @@
             "result": "R04"
         },
         {
-            "title": "Building includes Group A1 occupancy",
+            "title": "building includes Group A1 occupancy",
             "steps": [
                 {
                     "question": "P01",
@@ -127,7 +127,7 @@
             "result": "R05"
         },
         {
-            "title": "Building is larger than 600m^2",
+            "title": "building is larger than 600m^2",
             "steps": [
                 {
                     "question": "P01",
@@ -158,7 +158,7 @@
             "result": "R05"
         },
         {
-            "title": "Building has 4+ storeys",
+            "title": "building has 4+ storeys",
             "steps": [
                 {
                     "question": "P01",
@@ -195,7 +195,7 @@
             "result": "R05"
         },
         {
-            "title": "Building is not a dwelling unit",
+            "title": "building is not a dwelling unit",
             "steps": [
                 {
                     "question": "P01",
@@ -236,7 +236,7 @@
             "result": "R30"
         },
         {
-            "title": "Not sure if code applies, after one question does not",
+            "title": "not sure if code applies, after one question does not",
             "steps": [
                 {
                     "question": "P01",
@@ -252,7 +252,7 @@
             "result": "R00"
         },
         {
-            "title": "Not sure if code applies, but is outside scope of this tool",
+            "title": "not sure if code applies, but is outside scope of this tool",
             "steps": [
                 {
                     "question": "P01",
@@ -273,7 +273,7 @@
             "result": "R01"
         },
         {
-            "title": "Not sure if code applies, is heratage building",
+            "title": "not sure if code applies, is heratage building",
             "steps": [
                 {
                     "question": "P01",
@@ -299,7 +299,7 @@
             "result": "R02"
         },
         {
-            "title": "Existing building",
+            "title": "existing building",
             "steps": [
                 {
                     "question": "P01",

--- a/apps/web/cypress/fixtures/test-data.json
+++ b/apps/web/cypress/fixtures/test-data.json
@@ -31,7 +31,19 @@
                     "answer": "no"
                 }
             ],
-            "result": "You have selected an answer that indicates that the BC Building Code 2024 does not apply to this structure. This tool is used to assist building code users in determining the applicable requirements for their building, as such all structures that are not governed by the BC Building Code 2024 are beyond the scope of this tool."
+            "result": "R00"
         }
-    ]
+    ],
+    "results": {
+            "R00": "You have selected an answer that indicates that the BC Building Code 2024 does not apply to this structure. This tool is used to assist building code users in determining the applicable requirements for their building, as such all structures that are not governed by the BC Building Code 2024 are beyond the scope of this tool.",
+            "R01": "You have selected {values from previous answer}. This indicates that some or all of this structure may not be governed by the BC Building Code 2024. This tool has been designed to assist BC Building Code 2024 users in determining the Building Code requirements for Part 9 buildings. Based on your selection, some or all of your project is beyond the scope of this tool at this time.",
+            "R02": "You have selected an option that indicates that this building is a heritage building. Heritage buildings have alternative measures for Building Code compliance. These alternative measures are beyond the scope of this tool at this time. Please see in Table 1.1.1.1.(5) of Division A - Section 1.1 ‘General’ for more information.",
+            "R03": "You have selected an option that indicates that this building is an alteration to an existing building. Alteration to existing buildings have alternative measures for Building Code compliance. These alternative measures are beyond the scope of this tool at this time. Please see Sentences 1.1.1.1(6) and 1.1.1.2.(1), and Table 1.1.1.1.(6) in Division A - Section 1.1 ‘General’ for more information.",
+            "R04": "Based on the options you have selected this project does not contain a Group C residential occupancy. This tool is design to assist BC Building Code 2024 users in evaluating the prescriptive requirements of the BC Building Code for Part 9 Group C residential occupancy buildings, therefore your project is beyond the scope of this tool at this time.",
+            "R05": "Based on the options you have selected; this project is not a Part 9 building. This tool is design to assist BC Building Code 2024 users in evaluating the Acceptable Solutions in Division B of the BC Building Code for Part 9 buildings, therefore your project is beyond the scope of this tool at this time.",
+            "R10": "Based on the building characteristics provided, this dwelling unit meets the provision of Subsection 9.9.9. ‘Egress from Dwelling Units’.",
+            "R11": "Based on the provided building characteristics the dwelling unit must be provided with: ▪ an exterior passageway that has a floor assembly with a fire-resistance rating less than 45 min, and ▪ be served by a single exit stairway or ramp, and",
+            "R20": "The dwelling unit has not been provided with sufficient means of egress per the building characteristics provided and Subsection 9.9.9. ‘Egress from Dwelling Units’ of the BC Building Code 2024.",
+            "R30": "Based on the building characteristics provided this dwelling unit or building is not governed by Part 9 of the Building Code or is not a dwelling unit. This tool is only designed to address the egress from dwelling units of Part 9 buildings."
+        }
 }

--- a/apps/web/cypress/support/commands.ts
+++ b/apps/web/cypress/support/commands.ts
@@ -43,3 +43,7 @@ Cypress.Commands.add("getByTestID", (id, options) => {
 Cypress.Commands.add("getByGeneralTestID", (id, options) => {
   return cy.get(`[data-testid*=${id}]`, options);
 });
+
+Cypress.Commands.add("getInputByTestID", (id, options) => {
+  return cy.get(`input[data-testid=${id}]`, options);
+});

--- a/apps/web/cypress/support/index.ts
+++ b/apps/web/cypress/support/index.ts
@@ -23,6 +23,17 @@ declare global {
         id: string,
         options?: Partial<Loggable & Timeoutable & Withinable & Shadow>,
       ): Chainable<JQuery<HTMLElement>>;
+
+      /**
+       * Get an input element by the data-testid attribute.
+       * This is often used to find checkboxes as they have duplicate IDs for the label and input.
+       * @example cy.getInputByTestID('question-title')
+       */
+      getInputByTestID(id: string): Chainable<JQuery<HTMLElement>>;
+      getInputByTestID(
+        id: string,
+        options?: Partial<Loggable & Timeoutable & Withinable & Shadow>,
+      ): Chainable<JQuery<HTMLElement>>;
     }
   }
 }

--- a/packages/ui/src/checkbox-group/CheckboxGroup.tsx
+++ b/packages/ui/src/checkbox-group/CheckboxGroup.tsx
@@ -96,7 +96,6 @@ export default function CheckboxGroup({
           className={"ui-Checkbox"}
           key={`${option.value}`}
           value={`${option.value}`}
-          // TODO - apply different test id to the input and the label
           data-testid={GET_TESTID_CHECKBOX(testIdNamespace, option.value)}
         >
           {currentValue?.includes(option.value) && (

--- a/packages/ui/src/checkbox-group/CheckboxGroup.tsx
+++ b/packages/ui/src/checkbox-group/CheckboxGroup.tsx
@@ -96,6 +96,7 @@ export default function CheckboxGroup({
           className={"ui-Checkbox"}
           key={`${option.value}`}
           value={`${option.value}`}
+          // TODO - apply different test id to the input and the label
           data-testid={GET_TESTID_CHECKBOX(testIdNamespace, option.value)}
         >
           {currentValue?.includes(option.value) && (


### PR DESCRIPTION
<!-- You may remove any sections that are not applicable -->

[HOUSNAV-23](https://hous-bssb.atlassian.net/browse/HOUSNAV-23)

## Overview & Purpose
Add walkthrough tests for the intro UI.

## Summary of Changes

- Added walkthroughs for most cases in the intro UI that kick the user out to a a result.
- Update the UI tests to deal with checkboxes.
- Move the results data into its own object.
- Add custom command for grabbing inputs specifically.


## Notes & Resources
Defined terms are causing some problems for the UI tests. They are easy for cypress to accidentally click one of them instead of the actual button. When we run the tests focusing on the checkbox instead of the center of the buttons, it works.