### PR TITLE
HOUSENAV-47: UI Tests for 9991 - Experimental

### DIFF
--- a/apps/web/cypress.config.ts
+++ b/apps/web/cypress.config.ts
@@ -3,5 +3,6 @@ import { defineConfig } from "cypress";
 export default defineConfig({
   e2e: {
     baseUrl: "http://localhost:3000",
+    excludeSpecPattern: "**/experimental.cy.ts",
   },
 });

--- a/apps/web/cypress/e2e/9.9.9.cy.ts
+++ b/apps/web/cypress/e2e/9.9.9.cy.ts
@@ -4,7 +4,8 @@ import {
   GET_TESTID_RADIO,
 } from "@repo/constants/src/testids";
 
-import { walkthroughs, results } from "../fixtures/test-data.json";
+import { walkthroughs } from "../fixtures/test-data.json";
+import { results } from "../fixtures/results-data.json";
 
 describe("walkthrough 1", () => {
   beforeEach(() => {

--- a/apps/web/cypress/e2e/9.9.9.cy.ts
+++ b/apps/web/cypress/e2e/9.9.9.cy.ts
@@ -12,19 +12,22 @@ describe("walkthrough 1", () => {
     cy.visit("/walkthrough/9.9.9");
   });
 
-  //Test all walkthroughs defined in test data
+  // Test all walkthroughs defined in test data
   walkthroughs.forEach((walkthrough) => {
     it(walkthrough.title, () => {
       walkthrough.steps.forEach((step) => {
-        // select and submit an answer for the given question
+        // Select and submit an answer for the given question
         if (step.type === "radio") {
           cy.getByTestID(GET_TESTID_RADIO(step.question, step.answer)).click();
         } else if (step.type === "checkbox") {
-          step.answer.split(",").forEach((answer) => {
-            cy.getInputByTestID(
-              GET_TESTID_CHECKBOX(step.question, answer),
-            ).click({ force: true });
-          });
+          // Skip tapping the checkbox if the answer is empty
+          if (step.answer != "") {
+            step.answer.split(",").forEach((answer) => {
+              cy.getInputByTestID(
+                GET_TESTID_CHECKBOX(step.question, answer),
+              ).click({ force: true });
+            });
+          }
         }
         cy.getByGeneralTestID(TESTID_WALKTHROUGH_FOOTER_NEXT).click();
       });

--- a/apps/web/cypress/e2e/experimental.cy.ts
+++ b/apps/web/cypress/e2e/experimental.cy.ts
@@ -1,13 +1,38 @@
 import { TESTID_WALKTHROUGH_FOOTER_NEXT } from "@repo/constants/src/testids";
 
+import { walkthroughs } from "../fixtures/extra-test-data.json";
+import { results } from "../fixtures/results-data.json";
+
 describe("Experimental tests", () => {
   beforeEach(() => {
     cy.visit("/walkthrough/9.9.9");
   });
 
+  // Test all walkthroughs defined in extra test data
+  // Does not worry if checkboxes or radio buttons are used
+  walkthroughs.forEach((walkthrough) => {
+    it("Add random name", () => {
+      walkthrough.steps.forEach((step) => {
+        // select and submit an answer for the given question
+        step.answer.split(",").forEach((answer) => {
+          cy.get(`[data-testid*='${step.question}-${answer}']`).last().click({
+            force: true,
+          });
+        });
+        cy.getByGeneralTestID(TESTID_WALKTHROUGH_FOOTER_NEXT).click();
+      });
+
+      if (walkthrough.result) {
+        // Cypress will throw an error if the result is undefined
+        const result = results[walkthrough.result as keyof typeof results];
+        cy.contains(result);
+      }
+    });
+  });
+
   // Randomly go through the walkthough until you find a result (try to confirm there are no dead ends)
   for (let i = 0; i < 200; i++) {
-    it.only(`Random walkthrough produces retult: run ${i}`, () => {
+    it(`Random walkthrough produces result: run ${i}`, () => {
       for (let i = 0; i < 25; i++) {
         cy.get("body").then(($body) => {
           if ($body.find('[data-testid*="checkbox-"]').length > 0) {

--- a/apps/web/cypress/e2e/experimental.cy.ts
+++ b/apps/web/cypress/e2e/experimental.cy.ts
@@ -59,13 +59,11 @@ describe("Experimental tests", () => {
 
             // Click next
             cy.getByGeneralTestID(TESTID_WALKTHROUGH_FOOTER_NEXT).click();
-          } else {
-            // If there are no questions, confirm we are on a result page
-            cy.getByTestID("result").should("exist");
-            return;
           }
         });
       }
+      // At the end, confirm we are on a result page
+      cy.getByTestID("result").should("exist");
     });
   }
 });

--- a/apps/web/cypress/e2e/experimental.cy.ts
+++ b/apps/web/cypress/e2e/experimental.cy.ts
@@ -8,10 +8,12 @@ describe("Experimental tests", () => {
     cy.visit("/walkthrough/9.9.9");
   });
 
+  let walkthroughNumber = 1;
+
   // Test all walkthroughs defined in extra test data
   // Does not worry if checkboxes or radio buttons are used
   walkthroughs.forEach((walkthrough) => {
-    it("Add random name", () => {
+    it(`Walkthrough #${walkthroughNumber}`, () => {
       walkthrough.steps.forEach((step) => {
         // Skip tapping the button if the answer is empty
         if (step.answer != "") {
@@ -31,6 +33,7 @@ describe("Experimental tests", () => {
         cy.contains(result);
       }
     });
+    walkthroughNumber++;
   });
 
   // Randomly go through the walkthough until you find a result (try to confirm there are no dead ends)

--- a/apps/web/cypress/e2e/experimental.cy.ts
+++ b/apps/web/cypress/e2e/experimental.cy.ts
@@ -1,0 +1,40 @@
+import { TESTID_WALKTHROUGH_FOOTER_NEXT } from "@repo/constants/src/testids";
+
+describe("Experimental tests", () => {
+  beforeEach(() => {
+    cy.visit("/walkthrough/9.9.9");
+  });
+
+  // Randomly go through the walkthough until you find a result (try to confirm there are no dead ends)
+  for (let i = 0; i < 200; i++) {
+    it.only(`Random walkthrough produces retult: run ${i}`, () => {
+      for (let i = 0; i < 25; i++) {
+        cy.get("body").then(($body) => {
+          if ($body.find('[data-testid*="checkbox-"]').length > 0) {
+            // Click a random checkbox if we are on a checkbox question
+            const checkboxes = $body.find('[data-testid*="checkbox-"]');
+            const randomIndex = Cypress._.random(1, checkboxes.length - 1);
+            cy.wrap(checkboxes[randomIndex]).click({
+              force: true,
+            });
+
+            // Click next
+            cy.getByGeneralTestID(TESTID_WALKTHROUGH_FOOTER_NEXT).click();
+          } else if ($body.find('[data-testid*="radio-"]').length > 0) {
+            // Click a random radio button if we are on a radio button question
+            const radios = $body.find('[data-testid*="radio-"]');
+            const randomIndex = Cypress._.random(0, radios.length - 1);
+            cy.wrap(radios[randomIndex]).click();
+
+            // Click next
+            cy.getByGeneralTestID(TESTID_WALKTHROUGH_FOOTER_NEXT).click();
+          } else {
+            // If there are no questions, confirm we are on a result page
+            cy.getByTestID("result").should("exist");
+            return;
+          }
+        });
+      }
+    });
+  }
+});

--- a/apps/web/cypress/e2e/experimental.cy.ts
+++ b/apps/web/cypress/e2e/experimental.cy.ts
@@ -13,12 +13,15 @@ describe("Experimental tests", () => {
   walkthroughs.forEach((walkthrough) => {
     it("Add random name", () => {
       walkthrough.steps.forEach((step) => {
-        // select and submit an answer for the given question
-        step.answer.split(",").forEach((answer) => {
-          cy.get(`[data-testid*='${step.question}-${answer}']`).last().click({
-            force: true,
+        // Skip tapping the button if the answer is empty
+        if (step.answer != "") {
+          // Select and submit an answer for the given question
+          step.answer.split(",").forEach((answer) => {
+            cy.get(`[data-testid*='${step.question}-${answer}']`).last().click({
+              force: true,
+            });
           });
-        });
+        }
         cy.getByGeneralTestID(TESTID_WALKTHROUGH_FOOTER_NEXT).click();
       });
 

--- a/apps/web/cypress/fixtures/extra-test-data.json
+++ b/apps/web/cypress/fixtures/extra-test-data.json
@@ -1,318 +1,257 @@
 {
   "walkthroughs": [
     {
-      "title": "code does not apply",
       "steps": [
         {
           "question": "P01",
-          "type": "radio",
           "answer": "no"
         }
       ],
       "result": "R00"
     },
     {
-      "title": "heritage building",
       "steps": [
         {
           "question": "P01",
-          "type": "radio",
           "answer": "yes"
         },
         {
           "question": "P04",
-          "type": "radio",
           "answer": "true"
         }
       ],
       "result": "R02"
     },
     {
-      "title": "existing building",
       "steps": [
         {
           "question": "P01",
-          "type": "radio",
           "answer": "yes"
         },
         {
           "question": "P04",
-          "type": "radio",
           "answer": "false"
         },
         {
           "question": "P05",
-          "type": "radio",
           "answer": "true"
         }
       ],
       "result": "R03"
     },
     {
-      "title": "building has no occupancy",
       "steps": [
         {
           "question": "P01",
-          "type": "radio",
           "answer": "yes"
         },
         {
           "question": "P04",
-          "type": "radio",
           "answer": "false"
         },
         {
           "question": "P05",
-          "type": "radio",
           "answer": "false"
         },
         {
           "question": "P06",
-          "type": "checkbox",
           "answer": "none"
         }
       ],
       "result": "R00"
     },
     {
-      "title": "building includes Group D occupancy",
       "steps": [
         {
           "question": "P01",
-          "type": "radio",
           "answer": "yes"
         },
         {
           "question": "P04",
-          "type": "radio",
           "answer": "false"
         },
         {
           "question": "P05",
-          "type": "radio",
           "answer": "false"
         },
         {
           "question": "P06",
-          "type": "checkbox",
           "answer": "D"
         }
       ],
       "result": "R04"
     },
     {
-      "title": "building includes Group A1 occupancy",
       "steps": [
         {
           "question": "P01",
-          "type": "radio",
           "answer": "yes"
         },
         {
           "question": "P04",
-          "type": "radio",
           "answer": "false"
         },
         {
           "question": "P05",
-          "type": "radio",
           "answer": "false"
         },
         {
           "question": "P06",
-          "type": "checkbox",
           "answer": "A1"
         }
       ],
       "result": "R05"
     },
     {
-      "title": "building is larger than 600m^2",
       "steps": [
         {
           "question": "P01",
-          "type": "radio",
           "answer": "yes"
         },
         {
           "question": "P04",
-          "type": "radio",
           "answer": "false"
         },
         {
           "question": "P05",
-          "type": "radio",
           "answer": "false"
         },
         {
           "question": "P06",
-          "type": "checkbox",
           "answer": "C"
         },
         {
           "question": "P07",
-          "type": "radio",
           "answer": "true"
         }
       ],
       "result": "R05"
     },
     {
-      "title": "building has 4+ storeys",
       "steps": [
         {
           "question": "P01",
-          "type": "radio",
           "answer": "yes"
         },
         {
           "question": "P04",
-          "type": "radio",
           "answer": "false"
         },
         {
           "question": "P05",
-          "type": "radio",
           "answer": "false"
         },
         {
           "question": "P06",
-          "type": "checkbox",
           "answer": "C"
         },
         {
           "question": "P07",
-          "type": "radio",
           "answer": "false"
         },
         {
           "question": "P08",
-          "type": "radio",
           "answer": "false"
         }
       ],
       "result": "R05"
     },
     {
-      "title": "building is not a dwelling unit",
       "steps": [
         {
           "question": "P01",
-          "type": "radio",
           "answer": "yes"
         },
         {
           "question": "P04",
-          "type": "radio",
           "answer": "false"
         },
         {
           "question": "P05",
-          "type": "radio",
           "answer": "false"
         },
         {
           "question": "P06",
-          "type": "checkbox",
           "answer": "C"
         },
         {
           "question": "P07",
-          "type": "radio",
           "answer": "false"
         },
         {
           "question": "P08",
-          "type": "radio",
           "answer": "true"
         },
         {
           "question": "P1",
-          "type": "radio",
           "answer": "false"
         }
       ],
       "result": "R30"
     },
     {
-      "title": "not sure if code applies, after one question does not",
       "steps": [
         {
           "question": "P01",
-          "type": "radio",
           "answer": "notSure"
         },
         {
           "question": "P02",
-          "type": "checkbox",
           "answer": "18"
         }
       ],
       "result": "R00"
     },
     {
-      "title": "not sure if code applies, but is outside scope of this tool",
       "steps": [
         {
           "question": "P01",
-          "type": "radio",
           "answer": "notSure"
         },
         {
           "question": "P02",
-          "type": "checkbox",
           "answer": "13"
         },
         {
           "question": "P03",
-          "type": "checkbox",
           "answer": "3,6"
         }
       ],
       "result": "R01"
     },
     {
-      "title": "not sure if code applies, is heratage building",
       "steps": [
         {
           "question": "P01",
-          "type": "radio",
           "answer": "notSure"
         },
         {
           "question": "P02",
-          "type": "checkbox",
           "answer": "10"
         },
         {
           "question": "P03",
-          "type": "checkbox",
           "answer": "9"
         },
         {
           "question": "P04",
-          "type": "radio",
           "answer": "true"
         }
       ],
       "result": "R02"
     },
     {
-      "title": "existing building",
       "steps": [
         {
           "question": "P01",
-          "type": "radio",
           "answer": "yes"
         },
         {
           "question": "P04",
-          "type": "radio",
           "answer": "false"
         },
         {
           "question": "P05",
-          "type": "radio",
           "answer": "true"
         }
       ],

--- a/apps/web/cypress/fixtures/results-data.json
+++ b/apps/web/cypress/fixtures/results-data.json
@@ -1,0 +1,14 @@
+{
+  "results": {
+    "R00": "You have selected an answer that indicates that the BC Building Code 2024 does not apply to this structure. This tool is used to assist building code users in determining the applicable requirements for their building, as such all structures that are not governed by the BC Building Code 2024 are beyond the scope of this tool.",
+    "R01": "This indicates that some or all of this structure may not be governed by the BC Building Code 2024. This tool has been designed to assist BC Building Code 2024 users in determining the Building Code requirements for Part 9 buildings. Based on your selection, some or all of your project is beyond the scope of this tool at this time.",
+    "R02": "You have selected an option that indicates that this building is a heritage building. Heritage buildings have alternative measures for Building Code compliance. These alternative measures are beyond the scope of this tool at this time.",
+    "R03": "You have selected an option that indicates that this building is an alteration to an existing building. Alteration to existing buildings have alternative measures for Building Code compliance. These alternative measures are beyond the scope of this tool at this time.",
+    "R04": "Based on the options you have selected this project does not contain a Group C residential occupancy. This tool is design to assist BC Building Code 2024 users in evaluating the prescriptive requirements of the BC Building Code for Part 9 Group C residential occupancy buildings, therefore your project is beyond the scope of this tool at this time.",
+    "R05": "Based on the options you have selected; this project is not a Part 9 building. This tool is design to assist BC Building Code 2024 users in evaluating the Acceptable Solutions in Division B of the BC Building Code for Part 9 buildings, therefore your project is beyond the scope of this tool at this time.",
+    "R10": "Based on the building characteristics provided, this dwelling unit meets the provision of Subsection 9.9.9. ‘Egress from Dwelling Units’.",
+    "R11": "Based on the provided building characteristics the dwelling unit must be provided with: ▪ an exterior passageway that has a floor assembly with a fire-resistance rating less than 45 min, and ▪ be served by a single exit stairway or ramp, and",
+    "R20": "The dwelling unit has not been provided with sufficient means of egress per the building characteristics provided and Subsection 9.9.9. ‘Egress from Dwelling Units’ of the BC Building Code 2024.",
+    "R30": "Based on the building characteristics provided this dwelling unit or building is not governed by Part 9 of the Building Code or is not a dwelling unit. This tool is only designed to address the egress from dwelling units of Part 9 buildings."
+  }
+}


### PR DESCRIPTION
<!-- You may remove any sections that are not applicable -->

[HOUSNAV-47](https://hous-bssb.atlassian.net/browse/HOUSNAV-47)

## Overview & Purpose
Add "experimental" tests to our automated testing suite.

## Summary of Changes
- Add a monkey test that can verify that random paths all have a "result" screen.
- Add a test that doesn't check if the screen is a radio button or checkbox before clicking it. This allows the test data to be smaller and quicker to write.
- Move results to their own data file.
- Exclude experimental tests from normal cypres e2e test runs.

## Side Effects
Results are now in their own data file so that they can easily be referenced from other data files.

Formatting changed for the test-data file.


## Notes & Resources
The code quality of the "experimental" tests are not as high as the other tests. These tests will always be run locally, not on CI. They are currently functioning in a way that is not quite congruent with the way cypress normally works.

Currently, the monkey tests are inefficient as they run an arbitrary number of times due to the way cypress handles task queuing.
