### PR TITLE
HOUSNAV-19: Add aria-label on modal close button

### DIFF
--- a/packages/ui/src/modal-side/ModalSide.tsx
+++ b/packages/ui/src/modal-side/ModalSide.tsx
@@ -69,6 +69,7 @@ export default function ModalSide({
                     className="ui-ModalSide--CloseButton"
                     onPress={close}
                     data-testid={`${testid}-close-button`}
+                    aria-label="Close modal"
                   >
                     <Icon type="close" />
                   </Button>


### PR DESCRIPTION
<!-- You may remove any sections that are not applicable -->

[HOUSNAV-19](https://hous-bssb.atlassian.net/browse/HOUSNAV-19)

## Overview & Purpose
<!-- Please describe the purpose of your changes. Please also include relevant motivation and context. -->
Adds aria-label to close button for the modal so it's role is defined and read to meet accessibility requirements.


## Checklist
- [ ] I have written or updated vitests for this work
- [ ] I have reviewed the [accessibility guidelines](https://digital.gov.bc.ca/wcag/home/) relevant to this work
- [x] I have reviewed this work with at least one screen reader (when applicable)
    - reviewed with chrome accessibility tools that button does have the "close modal" label.
- [ ] I have added/updated any related documentation
