### PR TITLE
HOUSNAV-39: Glossary Terms DT + Modal refactor

### DIFF
--- a/apps/web/components/defined-term/DefinedTerm.tsx
+++ b/apps/web/components/defined-term/DefinedTerm.tsx
@@ -1,16 +1,22 @@
 // repo
 import Button, { ButtonProps } from "@repo/ui/button";
 import { TESTID_DEFINED_TERM } from "@repo/constants/src/testids";
-import { GLOSSARY_SECTIONS, GLOSSARY_TERMS } from "../../../web/tests/mockData";
 import Tooltip from "@repo/ui/tooltip";
 import ModalSide from "@repo/ui/modal-side";
+import {
+  ModalGlossaryData,
+  ModalSideDataEnum,
+  TooltipGlossaryData,
+} from "@repo/data/useGlossaryData";
 
 export interface DefinedTermProps extends Omit<ButtonProps, "variant"> {
   term: string;
+  overrideTerm?: string;
 }
 
 export default function DefinedTerm({
   term,
+  overrideTerm,
   children,
   "data-testid": testid = TESTID_DEFINED_TERM,
   ...props
@@ -30,18 +36,17 @@ export default function DefinedTerm({
 
   const tooltipButton = (
     <Tooltip
-      tooltipContent={GLOSSARY_TERMS.default.tooltipContent}
+      tooltipContent={TooltipGlossaryData.get(term.toLocaleLowerCase())}
       triggerContent={button}
     ></Tooltip>
   );
 
-  // TODO: Matt or Nicholas, add correct section for customHandler
-  const randomSection = Math.floor(Math.random() * 10) + 1;
   return (
     <ModalSide
+      type={ModalSideDataEnum.GLOSSARY}
       triggerContent={tooltipButton}
-      sections={GLOSSARY_SECTIONS}
-      scrollToSection={`9.9.9.${randomSection}`}
+      modalData={ModalGlossaryData}
+      scrollTo={overrideTerm}
     />
   );
 }

--- a/apps/web/components/defined-term/DefinedTerm.tsx
+++ b/apps/web/components/defined-term/DefinedTerm.tsx
@@ -11,18 +11,18 @@ import {
 
 export interface DefinedTermProps extends Omit<ButtonProps, "variant"> {
   term: string;
-  overrideTerm?: string;
+  overrideTooltip?: string;
 }
 
 export default function DefinedTerm({
   term,
-  overrideTerm,
+  overrideTooltip,
   children,
   "data-testid": testid = TESTID_DEFINED_TERM,
   ...props
 }: DefinedTermProps) {
   // TODO: Add glossary term functionality
-
+  const tooltipTerm = overrideTooltip ?? term;
   const button = (
     <Button
       variant="glossary"
@@ -36,7 +36,7 @@ export default function DefinedTerm({
 
   const tooltipButton = (
     <Tooltip
-      tooltipContent={TooltipGlossaryData.get(term.toLocaleLowerCase())}
+      tooltipContent={TooltipGlossaryData.get(tooltipTerm.toLocaleLowerCase())}
       triggerContent={button}
     ></Tooltip>
   );
@@ -46,7 +46,7 @@ export default function DefinedTerm({
       type={ModalSideDataEnum.GLOSSARY}
       triggerContent={tooltipButton}
       modalData={ModalGlossaryData}
-      scrollTo={overrideTerm}
+      scrollTo={term}
     />
   );
 }

--- a/apps/web/components/question/Question.tsx
+++ b/apps/web/components/question/Question.tsx
@@ -19,6 +19,11 @@ import QuestionMissing from "./question-types/QuestionMissing";
 import { useWalkthroughState } from "../../stores/WalkthroughRootStore";
 import { parseStringToComponents } from "../../utils/string";
 import "./Question.css";
+import ModalSide from "@repo/ui/modal-side";
+import {
+  ModalSideDataEnum,
+  BuildingCodeJSONData,
+} from "@repo/data/useGlossaryData";
 
 // helper function to get the correct question component
 const getQuestionComponent = (walkthroughItemType: string) => {
@@ -56,9 +61,16 @@ const Question = observer(() => {
           data-testid={TESTID_QUESTION_CODE_REFERENCE}
         >
           Reference:{" "}
-          <Button variant="code">
-            {currentQuestion.questionCodeReference.displayString}
-          </Button>
+          <ModalSide
+            type={ModalSideDataEnum.BUILDING_CODE}
+            triggerContent={
+              <Button variant="code">
+                {currentQuestion.questionCodeReference.displayString}
+              </Button>
+            }
+            modalData={BuildingCodeJSONData}
+            scrollTo={"9.9.9.1"}
+          />
         </p>
       )}
       <div className="web-Question--Content">{component}</div>

--- a/apps/web/utils/string.test.tsx
+++ b/apps/web/utils/string.test.tsx
@@ -2,7 +2,7 @@
 import { describe, it, expect } from "vitest";
 import { JSX } from "react";
 // repo
-import { getMultiChoiceQuestion } from "@repo/data/useWalkthroughTestData";
+import { getQuestion } from "@repo/data/useWalkthroughTestData";
 // local
 import { getStringFromComponents, parseStringToComponents } from "./string";
 import { isArray } from "./typeChecking";
@@ -13,7 +13,7 @@ describe("string", () => {
    */
   it("parseStringToComponents: defined-term", () => {
     // get test data
-    const questionData = getMultiChoiceQuestion();
+    const questionData = getQuestion("P04");
 
     // check if we have questionText and throw error if we don't
     if (!questionData?.questionData.questionText) {

--- a/apps/web/utils/string.tsx
+++ b/apps/web/utils/string.tsx
@@ -13,11 +13,14 @@ import Tooltip from "@repo/ui/tooltip";
 import DefinedTerm, {
   DefinedTermProps,
 } from "../components/defined-term/DefinedTerm";
-import PDFDownloadLink, {
-  PDFDownloadLinkProps,
-} from "../components/pdf-download-link/PDFDownloadLink";
-import { GLOSSARY_TERMS } from "../tests/mockData";
-import { TooltipGlossaryData } from "@repo/data/useGlossaryData";
+import Button from "@repo/ui/button";
+import Tooltip from "@repo/ui/tooltip";
+import {
+  BuildingCodeJSONData,
+  ModalSideDataEnum,
+  TooltipGlossaryData,
+} from "@repo/data/useGlossaryData";
+import ModalSide from "@repo/ui/modal-side";
 
 // Define custom components for html-react-parser
 const definedTermName = "defined-term";
@@ -57,10 +60,13 @@ export const parseStringToComponents = (
   const options = {
     replace: (domNode: DOMNode) => {
       if (domNode instanceof Element && domNode.attribs) {
-        const overrideTerm = domNode.attribs["override-term"];
-        const term =
+        const term = (
           domNode.attribs["override-term"] ??
-          (domToReact(domNode.children as DOMNode[]) as string);
+          (domToReact(domNode.children as DOMNode[]) as string)
+        ).toLocaleLowerCase();
+        const tooltipTerm = (
+          domNode.attribs["override-tooltip"] ?? term
+        ).toLocaleLowerCase();
         switch (domNode.name) {
           case definedTermName: {
             const DefinedTermComponent = customComponents[definedTermName];
@@ -70,8 +76,8 @@ export const parseStringToComponents = (
                   <DefinedTermComponent
                     {...(props as unknown as DefinedTermProps)}
                     key={domNode.attribs.key}
-                    overrideTerm={overrideTerm}
-                    term={domToReact(domNode.children as DOMNode[]) as string}
+                    term={term}
+                    overrideTooltip={tooltipTerm}
                   >
                     {domToReact(domNode.children as DOMNode[], options)}
                   </DefinedTermComponent>
@@ -94,7 +100,7 @@ export const parseStringToComponents = (
           case definedTermModal: {
             return (
               <Tooltip
-                tooltipContent={TooltipGlossaryData.get(term)}
+                tooltipContent={TooltipGlossaryData.get(tooltipTerm)}
                 triggerContent={
                   <Button
                     variant="glossary"
@@ -107,21 +113,23 @@ export const parseStringToComponents = (
                 }
               ></Tooltip>
             );
-          }
-          case glossaryTerm: {
-            return <span className="ui-ModalSide-Term">{term}</span>;
-          }
 
-          case buildingCode: {
+          case glossaryTerm:
             return (
-              <Button
-                variant="code"
-                onPress={customHandler ? () => customHandler(term) : () => {}}
-              >
-                {domToReact(domNode.children as DOMNode[])}
-              </Button>
+              <span className="ui-ModalSide-Term">
+                {domToReact(domNode.children as DOMNode[]) as string}
+              </span>
             );
-          }
+
+          case buildingCode:
+            return (
+              <ModalSide
+                type={ModalSideDataEnum.BUILDING_CODE}
+                triggerContent={<Button variant="code">{term}</Button>}
+                modalData={BuildingCodeJSONData}
+                scrollTo={"9.9.9.1"}
+              />
+            );
         }
       }
     },

--- a/apps/web/utils/string.tsx
+++ b/apps/web/utils/string.tsx
@@ -13,14 +13,15 @@ import Tooltip from "@repo/ui/tooltip";
 import DefinedTerm, {
   DefinedTermProps,
 } from "../components/defined-term/DefinedTerm";
-import Button from "@repo/ui/button";
-import Tooltip from "@repo/ui/tooltip";
 import {
   BuildingCodeJSONData,
   ModalSideDataEnum,
   TooltipGlossaryData,
 } from "@repo/data/useGlossaryData";
 import ModalSide from "@repo/ui/modal-side";
+import PDFDownloadLink, {
+  PDFDownloadLinkProps,
+} from "../components/pdf-download-link/PDFDownloadLink";
 
 // Define custom components for html-react-parser
 const definedTermName = "defined-term";
@@ -60,6 +61,8 @@ export const parseStringToComponents = (
   const options = {
     replace: (domNode: DOMNode) => {
       if (domNode instanceof Element && domNode.attribs) {
+        const props = attributesToProps(domNode.attribs);
+
         const term = (
           domNode.attribs["override-term"] ??
           (domToReact(domNode.children as DOMNode[]) as string)
@@ -70,23 +73,21 @@ export const parseStringToComponents = (
         switch (domNode.name) {
           case definedTermName: {
             const DefinedTermComponent = customComponents[definedTermName];
-            const props = attributesToProps(domNode.attribs);
 
-                return (
-                  <DefinedTermComponent
-                    {...(props as unknown as DefinedTermProps)}
-                    key={domNode.attribs.key}
-                    term={term}
-                    overrideTooltip={tooltipTerm}
-                  >
-                    {domToReact(domNode.children as DOMNode[], options)}
-                  </DefinedTermComponent>
-                );
-              }
+            return (
+              <DefinedTermComponent
+                {...(props as unknown as DefinedTermProps)}
+                key={domNode.attribs.key}
+                term={term}
+                overrideTooltip={tooltipTerm}
+              >
+                {domToReact(domNode.children as DOMNode[], options)}
+              </DefinedTermComponent>
+            );
+          }
           case pdfDownloadLinkName: {
             const PDFDownloadLinkComponent =
               customComponents[pdfDownloadLinkName];
-            const props = attributesToProps(domNode.attribs);
 
             return (
               <PDFDownloadLinkComponent
@@ -97,7 +98,8 @@ export const parseStringToComponents = (
               </PDFDownloadLinkComponent>
             );
           }
-          case definedTermModal: {
+
+          case definedTermModal:
             return (
               <Tooltip
                 tooltipContent={TooltipGlossaryData.get(tooltipTerm)}

--- a/apps/web/utils/string.tsx
+++ b/apps/web/utils/string.tsx
@@ -17,10 +17,13 @@ import PDFDownloadLink, {
   PDFDownloadLinkProps,
 } from "../components/pdf-download-link/PDFDownloadLink";
 import { GLOSSARY_TERMS } from "../tests/mockData";
+import { TooltipGlossaryData } from "@repo/data/useGlossaryData";
 
 // Define custom components for html-react-parser
 const definedTermName = "defined-term";
-const definedTermModal = "defined-term-modal";
+const definedTermModal = "defined-term-glossary";
+const glossaryTerm = "glossary-term";
+const buildingCode = "building-code";
 const pdfDownloadLinkName = "pdf-download-link";
 type CustomComponentTypes =
   | typeof definedTermName
@@ -54,20 +57,26 @@ export const parseStringToComponents = (
   const options = {
     replace: (domNode: DOMNode) => {
       if (domNode instanceof Element && domNode.attribs) {
+        const overrideTerm = domNode.attribs["override-term"];
+        const term =
+          domNode.attribs["override-term"] ??
+          (domToReact(domNode.children as DOMNode[]) as string);
         switch (domNode.name) {
           case definedTermName: {
             const DefinedTermComponent = customComponents[definedTermName];
             const props = attributesToProps(domNode.attribs);
 
-            return (
-              <DefinedTermComponent
-                {...(props as unknown as DefinedTermProps)}
-                key={domNode.attribs.key}
-              >
-                {domToReact(domNode.children as DOMNode[], options)}
-              </DefinedTermComponent>
-            );
-          }
+                return (
+                  <DefinedTermComponent
+                    {...(props as unknown as DefinedTermProps)}
+                    key={domNode.attribs.key}
+                    overrideTerm={overrideTerm}
+                    term={domToReact(domNode.children as DOMNode[]) as string}
+                  >
+                    {domToReact(domNode.children as DOMNode[], options)}
+                  </DefinedTermComponent>
+                );
+              }
           case pdfDownloadLinkName: {
             const PDFDownloadLinkComponent =
               customComponents[pdfDownloadLinkName];
@@ -83,24 +92,34 @@ export const parseStringToComponents = (
             );
           }
           case definedTermModal: {
-            // TODO: Matt or Nicholas, add correct section for customHandler
-            const randomSection = Math.floor(Math.random() * 10) + 1;
             return (
               <Tooltip
-                tooltipContent={GLOSSARY_TERMS.default.tooltipContent}
+                tooltipContent={TooltipGlossaryData.get(term)}
                 triggerContent={
                   <Button
                     variant="glossary"
                     onPress={
-                      customHandler
-                        ? () => customHandler(`9.9.9.${randomSection}`)
-                        : () => {}
+                      customHandler ? () => customHandler(term) : () => {}
                     }
                   >
                     {domToReact(domNode.children as DOMNode[])}
                   </Button>
                 }
               ></Tooltip>
+            );
+          }
+          case glossaryTerm: {
+            return <span className="ui-ModalSide-Term">{term}</span>;
+          }
+
+          case buildingCode: {
+            return (
+              <Button
+                variant="code"
+                onPress={customHandler ? () => customHandler(term) : () => {}}
+              >
+                {domToReact(domNode.children as DOMNode[])}
+              </Button>
             );
           }
         }

--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -1,3 +1,5 @@
 export const IMAGES_BASE_PATH = "/assets/images";
 // empty string is the default value for nextNavigationId and will show the question error screen
 export const NEXT_NAVIGATION_ID_ERROR = "";
+
+export const DEFINED_TERMS_SECTION_NUMBER = "1.4.1.2";

--- a/packages/data/json/9.9.9.json
+++ b/packages/data/json/9.9.9.json
@@ -45,7 +45,7 @@
   "questions": {
     "P01": {
       "walkthroughItemType": "multiChoice",
-      "questionText": "Does the Building Code apply to this <defined-term term='structure'>structure</defined-term>?",
+      "questionText": "Does the Building Code apply to this structure?",
       "possibleAnswers": [
         {
           "answerDisplayText": "Yes",
@@ -81,7 +81,7 @@
     },
     "P02": {
       "walkthroughItemType": "multiChoiceMultiple",
-      "questionText": "Check all that apply to the following <defined-term>structure</defined-term> in this project?",
+      "questionText": "Check all that apply to the following structure in this project?",
       "possibleAnswers": [
         {
           "answerDisplayText": "This project will involve the construction or design of a new <defined-term>building</defined-term>.",
@@ -207,7 +207,7 @@
           "answerValue": "5"
         },
         {
-          "answerDisplayText": "This project has permission of the <defined-term>authorities having jurisdiction</defined-term> to provide construction site offices, seasonal storage buildings, special events facilities, emergency facilities, and/or similar <defined-term>structures</defined-term>.",
+          "answerDisplayText": "This project has permission of the <defined-term>authorities having jurisdiction</defined-term> to provide construction site offices, seasonal storage buildings, special events facilities, emergency facilities, and/or similar structure.",
           "answerValue": "6"
         },
         {
@@ -251,7 +251,7 @@
     },
     "P04": {
       "walkthroughItemType": "multiChoice",
-      "questionText": "Is this <defined-term>structure</defined-term> a <defined-term>heritage building</defined-term>?",
+      "questionText": "Is this structure a <defined-term>heritage building</defined-term>?",
       "possibleAnswers": [
         {
           "answerDisplayText": "Yes",
@@ -303,7 +303,7 @@
     },
     "P06": {
       "walkthroughItemType": "multiChoiceMultiple",
-      "questionText": "Which <defined-term>major occupancies</defined-term> will be included in this <defined-term>building</defined-term>?",
+      "questionText": "Which <defined-term override-term='major occupancy'>major occupancies</defined-term> will be included in this <defined-term>building</defined-term>?",
       "possibleAnswers": [
         {
           "answerDisplayText": "<defined-term>Group A Division 1.</defined-term>",
@@ -338,7 +338,7 @@
           "answerValue": "C"
         },
         {
-          "answerDisplayText": "<defined-term>Group D.</defined-term>",
+          "answerDisplayText": "<defined-term override-term='major occupancy'>Group D.</defined-term>",
           "answerValue": "D"
         },
         {
@@ -428,14 +428,14 @@
     },
     "P08": {
       "walkthroughItemType": "multiChoice",
-      "questionText": "How many <defined-term>storeys</defined-term> in <defined-term>building height</defined-term> will this building be?",
+      "questionText": "How many <defined-term override-term='storey'>storeys</defined-term> in <defined-term>building</defined-term> height will this building be?",
       "possibleAnswers": [
         {
-          "answerDisplayText": "1-3 <defined-term>storeys</defined-term>",
+          "answerDisplayText": "1-3 <defined-term override-term='storey'>storeys</defined-term>",
           "answerValue": "true"
         },
         {
-          "answerDisplayText": "Greater than 3 <defined-term>storeys</defined-term>",
+          "answerDisplayText": "Greater than 3 <defined-term override-term='storey'>storeys</defined-term>",
           "answerValue": "false"
         }
       ],
@@ -484,7 +484,7 @@
     },
     "P2": {
       "walkthroughItemType": "multiChoice",
-      "questionText": "How many <defined-term>storeys</defined-term> does this <defined-term>dwelling unit</defined-term> have?",
+      "questionText": "How many <defined-term override-term='storey'>storeys</defined-term> does this <defined-term>dwelling unit</defined-term> have?",
       "questionCodeReference": {
         "displayString": "Vol 2, Section 9.9.9.1",
         "codeNumber": "V2-9.9.9.1"
@@ -542,7 +542,7 @@
       "walkthroughItemType": "multiChoiceMultiple",
       "answersAreDynamic": true,
       "storeAnswerAsObject": true,
-      "questionText": "Which <defined-term>storeys</defined-term> within the <defined-term>dwelling unit</defined-term> are provided with an egress or <defined-term>exit</defined-term> doors?",
+      "questionText": "Which <defined-term override-term='storey'>storeys</defined-term> within the <defined-term>dwelling unit</defined-term> are provided with an egress or <defined-term>exit</defined-term> doors?",
       "questionCodeReference": {
         "displayString": "Vol 2, Section 9.9.9.1",
         "codeNumber": "V2-9.9.9.1"
@@ -1807,7 +1807,7 @@
     },
     "P11": {
       "walkthroughItemType": "multiChoice",
-      "questionText": "How many <defined-term>dwelling units</defined-term> are in this <defined-term>building</defined-term>?",
+      "questionText": "How many <defined-term override-term='dwelling unit'>dwelling units</defined-term> are in this <defined-term>building</defined-term>?",
       "questionCodeReference": {
         "displayString": "Vol 2, Section 9.9.9.2",
         "codeNumber": "V2-9.9.9.2"
@@ -1891,7 +1891,7 @@
     },
     "P14": {
       "walkthroughItemType": "multiChoice",
-      "questionText": "Where the egress door opens onto the corridor or exterior passageway, is it possible to go in opposite directions to 2 separate <defined-term>exits</defined-term>?",
+      "questionText": "Where the egress door opens onto the corridor or exterior passageway, is it possible to go in opposite directions to 2 separate <defined-term override-term='exit'>exits</defined-term>?",
       "questionCodeReference": {
         "displayString": "Vol 2, Section 9.9.9.2",
         "codeNumber": "V2-9.9.9.2"

--- a/packages/data/json/9.9.9.json
+++ b/packages/data/json/9.9.9.json
@@ -306,55 +306,55 @@
       "questionText": "Which <defined-term override-term='major occupancy'>major occupancies</defined-term> will be included in this <defined-term>building</defined-term>?",
       "possibleAnswers": [
         {
-          "answerDisplayText": "<defined-term>Group A Division 1.</defined-term>",
+          "answerDisplayText": "<defined-term override-term='major occupancy' override-tooltip='group a division 1'>Group A Division 1.</defined-term>",
           "answerValue": "A1"
         },
         {
-          "answerDisplayText": "<defined-term>Group A Division 2.</defined-term>",
+          "answerDisplayText": "<defined-term override-term='major occupancy'override-tooltip='group a division 2'>Group A Division 2.</defined-term>",
           "answerValue": "A2"
         },
         {
-          "answerDisplayText": "<defined-term>Group A Division 3.</defined-term>",
+          "answerDisplayText": "<defined-term override-term='major occupancy' override-tooltip='group a division 3'>Group A Division 3.</defined-term>",
           "answerValue": "A3"
         },
         {
-          "answerDisplayText": "<defined-term>Group A Division 4.</defined-term>",
+          "answerDisplayText": "<defined-term override-term='major occupancy' override-tooltip='group a division 4'>Group A Division 4.</defined-term>",
           "answerValue": "A4"
         },
         {
-          "answerDisplayText": "<defined-term>Group B Division 1.</defined-term>",
+          "answerDisplayText": "<defined-term override-term='major occupancy' override-tooltip='group b division 1'>Group B Division 1.</defined-term>",
           "answerValue": "B1"
         },
         {
-          "answerDisplayText": "<defined-term>Group B Division 2.</defined-term>",
+          "answerDisplayText": "<defined-term override-term='major occupancy' override-tooltip='group b division 2'>Group B Division 2.</defined-term>",
           "answerValue": "B2"
         },
         {
-          "answerDisplayText": "<defined-term>Group B Division 3.</defined-term>",
+          "answerDisplayText": "<defined-term override-term='major occupancy' override-tooltip='group b division 3'>Group B Division 3.</defined-term>",
           "answerValue": "B3"
         },
         {
-          "answerDisplayText": "<defined-term>Group C.</defined-term>",
+          "answerDisplayText": "<defined-term override-term='major occupancy' override-tooltip='group c'>Group C.</defined-term>",
           "answerValue": "C"
         },
         {
-          "answerDisplayText": "<defined-term override-term='major occupancy'>Group D.</defined-term>",
+          "answerDisplayText": "<defined-term override-term='major occupancy' override-tooltip='group d'>Group D.</defined-term>",
           "answerValue": "D"
         },
         {
-          "answerDisplayText": "<defined-term>Group E.</defined-term>",
+          "answerDisplayText": "<defined-term override-term='major occupancy' override-tooltip='group e'>Group E.</defined-term>",
           "answerValue": "E"
         },
         {
-          "answerDisplayText": "<defined-term>Group F Division 1.</defined-term>",
+          "answerDisplayText": "<defined-term override-term='major occupancy' override-tooltip='group f division 1'>Group F Division 1.</defined-term>",
           "answerValue": "F1"
         },
         {
-          "answerDisplayText": "<defined-term>Group F Division 2.</defined-term>",
+          "answerDisplayText": "<defined-term override-term='major occupancy' override-tooltip='group f division 2'>Group F Division 2.</defined-term>",
           "answerValue": "F2"
         },
         {
-          "answerDisplayText": "<defined-term>Group F Division 3.</defined-term>",
+          "answerDisplayText": "<defined-term override-term='major occupancy' override-tooltip='group f division 3'>Group F Division 3.</defined-term>",
           "answerValue": "F3"
         },
         {

--- a/packages/data/json/9.9.9.test.ts
+++ b/packages/data/json/9.9.9.test.ts
@@ -14,9 +14,9 @@ describe("Data - 9.9.9", () => {
         }
 
         return !Object.values(data.sections).some((section) =>
-          section.sectionQuestions.includes(questionId)
+          section.sectionQuestions.includes(questionId),
         );
-      }
+      },
     );
     if (possibleUnusedQuestion)
       console.log("Possible unused question ID:", possibleUnusedQuestion[0]);
@@ -29,7 +29,7 @@ describe("Data - 9.9.9", () => {
     const sectionWithUnknownQuestion = Object.values(data.sections).find(
       (section) => {
         const unknownQuestion = section.sectionQuestions.find(
-          (questionId) => !Object.keys(data.questions).includes(questionId)
+          (questionId) => !Object.keys(data.questions).includes(questionId),
         );
         if (unknownQuestion) {
           console.log("Section:", section.sectionTitle);
@@ -37,7 +37,7 @@ describe("Data - 9.9.9", () => {
         }
 
         return !!unknownQuestion;
-      }
+      },
     );
 
     // expect sectionWithUnknownQuestion to be undefined

--- a/packages/data/json/9.9.9.test.ts
+++ b/packages/data/json/9.9.9.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect } from "vitest";
 // local
 import { isWalkthroughItemTypeVariable } from "../src/useWalkthroughData";
-import data from "../walkthroughs/9.9.9.json";
+import data from "./9.9.9.json";
 
 describe("Data - 9.9.9", () => {
   it("verify all questions either appear in a section or are of variable type", () => {
@@ -14,9 +14,9 @@ describe("Data - 9.9.9", () => {
         }
 
         return !Object.values(data.sections).some((section) =>
-          section.sectionQuestions.includes(questionId),
+          section.sectionQuestions.includes(questionId)
         );
-      },
+      }
     );
     if (possibleUnusedQuestion)
       console.log("Possible unused question ID:", possibleUnusedQuestion[0]);
@@ -29,7 +29,7 @@ describe("Data - 9.9.9", () => {
     const sectionWithUnknownQuestion = Object.values(data.sections).find(
       (section) => {
         const unknownQuestion = section.sectionQuestions.find(
-          (questionId) => !Object.keys(data.questions).includes(questionId),
+          (questionId) => !Object.keys(data.questions).includes(questionId)
         );
         if (unknownQuestion) {
           console.log("Section:", section.sectionTitle);
@@ -37,7 +37,7 @@ describe("Data - 9.9.9", () => {
         }
 
         return !!unknownQuestion;
-      },
+      }
     );
 
     // expect sectionWithUnknownQuestion to be undefined

--- a/packages/data/json/buildingCode.json
+++ b/packages/data/json/buildingCode.json
@@ -1,0 +1,150 @@
+[
+  {
+    "section": "9.9.9.1",
+    "header": "Egress from Dwelling Units",
+    "content": {
+      "clauses": [
+        {
+          "description": "Except as provided in <tag>Sentences (2) and (3), every dwelling unit containing more than 1 storey shall have exits or egress doors located so that it shall not be necessary to travel up or down more than 1 storey to reach a level served by...",
+          "subsections": [
+            {
+              "description": "an egress door to a public corridor, enclosed exit stair or exterior passageway, or"
+            },
+            {
+              "description": "an exit doorway not more than 1.5 m above adjacent ground level. "
+            }
+          ]
+        },
+        {
+          "description": "Where a dwelling unit is not located above or below another suite, the travel limit from a floor level in the dwelling unit to an exit or egress door may exceed 1 storey where that floor level is served by an openable window ",
+          "subsections": [
+            {
+              "description": "providing an unobstructed opening of not less than 1 m in height and 0.55 m in width, and ",
+              "subSectionFields": []
+            },
+            {
+              "description": "located so that the sill is not more than ",
+              "subClauses": [
+                "1 m above the floor, and ",
+                "7 m above adjacent ground level."
+              ],
+              "imagePath": "",
+              "imageDescription": ""
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "section": "9.9.9.2",
+    "header": "Egress from Dwelling Units",
+    "content": {
+      "clauses": [
+        {
+          "description": "Except as provided in <tag>Sentences (2) and (3), every dwelling unit containing more than 1 storey shall have exits or egress doors located so that it shall not be necessary to travel up or down more than 1 storey to reach a level served by...",
+          "subsections": [
+            {
+              "description": "an egress door to a public corridor, enclosed exit stair or exterior passageway, or"
+            },
+            {
+              "description": "an exit doorway not more than 1.5 m above adjacent ground level. "
+            }
+          ]
+        },
+        {
+          "description": "Where a dwelling unit is not located above or below another suite, the travel limit from a floor level in the dwelling unit to an exit or egress door may exceed 1 storey where that floor level is served by an openable window ",
+          "subsections": [
+            {
+              "description": "providing an unobstructed opening of not less than 1 m in height and 0.55 m in width, and ",
+              "subSectionFields": []
+            },
+            {
+              "description": "located so that the sill is not more than ",
+              "subClauses": [
+                "1 m above the floor, and ",
+                "7 m above adjacent ground level."
+              ],
+              "imagePath": "",
+              "imageDescription": ""
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "section": "9.9.9.3",
+    "header": "Egress from Dwelling Units",
+    "content": {
+      "clauses": [
+        {
+          "description": "Except as provided in <tag>Sentences (2) and (3), every dwelling unit containing more than 1 storey shall have exits or egress doors located so that it shall not be necessary to travel up or down more than 1 storey to reach a level served by...",
+          "subsections": [
+            {
+              "description": "an egress door to a public corridor, enclosed exit stair or exterior passageway, or"
+            },
+            {
+              "description": "an exit doorway not more than 1.5 m above adjacent ground level. "
+            }
+          ]
+        },
+        {
+          "description": "Where a dwelling unit is not located above or below another suite, the travel limit from a floor level in the dwelling unit to an exit or egress door may exceed 1 storey where that floor level is served by an openable window ",
+          "subsections": [
+            {
+              "description": "providing an unobstructed opening of not less than 1 m in height and 0.55 m in width, and ",
+              "subSectionFields": []
+            },
+            {
+              "description": "located so that the sill is not more than ",
+              "subClauses": [
+                "1 m above the floor, and ",
+                "7 m above adjacent ground level."
+              ],
+              "imagePath": "",
+              "imageDescription": ""
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "section": "9.9.9.4",
+    "header": "Egress from Dwelling Units",
+    "content": {
+      "clauses": [
+        {
+          "description": "Except as provided in <tag>Sentences (2) and (3), every dwelling unit containing more than 1 storey shall have exits or egress doors located so that it shall not be necessary to travel up or down more than 1 storey to reach a level served by...",
+          "subsections": [
+            {
+              "description": "an egress door to a public corridor, enclosed exit stair or exterior passageway, or"
+            },
+            {
+              "description": "an exit doorway not more than 1.5 m above adjacent ground level. "
+            }
+          ]
+        },
+        {
+          "description": "Where a dwelling unit is not located above or below another suite, the travel limit from a floor level in the dwelling unit to an exit or egress door may exceed 1 storey where that floor level is served by an openable window ",
+          "subsections": [
+            {
+              "description": "providing an unobstructed opening of not less than 1 m in height and 0.55 m in width, and ",
+              "subSectionFields": []
+            },
+            {
+              "description": "located so that the sill is not more than ",
+              "subClauses": [
+                "1 m above the floor, and ",
+                "7 m above adjacent ground level."
+              ],
+              "imagePath": "",
+              "imageDescription": ""
+            }
+          ]
+        }
+      ]
+    }
+  }
+]

--- a/packages/data/json/terms.json
+++ b/packages/data/json/terms.json
@@ -8,7 +8,7 @@
     "cleanDefinition": "Appliances means a device to convert fuel into energy and includes all components, controls, wiring and piping required to be part of the device by the applicable standard referred to in this Code."
   },
   "assembly occupancies": {
-    "definition": "<glossary-term>Assembly Occupancies</glossary-term> <building-code>(Group A)</building-code> means the <defined-term-glossary>occupancy</defined-term-glossary> or the use of a <defined-term-glossary>building</defined-term-glossary> or part thereof by a gathering of persons for civic, political, travel, religious, social, educational, recreational or like purposes, or for the consumption of food or drink.",
+    "definition": "<glossary-term>Assembly Occupancies</glossary-term> means the <defined-term-glossary>occupancy</defined-term-glossary> or the use of a <defined-term-glossary>building</defined-term-glossary> or part thereof by a gathering of persons for civic, political, travel, religious, social, educational, recreational or like purposes, or for the consumption of food or drink.",
     "cleanDefinition": "Assembly Occupancies means the occupancy or the use of a building or part thereof by a gathering of persons for civic, political, travel, religious, social, educational, recreational or like purposes, or for the consumption of food or drink."
   },
   "authority having jurisdiction": {
@@ -28,7 +28,7 @@
     "cleanDefinition": "Building Area means the greatest horizontal area of a building above grade within the outside surface of exterior walls or within the outside surface of exterior walls and the centre line of firewalls."
   },
   "business and personal services occupancy": {
-    "definition": "<glossary-term>Business and personal services occupancy</glossary-term> <building-code>(Group D)</building-code> means the <defined-term-glossary>occupancy</defined-term-glossary> or use of a <defined-term-glossary>building</defined-term-glossary> or part thereof for the transaction of business or the rendering or receiving of professional or personal services.",
+    "definition": "<glossary-term>Business and personal services occupancy</glossary-term> <defined-term-glossary override-term='major occupancy' override-tooltip='group d'>(Group D)</defined-term-glossary> means the <defined-term-glossary>occupancy</defined-term-glossary> or use of a <defined-term-glossary>building</defined-term-glossary> or part thereof for the transaction of business or the rendering or receiving of professional or personal services.",
     "cleanDefinition": "Business and personal services occupancy means the occupancy or use of a building or part thereof for the transaction of business or the rendering or receiving of professional or personal services."
   },
   "care": {
@@ -48,7 +48,7 @@
     "cleanDefinition": "Dead load means the weight of all permanent structural and non-structural components of a building."
   },
   "detention occupancies": {
-    "definition": "<glossary-term>Detention Occupancies</glossary-term> <building-code>(Group B, Division 1)</building-code> means the <defined-term-glossary>occupancy</defined-term-glossary> by persons who are restrained from or are incapable of evacuating to a safe location without the assistance of another person because of security measures not under their control.",
+    "definition": "<glossary-term>Detention Occupancies</glossary-term> <defined-term-glossary override-term='major occupancy' override-tooltip='group b division 1'>(Group B, Division 1)</defined-term-glossary> means the <defined-term-glossary>occupancy</defined-term-glossary> by persons who are restrained from or are incapable of evacuating to a safe location without the assistance of another person because of security measures not under their control.",
     "cleanDefinition": "Detention Occupancies means the occupancy by persons who are restrained from or are incapable of evacuating to a safe location without the assistance of another person because of security measures not under their control."
   },
   "dwelling unit": {
@@ -101,11 +101,11 @@
     "cleanDefinition": "Heritage Building is a building which is legally protected or officially recognized as a heritage property by the Provincial government or a local government."
   },
   "high-hazard industrial occupancy": {
-    "definition": "<glossary-term>High-hazard industrial occupancy</glossary-term> <building-code>(Group F, Division 1)</building-code> means an <defined-term-glossary>industrial occupancy</defined-term-glossary> containing sufficient quantities of highly combustible and flammable or explosive materials which, because of their inherent characteristics, constitute a special firehazard.",
+    "definition": "<glossary-term>High-hazard industrial occupancy</glossary-term> <defined-term-glossary override-term='major occupancy' override-tooltip='group f division 1'>(Group F, Division 1)</defined-term-glossary> means an <defined-term-glossary>industrial occupancy</defined-term-glossary> containing sufficient quantities of highly combustible and flammable or explosive materials which, because of their inherent characteristics, constitute a special firehazard.",
     "cleanDefinition": "High-hazard industrial occupancy means an industrial occupancy containing sufficient quantities of highly combustible and flammable or explosive materials which, because of their inherent characteristics, constitute a special firehazard."
   },
   "industrial occupancy": {
-    "definition": "<glossary-term>Industrial occupancy</glossary-term> Industrial occupancy <building-code>(Group F) m</building-code>means the <defined-term-glossary>occupancy</defined-term-glossary> or use of a <defined-term-glossary>building</defined-term-glossary> or part thereof for the assembling, fabricating, manufacturing, processing, repairing or storing of goods and materials.",
+    "definition": "<glossary-term>Industrial occupancy</glossary-term> Industrial occupancy <defined-term-glossary override-term='major occupancy' override-tooltip='group f'>(Group F) </defined-term-glossary>means the <defined-term-glossary>occupancy</defined-term-glossary> or use of a <defined-term-glossary>building</defined-term-glossary> or part thereof for the assembling, fabricating, manufacturing, processing, repairing or storing of goods and materials.",
     "cleanDefinition": "Industrial occupancy means the occupancy or use of a building or part thereof for the assembling, fabricating, manufacturing, processing, repairing or storing of goods and materials. "
   },
   "limiting distance": {
@@ -117,23 +117,38 @@
     "cleanDefinition": "Loadbearing means subjected to or designed to carry loads in addition to its own dead load, excepting a wall element subjected only to wind or earthquake loads in addition to its own dead load."
   },
   "low-hazard industrial occupancy": {
-    "definition": "<glossary-term>Low-hazard Industrial Occupancies</glossary-term> <building-code>(Group F, Division 3)</building-code> means an industrial <defined-term-glossary>occupancy</defined-term-glossary> in which the combustible content is not more than 50 kg/m² or 1,200 MJ/m² of <defined-term-glossary>floor area</defined-term-glossary>.",
+    "definition": "<glossary-term>Low-hazard Industrial Occupancies</glossary-term> <defined-term-glossary override-term='major occupancy' override-tooltip='group f division 3'>(Group F, Division 3)</defined-term-glossary> means an industrial <defined-term-glossary>occupancy</defined-term-glossary> in which the combustible content is not more than 50 kg/m² or 1,200 MJ/m² of <defined-term-glossary>floor area</defined-term-glossary>.",
     "cleanDefinition": "Low-hazard industrial occupancies means an industrial occupancy in which the combustible content is not more than 50 kg/m² or 1,200 MJ/m² of floor area."
   },
   "major occupancy": {
-    "definition": "<glossary-term>Major occupancy</glossary-term> means the principal occupancy for which a <defined-term-glossary>building</defined-term-glossary> or part thereof is used or intended to be used, and shall be deemed to include the subsidiary <defined-term-glossary override-term='occupancy'>occupancies</defined-term-glossary> that are an integral part of the principal <defined-term-glossary>occupancy</defined-term-glossary>. The major occupancy classifications used in this Code are as follows:<br>• A1 - <defined-term-glossary>Assembly occupancies</defined-term-glossary> intended for the production and viewing of the performing arts<br>• A2 - <defined-term-glossary>Assembly occupancies</defined-term-glossary> not elsewhere classified in <building-code>Group A</building-code><br>• A3 - <defined-term-glossary>Assembly occupancies</defined-term-glossary> of the arena type<br>• A4 - <defined-term-glossary>Assembly occupancies</defined-term-glossary> in which the occupants are gathered in the open air<br>• B1 - <defined-term-glossary>Detention occupancies</defined-term-glossary> in which persons are under restraint or are incapable of self-preservation because of security measures not under their control<br>• B2 - Treatment occupancies<br>• B3 - Care occupancies<br>• C - <defined-term-glossary override-term='residential occupancy'>Residential occupancies</defined-term-glossary><br>• D - <defined-term-glossary override-term='business and personal services occupancy'>Business and personal services occupancies</defined-term-glossary><br>• E - <defined-term-glossary override-term='mercantile occupancies'>Mercantile occupancies</defined-term-glossary><br>• F1 - <defined-term-glossary override-term='high-hazard industrial occupancy'>High-hazard industrial occupancies</defined-term-glossary><br>• F2 - <defined-term-glossary override-term='medium-hazard industrial occupancy'>Medium-hazard industrial occupancies</defined-term-glossary><br>• F3 - <defined-term-glossary override-term='low-hazard industrial occupancy'>Low-hazard industrial occupancies</defined-term-glossary>",
-    "cleanDefinition": "Major occupancy means the principal occupancy for which a building or part thereof is used or intended to be used, and shall be deemed to include the subsidiary occupancies that are an integral part of the principal occupancy. The major occupancy classifications used in this Code are as follows: "
+    "definition": "<glossary-term>Major occupancy</glossary-term> means the principal occupancy for which a <defined-term-glossary>building</defined-term-glossary> or part thereof is used or intended to be used, and shall be deemed to include the subsidiary <defined-term-glossary override-term='occupancy'>occupancies</defined-term-glossary> that are an integral part of the principal <defined-term-glossary>occupancy</defined-term-glossary>. The major occupancy classifications used in this Code are as follows: ",
+    "cleanDefinition": "Major occupancy means the principal occupancy for which a building or part thereof is used or intended to be used, and shall be deemed to include the subsidiary occupancies that are an integral part of the principal occupancy.",
+    "definitionList": [
+      "A1 - <defined-term-glossary>Assembly occupancies</defined-term-glossary> intended for the production and viewing of the performing arts",
+      "A2 - <defined-term-glossary>Assembly occupancies</defined-term-glossary> not elsewhere classified in Group A ",
+      "A3 - <defined-term-glossary>Assembly occupancies</defined-term-glossary> of the arena type ",
+      "A4 - <defined-term-glossary>Assembly occupancies</defined-term-glossary> in which the occupants are gathered in the open air ",
+      "B1 - <defined-term-glossary>Detention occupancies</defined-term-glossary> in which persons are under restraint or are incapable of self-preservation because of security measures not under their control ",
+      "B2 - <defined-term-glossary>Treatment</defined-term-glossary> <defined-term-glossary override-term='occupancy'>occupancies</defined-term-glossary> ",
+      "B3 - <defined-term-glossary>Care</defined-term-glossary> <defined-term-glossary override-term='occupancy'>occupancies</defined-term-glossary> ",
+      "C - <defined-term-glossary override-term='residential occupancy'>Residential occupancies</defined-term-glossary>",
+      "D - <defined-term-glossary override-term='business and personal services occupancy'>Business and personal services occupancies</defined-term-glossary>",
+      "E - <defined-term-glossary override-term='mercantile occupancies'>Mercantile occupancies</defined-term-glossary>",
+      "F1 - <defined-term-glossary override-term='high-hazard industrial occupancy'>High-hazard industrial occupancies</defined-term-glossary>",
+      "F2 - <defined-term-glossary override-term='medium-hazard industrial occupancy'>Medium-hazard industrial occupancies</defined-term-glossary>",
+      "F3 - <defined-term-glossary override-term='low-hazard industrial occupancy'>Low-hazard industrial occupancies</defined-term-glossary>"
+    ]
   },
   "means of egress": {
     "definition": "<glossary-term>Means of egress</glossary-term> means a continuous path of travel provided for the escape of persons from any point in a <defined-term-glossary>building</defined-term-glossary> or contained open space to a separate <defined-term-glossary>building</defined-term-glossary>, an open public thoroughfare, or an exterior open space protected from fire exposure from the <defined-term-glossary>building</defined-term-glossary> and having access to an open public thoroughfare. Means of egress includes <defined-term-glossary override-term='exit'>exits</defined-term-glossary> and access to <defined-term-glossary override-term='exit'>exits</defined-term-glossary>.",
     "cleanDefinition": "Means of egress means a continuous path of travel provided for the escape of persons from any point in a building or contained open space to a separate building, an open public thoroughfare, or an exterior open space protected from fire exposure from the building and having access to an open public thoroughfare. Means of egress includes exits and access to exits."
   },
   "medium-hazard industrial occupancy": {
-    "definition": "<glossary-term>Medium-hazard Industrial Occupancies</glossary-term> <building-code>(Group F, Division 2)</building-code> means an industrial <defined-term-glossary>occupancy</defined-term-glossary> in which the combustible content is more than 50 kg/m² or 1,200 MJ/m² of <defined-term-glossary>floor area</defined-term-glossary> and not classified as a high-hazard industrial occupancy.",
+    "definition": "<glossary-term>Medium-hazard Industrial Occupancies</glossary-term> <defined-term-glossary override-term='major occupancy' override-tooltip='group f division 2'>(Group F, Division 2)</defined-term-glossary> means an industrial <defined-term-glossary>occupancy</defined-term-glossary> in which the combustible content is more than 50 kg/m² or 1,200 MJ/m² of <defined-term-glossary>floor area</defined-term-glossary> and not classified as a high-hazard industrial occupancy.",
     "cleanDefinition": "Medium-hazard industrial occupancies means an industrial occupancy in which the combustible content is more than 50 kg/m² or 1,200 MJ/m² of floor area and not classified as a high-hazard industrial occupancy."
   },
   "mercantile occupancies": {
-    "definition": "<glossary-term>Mercantile occupancies</glossary-term> <building-code>(Group E)</building-code> means the occupancy or use of a <defined-term-glossary>building</defined-term-glossary> or part thereof for the displaying or selling of retail goods, wares or merchandise.",
+    "definition": "<glossary-term>Mercantile occupancies</glossary-term> <defined-term-glossary override-term='major occupancy' override-tooltip='group e'>(Group E)</defined-term-glossary> means the occupancy or use of a <defined-term-glossary>building</defined-term-glossary> or part thereof for the displaying or selling of retail goods, wares or merchandise.",
     "cleanDefinition": "Mercantile occupancies means the occupancy or use of a building or part thereof for the displaying or selling of retail goods, wares or merchandise."
   },
   "noncombustible": {
@@ -161,8 +176,21 @@
     "cleanDefinition": "Plumbing system means a drainage system, a venting system and a water system or parts thereof."
   },
   "post-disaster building": {
-    "definition": "<glossary-term>Post-disaster Building</glossary-term> means a <defined-term-glossary>building</defined-term-glossary> that the <defined-term-glossary>authority having jurisdiction</defined-term-glossary> has determined is necessary for the provision of essential services to the general public in the event of a disaster and includes <defined-term-glossary override-term='building'>buildings</defined-term-glossary> meeting these criteria but not limited to:<br>• hospitals, emergency treatment facilities and blood banks,<br>• telephone exchanges,<br>• power generating stations and electrical substations,<br>• control centres for natural gas distribution,<br>• control centres for air, land and marine transportation,<br>• water treatment facilities,<br>• water storage facilities,<br>• water and sewage pumping stations,<br>• sewage treatment facilities,<br>• <defined-term-glossary override-term='building'>buildings</defined-term-glossary> having critical national defence functions, and<br>• <defined-term-glossary override-term='building'>buildings</defined-term-glossary> of the following types, unless exempted from this designation by the <defined-term-glossary>authority having jurisdiction</defined-term-glossary>:<br>• emergency response facilities,<br>• fire, rescue and police stations and housing for vehicles, aircraft or boats used for such purposes, and<br>• communications facilities, including radio and television stations. (<building-code>See Note A-1.4.1.2.(1).</building-code>)",
-    "cleanDefinition": "Post-disaster building means a building that the authority having jurisdiction has determined is necessary for the provision of essential services to the general public in the event of a disaster and includes buildings meeting these criteria but not limited to: • hospitals, emergency treatment facilities and blood banks, • telephone exchanges, • power generating stations and electrical substations, • control centres for natural gas distribution, • control centres for air, land and marine transportation, • water treatment facilities, • water storage facilities, • water and sewage pumping stations, • sewage treatment facilities, • buildings having critical national defence functions, and • buildings of the following types, unless exempted from this designation by the authority having jurisdiction: • emergency response facilities, • fire, rescue and police stations and housing for vehicles, aircraft or boats used for such purposes, and • communications facilities, including radio and television stations."
+    "definition": "<glossary-term>Post-disaster Building</glossary-term> means a <defined-term-glossary>building</defined-term-glossary> that the <defined-term-glossary>authority having jurisdiction</defined-term-glossary> has determined is necessary for the provision of essential services to the general public in the event of a disaster and includes <defined-term-glossary override-term='building'>buildings</defined-term-glossary> meeting these criteria but not limited to: ",
+    "cleanDefinition": "Post-disaster building means a building that the authority having jurisdiction has determined is necessary for the provision of essential services to the general public in the event of a disaster and includes buildings meeting certain criteria",
+    "definitionList": [
+      "hospitals, emergency treatment facilities and blood banks",
+      "telephone exchanges",
+      "power generating stations and electrical substations",
+      "control centres for natural gas distribution",
+      "control centres for air, land and marine transportation",
+      "water treatment facilities",
+      "water storage facilities",
+      "water and sewage pumping stations",
+      "sewage treatment facilities",
+      "<defined-term-glossary override-term='building'>buildings</defined-term-glossary> having critical national defence functions",
+      "<defined-term-glossary override-term='building'>buildings</defined-term-glossary> of the following types, unless exempted from this designation by the <defined-term-glossary>authority having jurisdiction</defined-term-glossary>:  Emergency response facilities | emergency response facilities | fire, rescue and police stations and housing for vehicles, aircraft or boats used for such purposes | communications facilities, including radio and television stations. (<building-code>See Note A-1.4.1.2.(1).</building-code>)"
+    ]
   },
   "public corridor": {
     "definition": "<glossary-term>Public corridor</glossary-term> means a corridor that provides access to <defined-term-glossary>exit</defined-term-glossary> from more than one <defined-term-glossary>suite</defined-term-glossary>. <building-code>See Note A-1.4.1.2.(1).</building-code>",
@@ -173,7 +201,7 @@
     "cleanDefinition": "Ramp means a path of travel having a slope steeper than 1 in 20."
   },
   "residential occupancy": {
-    "definition": "<glossary-term>Residential occupancy</glossary-term> <building-code>(Group C)</building-code> means the <defined-term-glossary>occupancy</defined-term-glossary> or use of a <defined-term-glossary>building</defined-term-glossary> or part thereof by persons for whom sleeping accommodation is provided but who are not harboured for the purpose of receiving <defined-term-glossary>care</defined-term-glossary> or <defined-term-glossary>treatment</defined-term-glossary> and are not involuntarily detained.",
+    "definition": "<glossary-term>Residential occupancy</glossary-term> <defined-term-glossary override-term='major occupancy' override-tooltip='group c'>(Group C)</defined-term-glossary> means the <defined-term-glossary>occupancy</defined-term-glossary> or use of a <defined-term-glossary>building</defined-term-glossary> or part thereof by persons for whom sleeping accommodation is provided but who are not harboured for the purpose of receiving <defined-term-glossary>care</defined-term-glossary> or <defined-term-glossary>treatment</defined-term-glossary> and are not involuntarily detained.",
     "cleanDefinition": "Residential occupancy means the occupancy or use of a building or part thereof by persons for whom sleeping accommodation is provided but who are not harboured for the purpose of receiving care or treatment and are not involuntarily detained."
   },
   "secondary suite": {
@@ -220,9 +248,69 @@
     "definition": "<glossary-term>Vertical service space</glossary-term> means a shaft oriented essentially vertically that is provided in a <defined-term-glossary>building</defined-term-glossary> to facilitate the installation of building services including mechanical, electrical and plumbing installations and facilities such as elevators, refuse chutes and linen chutes.",
     "cleanDefinition": "Vertical service space means a shaft oriented essentially vertically that is provided in a building to facilitate the installation of building services including mechanical, electrical and plumbing installations and facilities such as elevators, refuse chutes and linen chutes."
   },
-  "group d.": {
-    "definition": "<defined-term-glossary override-term='business and personal services occupancy'>Business and personal services occupancies</defined-term-glossary>",
+  "group a division 1": {
+    "definition": "<defined-term-glossary override-term='major occupancy'>(Group A Division 1) </defined-term-glossary> defined-term-glossary>Assembly occupancies</defined-term-glossary> intended for the production and viewing of the performing arts.",
+    "cleanDefinition": "Assembly occupancies intended for the production and viewing of the performing arts.",
+    "hideTerm": true
+  },
+  "group a division 2": {
+    "definition": "<defined-term-glossary override-term='major occupancy'>(Group A Division 2)</defined-term-glossary> defined-term-glossary>Assembly occupancies</defined-term-glossary> not elsewhere classified in Group A.",
+    "cleanDefinition": "Assembly occupancies not elsewhere classified in Group A.",
+    "hideTerm": true
+  },
+  "group a division 3": {
+    "definition": "<defined-term-glossary override-term='major occupancy'>(Group A Division 3)</defined-term-glossary> defined-term-glossary>Assembly occupancies</defined-term-glossary> of the arena type.",
+    "cleanDefinition": "Assembly occupancies of the arena type.",
+    "hideTerm": true
+  },
+  "group a division 4": {
+    "definition": "<defined-term-glossary override-term='major occupancy'>(Group A Division 4)</defined-term-glossary> <defined-term-glossary>Assembly occupancies</defined-term-glossary> in which the occupants are gathered in the open air.",
+    "cleanDefinition": "Assembly occupancies in which the occupants are gathered in the open air.",
+    "hideTerm": true
+  },
+  "group b division 1": {
+    "definition": "<defined-term-glossary override-term='major occupancy'>(Group B Division 1)</defined-term-glossary>Detention occupancies in which persons are under restraint or are incapable of self-preservation because of security measures not under their control.",
+    "cleanDefinition": "Detention occupancies in which persons are under restraint or are incapable of self-preservation because of security measures not under their control.",
+    "hideTerm": true
+  },
+  "group b division 2": {
+    "definition": "<defined-term-glossary override-term='major occupancy'>(Group B Division 2)</defined-term-glossary> <defined-term-glossary>Treatment occupancies</defined-term-glossary>",
+    "cleanDefinition": "Treatment occupancies",
+    "hideTerm": true
+  },
+  "group b division 3": {
+    "definition": "<defined-term-glossary override-term='major occupancy'>(Group B Division 3) Care occupancies</defined-term-glossary>",
+    "cleanDefinition": "Care occupancies",
+    "hideTerm": true
+  },
+  "group c": {
+    "definition": "<defined-term-glossary override-term='major occupancy'>(Group C) Residential occupancies</defined-term-glossary>",
+    "cleanDefinition": "Residential occupancies",
+    "hideTerm": true
+  },
+  "group d": {
+    "definition": "<defined-term-glossary override-term='major occupancy'>(Group D) Business and personal services occupancies</defined-term-glossary>",
     "cleanDefinition": "Business and personal services occupancies",
+    "hideTerm": true
+  },
+  "group e": {
+    "definition": "<defined-term-glossary override-term='major occupancy'>(Group E) Mercantile occupancies</defined-term-glossary>",
+    "cleanDefinition": "Mercantile occupancies",
+    "hideTerm": true
+  },
+  "group f division 1": {
+    "definition": "<defined-term-glossary override-term='major occupancy'>(Group F Division 1) High-hazard industrial occupancies</defined-term-glossary>",
+    "cleanDefinition": "High-hazard industrial occupancies",
+    "hideTerm": true
+  },
+  "group f division 2": {
+    "definition": "<defined-term-glossary override-term='major occupancy'>(Group F Division 2) Medium-hazard industrial occupancies</defined-term-glossary>",
+    "cleanDefinition": "Medium-hazard industrial occupancies",
+    "hideTerm": true
+  },
+  "group f division 3": {
+    "definition": "<defined-term-glossary override-term='major occupancy'>(Group F Division 3) Low-hazard industrial occupancies</defined-term-glossary>",
+    "cleanDefinition": "Low-hazard industrial occupancies",
     "hideTerm": true
   }
 }

--- a/packages/data/json/terms.json
+++ b/packages/data/json/terms.json
@@ -1,0 +1,228 @@
+{
+  "alteration": {
+    "definition": "<glossary-term>Alteration</glossary-term> means a change or extension to any matter or thing or to any <defined-term-glossary>occupancy</defined-term-glossary> regulated by this Code.",
+    "cleanDefinition": "Alteration means a change or extension to any matter or thing or to any occupancy regulated by this Code."
+  },
+  "appliances": {
+    "definition": "<glossary-term>Appliances</glossary-term> means a device to convert fuel into energy and includes all components, controls, wiring and piping required to be part of the device by the applicable standard referred to in this Code.",
+    "cleanDefinition": "Appliances means a device to convert fuel into energy and includes all components, controls, wiring and piping required to be part of the device by the applicable standard referred to in this Code."
+  },
+  "assembly occupancies": {
+    "definition": "<glossary-term>Assembly Occupancies</glossary-term> <building-code>(Group A)</building-code> means the <defined-term-glossary>occupancy</defined-term-glossary> or the use of a <defined-term-glossary>building</defined-term-glossary> or part thereof by a gathering of persons for civic, political, travel, religious, social, educational, recreational or like purposes, or for the consumption of food or drink.",
+    "cleanDefinition": "Assembly Occupancies means the occupancy or the use of a building or part thereof by a gathering of persons for civic, political, travel, religious, social, educational, recreational or like purposes, or for the consumption of food or drink."
+  },
+  "authority having jurisdiction": {
+    "definition": "<glossary-term>Authority having jurisdiction</glossary-term> means the governmental body responsible for the enforcement of any part of this Code or the official or agency designated by that body to exercise such a function. Notwithstanding this definition, the Chief Inspector of Mines has the sole responsibility for administration and enforcement in respect to all <defined-term-glossary override-term='building'>buildings</defined-term-glossary>, structures and site services used at a mine, as defined in the Mines Act.",
+    "cleanDefinition": "Authority having jurisdiction means the governmental body responsible for the enforcement of any part of this Code or the official or agency designated by that body to exercise such a function. Notwithstanding this definition, the Chief Inspector of Mines has the sole responsibility for administration and enforcement in respect to all buildings, structures and site services used at a mine, as defined in the Mines Act."
+  },
+  "basement": {
+    "definition": "<glossary-term>Basement</glossary-term> means a <defined-term-glossary>storey</defined-term-glossary> or <defined-term-glossary override-term='storey'>storeys</defined-term-glossary> of a building located below the first storey.",
+    "cleanDefinition": "Basement means a storey or storeys of a building located below the first storey. "
+  },
+  "building": {
+    "definition": "<glossary-term>Building</glossary-term> means any structure used or intended for supporting or sheltering any use or <defined-term-glossary>occupancy</defined-term-glossary>.",
+    "cleanDefinition": "Building means any structure used or intended for supporting or sheltering any use or occupancy."
+  },
+  "building area": {
+    "definition": "<glossary-term>Building Area</glossary-term> means the greatest horizontal area of a <defined-term-glossary>building</defined-term-glossary> above <defined-term-glossary>grade</defined-term-glossary> within the outside surface of exterior walls or within the outside surface of exterior walls and the centre line of <defined-term-glossary override-term='firewall'>firewalls</defined-term-glossary>.",
+    "cleanDefinition": "Building Area means the greatest horizontal area of a building above grade within the outside surface of exterior walls or within the outside surface of exterior walls and the centre line of firewalls."
+  },
+  "business and personal services occupancy": {
+    "definition": "<glossary-term>Business and personal services occupancy</glossary-term> <building-code>(Group D)</building-code> means the <defined-term-glossary>occupancy</defined-term-glossary> or use of a <defined-term-glossary>building</defined-term-glossary> or part thereof for the transaction of business or the rendering or receiving of professional or personal services.",
+    "cleanDefinition": "Business and personal services occupancy means the occupancy or use of a building or part thereof for the transaction of business or the rendering or receiving of professional or personal services."
+  },
+  "care": {
+    "definition": "<glossary-term>Care</glossary-term> means the provision of services other than <defined-term-glossary>treatment</defined-term-glossary> by or through care facility management to residents who require these services because of cognitive, physical or behavioural limitations.",
+    "cleanDefinition": "Care means the provision of services other than treatment by or through care facility management to residents who require these services because of cognitive, physical or behavioural limitations."
+  },
+  "closure": {
+    "definition": "<glossary-term>Closure</glossary-term> means a device or assembly for closing an opening through a <defined-term-glossary>fire separation</defined-term-glossary> or an exterior wall, such as a door, a shutter, a damper, wired glass or glass block, and includes all components such as hardware, closing devices, frames and anchors.",
+    "cleanDefinition": "Closure means a device or assembly for closing an opening through a fire separation or an exterior wall, such as a door, a shutter, a damper, wired glass or glass block, and includes all components such as hardware, closing devices, frames and anchors."
+  },
+  "combustible": {
+    "definition": "<glossary-term>Combustible</glossary-term> means that a material fails to meet the acceptance criteria of CAN/ULCS114, 'Standard Method of Test for Determination of Non-Combustibility in Building Materials.' ",
+    "cleanDefinition": "Combustible means that a material fails to meet the acceptance criteria of CAN/ULCS114, 'Standard Method of Test for Determination of Non-Combustibility in Building Materials.' "
+  },
+  "dead load": {
+    "definition": "<glossary-term>Dead load</glossary-term> means the weight of all permanent structural and non-structural components of a <defined-term-glossary>building</defined-term-glossary>.",
+    "cleanDefinition": "Dead load means the weight of all permanent structural and non-structural components of a building."
+  },
+  "detention occupancies": {
+    "definition": "<glossary-term>Detention Occupancies</glossary-term> <building-code>(Group B, Division 1)</building-code> means the <defined-term-glossary>occupancy</defined-term-glossary> by persons who are restrained from or are incapable of evacuating to a safe location without the assistance of another person because of security measures not under their control.",
+    "cleanDefinition": "Detention Occupancies means the occupancy by persons who are restrained from or are incapable of evacuating to a safe location without the assistance of another person because of security measures not under their control."
+  },
+  "dwelling unit": {
+    "definition": "<glossary-term>Dwelling unit</glossary-term> means a <defined-term-glossary>suite</defined-term-glossary> operated as a housekeeping unit, used or intended to be used by one or more persons and usually containing cooking, eating, living, sleeping and sanitary facilities.",
+    "cleanDefinition": "Dwelling unit means a suite operated as a housekeeping unit, used or intended to be used by one or more persons and usually containing cooking, eating, living, sleeping and sanitary facilities."
+  },
+  "exit": {
+    "definition": "<glossary-term>Exit</glossary-term> means that part of a <defined-term-glossary>means of egress</defined-term-glossary>, including doorways, that leads from the <defined-term-glossary>floor area</defined-term-glossary> it serves to a separate <defined-term-glossary>building</defined-term-glossary>, an open public thoroughfare, or an exterior open space protected from fire exposure from the <defined-term-glossary>building</defined-term-glossary> and having access to an open public thoroughfare. <building-code>See Note A-1.4.1.2.(1).</building-code>",
+    "cleanDefinition": "Exit means that part of a means of egress, including doorways, that leads from the floor area it serves to a separate building, an open public thoroughfare, or an exterior open space protected from fire exposure from the building and having access to an open public thoroughfare."
+  },
+  "exposing building face": {
+    "definition": "<glossary-term>Exposing building face</glossary-term> means that part of the exterior wall of a <defined-term-glossary>building</defined-term-glossary> that faces one direction and is located between ground level and the ceiling of its top <defined-term-glossary>storey</defined-term-glossary> or, where a <defined-term-glossary>building</defined-term-glossary> is divided into <defined-term-glossary override-term='fire compartment'>fire compartments</defined-term-glossary>, the exterior wall of a <defined-term-glossary>fire compartment</defined-term-glossary> that faces one direction.",
+    "cleanDefinition": "Exposing building face means that part of the exterior wall of a building that faces one direction and is located between ground level and the ceiling of its top storey or, where a building is divided into fire compartments, the exterior wall of a fire compartment that faces one direction."
+  },
+  "farm building": {
+    "definition": "<glossary-term>Farm Building</glossary-term> means a <defined-term-glossary>building</defined-term-glossary> or part thereof that does not contain a <defined-term-glossary>residential occupancy</defined-term-glossary> and that is associated with and located on land devoted to the practice of farming, and used essentially for the housing of equipment or livestock, or production, storage or processing of agricultural and horticultural produce or feeds. <building-code>See Note A-1.4.1.2.(1).</building-code>",
+    "cleanDefinition": "Farm Building means a building or part thereof that does not contain a residential occupancy and that is associated with and located on land devoted to the practice of farming, and used essentially for the housing of equipment or livestock, or production, storage or processing of agricultural and horticultural produce or feeds."
+  },
+  "fire compartment": {
+    "definition": "<glossary-term>Fire compartment</glossary-term> means an enclosed space in a <defined-term-glossary>building</defined-term-glossary> that is separated from all other parts of the <defined-term-glossary>building</defined-term-glossary> by enclosing construction providing a <defined-term-glossary>fire separation</defined-term-glossary> having a required <defined-term-glossary>fire-resistance rating</defined-term-glossary>.",
+    "cleanDefinition": "Fire compartment means an enclosed space in a building that is separated from all other parts of the building by enclosing construction providing a fire separation having a required fire-resistance rating."
+  },
+  "fire-protection rating": {
+    "definition": "<glossary-term>Fire-protection rating</glossary-term> means the time in minutes or hours that a <defined-term-glossary>closure</defined-term-glossary> will withstand the passage of flame when exposed to fire under specified conditions of test and performance criteria, or as otherwise prescribed in this Code.",
+    "cleanDefinition": "Fire-protection rating means the time in minutes or hours that a closure will withstand the passage of flame when exposed to fire under specified conditions of test and performance criteria, or as otherwise prescribed in this Code."
+  },
+  "fire-resistance rating": {
+    "definition": "<glossary-term>Fire-resistance rating</glossary-term> means the time in minutes or hours that a material or assembly of materials will withstand the passage of flame and the transmission of heat when exposed to fire under specified conditions of test and performance criteria, or as determined by extension or interpretation of information derived therefrom as prescribed in this Code. <building-code>See Sentence D-1.2.1.(2) in Appendix D of Division B.</building-code>",
+    "cleanDefinition": "Fire-resistance rating means the time in minutes or hours that a material or assembly of materials will withstand the passage of flame and the transmission of heat when exposed to fire under specified conditions of test and performance criteria, or as determined by extension or interpretation of information derived therefrom as prescribed in this Code."
+  },
+  "fire separation": {
+    "definition": "<glossary-term>Fire separation</glossary-term> means a construction assembly that acts as a barrier against the spread of fire. <building-code>See Note A-1.4.1.2.(1).</building-code>",
+    "cleanDefinition": "Fire separation means a construction assembly that acts as a barrier against the spread of fire."
+  },
+  "firewall": {
+    "definition": "<glossary-term>Firewall</glossary-term> means a type of <defined-term-glossary>fire separation</defined-term-glossary> of noncombustible construction that subdivides a <defined-term-glossary>building</defined-term-glossary> or separates adjoining <defined-term-glossary override-term='building'>buildings</defined-term-glossary> to resist the spread of fire and that has a fire-resistance rating as prescribed in this Code and has structural stability to remain intact under fire conditions for the required fire-rated time.",
+    "cleanDefinition": "Firewall means a type of fire separation of noncombustible construction that subdivides a building or separates adjoining buildings to resist the spread of fire and that has a fire-resistance rating as prescribed in this Code and has structural stability to remain intact under fire conditions for the required fire-rated time."
+  },
+
+  "floor area": {
+    "definition": "<glossary-term>Floor area</glossary-term> means the space on any <defined-term-glossary>storey</defined-term-glossary> of a <defined-term-glossary>building</defined-term-glossary> between exterior walls and required <defined-term-glossary override-term='firewall'>firewalls</defined-term-glossary>, including the space occupied by interior walls and <defined-term-glossary>partitions</defined-term-glossary>, but not including <defined-term-glossary override-term='exit'>exits</defined-term-glossary>, <defined-term-glossary override-term='vertical service space'>vertical service spaces</defined-term-glossary>, and their enclosing assemblies.",
+    "cleanDefinition": "Floor area means the space on any storey of a building between exterior walls and required firewalls, including the space occupied by interior walls and partitions, but not including <defined-term-glossary override-term='exit'>exits, vertical service spaces, and their enclosing assemblies."
+  },
+  "grade": {
+    "definition": "<glossary-term>Grade</glossary-term> means the lowest of the average levels of finished ground adjoining each exterior wall of a <defined-term-glossary>building</defined-term-glossary>, except that localized depressions need not be considered in the determination of average levels of finished ground. (See First <defined-term-glossary>storey</defined-term-glossary> and <building-code>Note A-1.4.1.2.(1).</building-code>",
+    "cleanDefinition": "Grade means the lowest of the average levels of finished ground adjoining each exterior wall of a building, except that localized depressions need not be considered in the determination of average levels of finished ground."
+  },
+  "heritage building": {
+    "definition": "<glossary-term>Heritage Building</glossary-term> is a <defined-term-glossary>building</defined-term-glossary> which is legally protected or officially recognized as a heritage property by the Provincial government or a local government. <building-code>See Note A-1.1.1.1.(5).</building-code>",
+    "cleanDefinition": "Heritage Building is a building which is legally protected or officially recognized as a heritage property by the Provincial government or a local government."
+  },
+  "high-hazard industrial occupancy": {
+    "definition": "<glossary-term>High-hazard industrial occupancy</glossary-term> <building-code>(Group F, Division 1)</building-code> means an <defined-term-glossary>industrial occupancy</defined-term-glossary> containing sufficient quantities of highly combustible and flammable or explosive materials which, because of their inherent characteristics, constitute a special firehazard.",
+    "cleanDefinition": "High-hazard industrial occupancy means an industrial occupancy containing sufficient quantities of highly combustible and flammable or explosive materials which, because of their inherent characteristics, constitute a special firehazard."
+  },
+  "industrial occupancy": {
+    "definition": "<glossary-term>Industrial occupancy</glossary-term> Industrial occupancy <building-code>(Group F) m</building-code>means the <defined-term-glossary>occupancy</defined-term-glossary> or use of a <defined-term-glossary>building</defined-term-glossary> or part thereof for the assembling, fabricating, manufacturing, processing, repairing or storing of goods and materials.",
+    "cleanDefinition": "Industrial occupancy means the occupancy or use of a building or part thereof for the assembling, fabricating, manufacturing, processing, repairing or storing of goods and materials. "
+  },
+  "limiting distance": {
+    "definition": "<glossary-term>Limiting distance</glossary-term> means the distance from an <defined-term-glossary>exposing building face</defined-term-glossary> to a property line, the centre line of a street, lane or public thoroughfare, or to an imaginary line between 2 <defined-term-glossary override-term='building'>buildings</defined-term-glossary> or <defined-term-glossary override-term='fire compartment'>fire compartments</defined-term-glossary> on the same property, measured at right angles to the <defined-term-glossary>exposing building face</defined-term-glossary>.",
+    "cleanDefinition": "Limiting distance means the distance from an exposing building face to a property line, the centre line of a street, lane or public thoroughfare, or to an imaginary line between 2 buildings or fire compartments on the same property, measured at right angles to the exposing building face."
+  },
+  "loadbearing": {
+    "definition": "<glossary-term>Loadbearing</glossary-term> (as applying to a <defined-term-glossary>building</defined-term-glossary> element) means subjected to or designed to carry loads in addition to its own <defined-term-glossary>dead load</defined-term-glossary>, excepting a wall element subjected only to wind or earthquake loads in addition to its own dead load.",
+    "cleanDefinition": "Loadbearing means subjected to or designed to carry loads in addition to its own dead load, excepting a wall element subjected only to wind or earthquake loads in addition to its own dead load."
+  },
+  "low-hazard industrial occupancy": {
+    "definition": "<glossary-term>Low-hazard Industrial Occupancies</glossary-term> <building-code>(Group F, Division 3)</building-code> means an industrial <defined-term-glossary>occupancy</defined-term-glossary> in which the combustible content is not more than 50 kg/m² or 1,200 MJ/m² of <defined-term-glossary>floor area</defined-term-glossary>.",
+    "cleanDefinition": "Low-hazard industrial occupancies means an industrial occupancy in which the combustible content is not more than 50 kg/m² or 1,200 MJ/m² of floor area."
+  },
+  "major occupancy": {
+    "definition": "<glossary-term>Major occupancy</glossary-term> means the principal occupancy for which a <defined-term-glossary>building</defined-term-glossary> or part thereof is used or intended to be used, and shall be deemed to include the subsidiary <defined-term-glossary override-term='occupancy'>occupancies</defined-term-glossary> that are an integral part of the principal <defined-term-glossary>occupancy</defined-term-glossary>. The major occupancy classifications used in this Code are as follows:<br>• A1 - <defined-term-glossary>Assembly occupancies</defined-term-glossary> intended for the production and viewing of the performing arts<br>• A2 - <defined-term-glossary>Assembly occupancies</defined-term-glossary> not elsewhere classified in <building-code>Group A</building-code><br>• A3 - <defined-term-glossary>Assembly occupancies</defined-term-glossary> of the arena type<br>• A4 - <defined-term-glossary>Assembly occupancies</defined-term-glossary> in which the occupants are gathered in the open air<br>• B1 - <defined-term-glossary>Detention occupancies</defined-term-glossary> in which persons are under restraint or are incapable of self-preservation because of security measures not under their control<br>• B2 - Treatment occupancies<br>• B3 - Care occupancies<br>• C - <defined-term-glossary override-term='residential occupancy'>Residential occupancies</defined-term-glossary><br>• D - <defined-term-glossary override-term='business and personal services occupancy'>Business and personal services occupancies</defined-term-glossary><br>• E - <defined-term-glossary override-term='mercantile occupancies'>Mercantile occupancies</defined-term-glossary><br>• F1 - <defined-term-glossary override-term='high-hazard industrial occupancy'>High-hazard industrial occupancies</defined-term-glossary><br>• F2 - <defined-term-glossary override-term='medium-hazard industrial occupancy'>Medium-hazard industrial occupancies</defined-term-glossary><br>• F3 - <defined-term-glossary override-term='low-hazard industrial occupancy'>Low-hazard industrial occupancies</defined-term-glossary>",
+    "cleanDefinition": "Major occupancy means the principal occupancy for which a building or part thereof is used or intended to be used, and shall be deemed to include the subsidiary occupancies that are an integral part of the principal occupancy. The major occupancy classifications used in this Code are as follows: "
+  },
+  "means of egress": {
+    "definition": "<glossary-term>Means of egress</glossary-term> means a continuous path of travel provided for the escape of persons from any point in a <defined-term-glossary>building</defined-term-glossary> or contained open space to a separate <defined-term-glossary>building</defined-term-glossary>, an open public thoroughfare, or an exterior open space protected from fire exposure from the <defined-term-glossary>building</defined-term-glossary> and having access to an open public thoroughfare. Means of egress includes <defined-term-glossary override-term='exit'>exits</defined-term-glossary> and access to <defined-term-glossary override-term='exit'>exits</defined-term-glossary>.",
+    "cleanDefinition": "Means of egress means a continuous path of travel provided for the escape of persons from any point in a building or contained open space to a separate building, an open public thoroughfare, or an exterior open space protected from fire exposure from the building and having access to an open public thoroughfare. Means of egress includes exits and access to exits."
+  },
+  "medium-hazard industrial occupancy": {
+    "definition": "<glossary-term>Medium-hazard Industrial Occupancies</glossary-term> <building-code>(Group F, Division 2)</building-code> means an industrial <defined-term-glossary>occupancy</defined-term-glossary> in which the combustible content is more than 50 kg/m² or 1,200 MJ/m² of <defined-term-glossary>floor area</defined-term-glossary> and not classified as a high-hazard industrial occupancy.",
+    "cleanDefinition": "Medium-hazard industrial occupancies means an industrial occupancy in which the combustible content is more than 50 kg/m² or 1,200 MJ/m² of floor area and not classified as a high-hazard industrial occupancy."
+  },
+  "mercantile occupancies": {
+    "definition": "<glossary-term>Mercantile occupancies</glossary-term> <building-code>(Group E)</building-code> means the occupancy or use of a <defined-term-glossary>building</defined-term-glossary> or part thereof for the displaying or selling of retail goods, wares or merchandise.",
+    "cleanDefinition": "Mercantile occupancies means the occupancy or use of a building or part thereof for the displaying or selling of retail goods, wares or merchandise."
+  },
+  "noncombustible": {
+    "definition": "<glossary-term>Noncombustible</glossary-term> means that a material meets the acceptance criteria of CAN/ULC-S114, Standard Method of Test for Determination of Non-Combustibility in <defined-term-glossary>building</defined-term-glossary> materials.",
+    "cleanDefinition": "Noncombustible means that a material meets the acceptance criteria of CAN/ULC-S114, Standard Method of Test for Determination of Non-Combustibility in building materials."
+  },
+  "noncombustible construction": {
+    "definition": "<glossary-term>Noncombustible construction</glossary-term> means that type of construction in which a degree of fire safety is attained by the use of <defined-term-glossary>noncombustible</defined-term-glossary> materials for structural members and other <defined-term-glossary>building</defined-term-glossary> assemblies.",
+    "cleanDefinition": "Noncombustible construction means that type of construction in which a degree of fire safety is attained by the use of noncombustible materials for structural members and other building assemblies."
+  },
+  "occupancy": {
+    "definition": "<glossary-term>Occupancy</glossary-term> means the use or intended use of a <defined-term-glossary>building</defined-term-glossary> or part thereof for the shelter or support of persons, animals or property.",
+    "cleanDefinition": "Occupancy means the use or intended use of a building or part thereof for the shelter or support of persons, animals or property."
+  },
+  "open-air storey": {
+    "definition": "<glossary-term>Open-air storey</glossary-term> means a <defined-term-glossary>storey</defined-term-glossary> in which at least 25% of the total area of its perimeter walls is open to the outdoors in a manner that will provide cross-ventilation to the entire <defined-term-glossary>storey</defined-term-glossary>.",
+    "cleanDefinition": "Open-air storey means a storey in which at least 25% of the total area of its perimeter walls is open to the outdoors in a manner that will provide cross-ventilation to the entire storey."
+  },
+  "partitions": {
+    "definition": "<glossary-term>Partitions</glossary-term> means an interior wall 1 <defined-term-glossary>storey</defined-term-glossary> or part-storey in height that is not <defined-term-glossary>loadbearing</defined-term-glossary>.",
+    "cleanDefinition": "Partitions means an interior wall 1 storey or part-storey in height that is not loadbearing."
+  },
+  "plumbing system": {
+    "definition": "<glossary-term>Plumbing system</glossary-term> means a drainage system, a venting system and a water system or parts thereof.",
+    "cleanDefinition": "Plumbing system means a drainage system, a venting system and a water system or parts thereof."
+  },
+  "post-disaster building": {
+    "definition": "<glossary-term>Post-disaster Building</glossary-term> means a <defined-term-glossary>building</defined-term-glossary> that the <defined-term-glossary>authority having jurisdiction</defined-term-glossary> has determined is necessary for the provision of essential services to the general public in the event of a disaster and includes <defined-term-glossary override-term='building'>buildings</defined-term-glossary> meeting these criteria but not limited to:<br>• hospitals, emergency treatment facilities and blood banks,<br>• telephone exchanges,<br>• power generating stations and electrical substations,<br>• control centres for natural gas distribution,<br>• control centres for air, land and marine transportation,<br>• water treatment facilities,<br>• water storage facilities,<br>• water and sewage pumping stations,<br>• sewage treatment facilities,<br>• <defined-term-glossary override-term='building'>buildings</defined-term-glossary> having critical national defence functions, and<br>• <defined-term-glossary override-term='building'>buildings</defined-term-glossary> of the following types, unless exempted from this designation by the <defined-term-glossary>authority having jurisdiction</defined-term-glossary>:<br>• emergency response facilities,<br>• fire, rescue and police stations and housing for vehicles, aircraft or boats used for such purposes, and<br>• communications facilities, including radio and television stations. (<building-code>See Note A-1.4.1.2.(1).</building-code>)",
+    "cleanDefinition": "Post-disaster building means a building that the authority having jurisdiction has determined is necessary for the provision of essential services to the general public in the event of a disaster and includes buildings meeting these criteria but not limited to: • hospitals, emergency treatment facilities and blood banks, • telephone exchanges, • power generating stations and electrical substations, • control centres for natural gas distribution, • control centres for air, land and marine transportation, • water treatment facilities, • water storage facilities, • water and sewage pumping stations, • sewage treatment facilities, • buildings having critical national defence functions, and • buildings of the following types, unless exempted from this designation by the authority having jurisdiction: • emergency response facilities, • fire, rescue and police stations and housing for vehicles, aircraft or boats used for such purposes, and • communications facilities, including radio and television stations."
+  },
+  "public corridor": {
+    "definition": "<glossary-term>Public corridor</glossary-term> means a corridor that provides access to <defined-term-glossary>exit</defined-term-glossary> from more than one <defined-term-glossary>suite</defined-term-glossary>. <building-code>See Note A-1.4.1.2.(1).</building-code>",
+    "cleanDefinition": "Public corridor means a corridor that provides access to exit from more than one suite."
+  },
+  "ramp": {
+    "definition": "<glossary-term>Ramp</glossary-term> means a path of travel having a slope steeper than 1 in 20.",
+    "cleanDefinition": "Ramp means a path of travel having a slope steeper than 1 in 20."
+  },
+  "residential occupancy": {
+    "definition": "<glossary-term>Residential occupancy</glossary-term> <building-code>(Group C)</building-code> means the <defined-term-glossary>occupancy</defined-term-glossary> or use of a <defined-term-glossary>building</defined-term-glossary> or part thereof by persons for whom sleeping accommodation is provided but who are not harboured for the purpose of receiving <defined-term-glossary>care</defined-term-glossary> or <defined-term-glossary>treatment</defined-term-glossary> and are not involuntarily detained.",
+    "cleanDefinition": "Residential occupancy means the occupancy or use of a building or part thereof by persons for whom sleeping accommodation is provided but who are not harboured for the purpose of receiving care or treatment and are not involuntarily detained."
+  },
+  "secondary suite": {
+    "definition": "<glossary-term>Secondary suite</glossary-term> means a self-contained <defined-term-glossary>dwelling unit</defined-term-glossary> located within a <defined-term-glossary>building</defined-term-glossary> or portion of a <defined-term-glossary>building</defined-term-glossary> • completely separated from other parts of the <defined-term-glossary>building</defined-term-glossary> by a vertical <defined-term-glossary>fire separation</defined-term-glossary> that has a <defined-term-glossary>fire-resistance rating</defined-term-glossary> of not less than 1 h and extends from ground or lowermost assembly continuously through or adjacent to all <defined-term-glossary override-term='storey'>storeys</defined-term-glossary> and spaces including <defined-term-glossary override-term='service space'>service spaces</defined-term-glossary> of the separated portions, • of only <defined-term-glossary>residential occupancy</defined-term-glossary> that contains only one other <defined-term-glossary>dwelling unit</defined-term-glossary> and common spaces, and • where both <defined-term-glossary override-term='dwelling unit'>dwelling units</defined-term-glossary> constitute a single real estate entity. <building-code>See Note A-1.4.1.2.(1) of Division A.</building-code>",
+    "cleanDefinition": "Secondary suite means a self-contained dwelling unit located within a building or portion of a building completely separated from other parts of the building by a vertical fire separation that has a fire-resistance rating of not less than 1 h and extends from ground or lowermost assembly continuously through or adjacent to all storeys and spaces including service spaces of the separated portions, of only residential occupancy that contains only one other dwelling unit and common spaces, and where both dwelling units constitute a single real estate entity."
+  },
+  "service space": {
+    "definition": "<glossary-term>Service Space</glossary-term> means space provided in a <defined-term-glossary>building</defined-term-glossary> to facilitate or conceal the installation of <defined-term-glossary>building</defined-term-glossary> service facilities such as chutes, ducts, pipes, shafts or wires. ",
+    "cleanDefinition": "Service Space means space provided in a building to facilitate or conceal the installation of building service facilities such as chutes, ducts, pipes, shafts or wires."
+  },
+  "sprinklered": {
+    "definition": "<glossary-term>Sprinklered</glossary-term> (as applying to a <defined-term-glossary>building</defined-term-glossary> or part thereof) means that the <defined-term-glossary>building</defined-term-glossary> or part thereof is equipped with a system of automatic sprinklers.",
+    "cleanDefinition": "Sprinklered means that the building or part thereof is equipped with a system of automatic sprinklers."
+  },
+  "storage garage": {
+    "definition": "<glossary-term>Storage garage</glossary-term> means a <defined-term-glossary>building</defined-term-glossary> or part thereof intended for the storage or parking of motor vehicles and containing no provision for the repair or servicing of such vehicles. <building-code>See Note A-1.4.1.2.(1).</building-code>",
+    "cleanDefinition": "Storage garage means a building or part thereof intended for the storage or parking of motor vehicles and containing no provision for the repair or servicing of such vehicles."
+  },
+  "storey": {
+    "definition": "<glossary-term>Storey</glossary-term> means that portion of a <defined-term-glossary>building</defined-term-glossary> that is situated between the top of any floor and the top of the floor next above it, and if there is no floor above it, that portion between the top of such floor and the ceiling above it.",
+    "cleanDefinition": "Storey means that portion of a building that is situated between the top of any floor and the top of the floor next above it, and if there is no floor above it, that portion between the top of such floor and the ceiling above it."
+  },
+  "street": {
+    "definition": "<glossary-term>Street</glossary-term> means any highway, road, boulevard, square or other improved thoroughfare 9 m or more in width, that has been dedicated or deeded for public use and is accessible to fire department vehicles and equipment.",
+    "cleanDefinition": "Street means any highway, road, boulevard, square or other improved thoroughfare 9 m or more in width, that has been dedicated or deeded for public use and is accessible to fire department vehicles and equipment."
+  },
+  "suite": {
+    "definition": "<glossary-term>Suite</glossary-term> means a single room or series of rooms of complementary use, operated under a single tenancy, and includes <defined-term-glossary override-term='dwelling unit'>dwelling units</defined-term-glossary>, individual guest rooms in motels, hotels, boarding houses, rooming houses and dormitories as well as individual stores and individual or complementary rooms for <defined-term-glossary override-term='business and personal services occupancy'>business and personal services occupancies</defined-term-glossary>. <building-code>See Note A-1.4.1.2.(1).</building-code>",
+    "cleanDefinition": "Suite means a single room or series of rooms of complementary use, operated under a single tenancy, and includes dwelling units, individual guest rooms in motels, hotels, boarding houses, rooming houses and dormitories as well as individual stores and individual or complementary rooms for business and personal services occupancies."
+  },
+  "treatment": {
+    "definition": "<glossary-term>Treatment</glossary-term> means the provision of medical or other health-related intervention to persons, where the administration or lack of administration of these interventions may render them incapable of evacuating to a safe location without the assistance of another person. <building-code>See Note A-1.4.1.2.(1).</building-code>",
+    "cleanDefinition": "Treatment means the provision of medical or other health-related intervention to persons, where the administration or lack of administration of these interventions may render them incapable of evacuating to a safe location without the assistance of another person."
+  },
+  "unsafe condition": {
+    "definition": "<glossary-term>Unsafe condition</glossary-term> means any condition that could cause undue hazard to the life, limb or health of any person authorized or expected to be on or about the premises.",
+    "cleanDefinition": "Unsafe condition means any condition that could cause undue hazard to the life, limb or health of any person authorized or expected to be on or about the premises."
+  },
+  "unprotected openings": {
+    "definition": "<glossary-term>Unprotected opening</glossary-term> (as applying to <defined-term-glossary>exposing building face</defined-term-glossary>) means a doorway, window or opening other than one equipped with a closure having the required fire-protection rating.",
+    "cleanDefinition": "Unprotected opening means a doorway, window or opening other than one equipped with a closure having the required fire-protection rating."
+  },
+  "vertical service space": {
+    "definition": "<glossary-term>Vertical service space</glossary-term> means a shaft oriented essentially vertically that is provided in a <defined-term-glossary>building</defined-term-glossary> to facilitate the installation of building services including mechanical, electrical and plumbing installations and facilities such as elevators, refuse chutes and linen chutes.",
+    "cleanDefinition": "Vertical service space means a shaft oriented essentially vertically that is provided in a building to facilitate the installation of building services including mechanical, electrical and plumbing installations and facilities such as elevators, refuse chutes and linen chutes."
+  },
+  "group d.": {
+    "definition": "<defined-term-glossary override-term='business and personal services occupancy'>Business and personal services occupancies</defined-term-glossary>",
+    "cleanDefinition": "Business and personal services occupancies",
+    "hideTerm": true
+  }
+}

--- a/packages/data/json/terms.test.ts
+++ b/packages/data/json/terms.test.ts
@@ -1,0 +1,33 @@
+// 3rd party
+import { describe, it, expect } from "vitest";
+// local
+import data from "./terms.json";
+import { BuildingGlossaryJSONType } from "@repo/data/useGlossaryData";
+
+const glossary = data as unknown as BuildingGlossaryJSONType;
+
+describe("Glossary Terms Format", () => {
+  Object.entries(glossary).forEach(([term, content]) => {
+    describe(`Term: ${term}`, () => {
+      it('should have a "definition"', () => {
+        expect(content.definition).toBeDefined();
+      });
+
+      it('should have a "cleanDefinition"', () => {
+        expect(content.cleanDefinition).toBeDefined();
+      });
+
+      if (content.definitionList !== undefined) {
+        it('should have "definitionList" as an array', () => {
+          expect(Array.isArray(content.definitionList)).toBe(true);
+        });
+      }
+
+      if (content.hideTerm !== undefined) {
+        it('should have "hideTerm" as a boolean', () => {
+          expect(typeof content.hideTerm).toBe("boolean");
+        });
+      }
+    });
+  });
+});

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -5,7 +5,8 @@
   "exports": {
     "./useData": "./src/useData.ts",
     "./useWalkthroughData": "./src/useWalkthroughData.ts",
-    "./useWalkthroughTestData": "./src/useWalkthroughTestData.ts"
+    "./useWalkthroughTestData": "./src/useWalkthroughTestData.ts",
+    "./useGlossaryData": "./src/useGlossaryData.ts"
   },
   "scripts": {
     "lint": "eslint . --max-warnings 0",

--- a/packages/data/src/useGlossaryData.ts
+++ b/packages/data/src/useGlossaryData.ts
@@ -1,0 +1,66 @@
+import glossary from "../json/terms.json";
+import buildingCode from "../json/buildingCode.json";
+
+export enum ModalSideDataEnum {
+  GLOSSARY = "glossary",
+  BUILDING_CODE = "buildingCode",
+}
+
+export type SubClauseType = {
+  description: string;
+  subClauses?: string[];
+  imagePath?: string;
+  imageDescription?: string;
+};
+
+export type ClauseType = {
+  description: string;
+  subsections?: SubClauseType[];
+};
+
+export type ArticleContentType = {
+  clauses: ClauseType[];
+};
+
+export type GlossaryContentType = {
+  definition: string;
+  cleanDefinition: string;
+  hideTerm: boolean;
+};
+
+export type ArticleType = {
+  section: string;
+  header?: string;
+  content: ArticleContentType | GlossaryContentType;
+};
+
+export type BuildingGlossaryJSONType = {
+  [term: string]: GlossaryContentType;
+};
+
+const GlossaryJSONData = glossary as unknown as BuildingGlossaryJSONType;
+export const BuildingCodeJSONData = buildingCode as unknown as ArticleType[];
+
+export default function transformGlossaryData(
+  data: BuildingGlossaryJSONType
+): ArticleType[] {
+  return Object.entries(data).map(([term, content]) => ({
+    section: term.toLocaleLowerCase(),
+    header: undefined,
+    content,
+  }));
+}
+
+function setMappedGlossaryData(
+  data: BuildingGlossaryJSONType
+): Map<string, string> {
+  return new Map(
+    Object.entries(data).map(([term, content]) => [
+      term.toLowerCase(),
+      content.cleanDefinition,
+    ])
+  );
+}
+
+export const ModalGlossaryData = transformGlossaryData(GlossaryJSONData);
+export const TooltipGlossaryData = setMappedGlossaryData(GlossaryJSONData);

--- a/packages/data/src/useGlossaryData.ts
+++ b/packages/data/src/useGlossaryData.ts
@@ -23,13 +23,14 @@ export type ArticleContentType = {
 };
 
 export type GlossaryContentType = {
-  definition: string;
-  cleanDefinition: string;
-  hideTerm: boolean;
+  definition: string; // The definition of the term in HTML format
+  cleanDefinition: string; // The definition of the term in plain text format
+  definitionList?: string[]; // A list of definitions for the term to be in a bulleted list
+  hideTerm?: boolean; // A boolean to hide the term from the glossary (Used for major occupancy groups currently)
 };
 
 export type ArticleType = {
-  section: string;
+  section: string; // The section of the glossary (Used for the anchor link)
   header?: string;
   content: ArticleContentType | GlossaryContentType;
 };
@@ -39,10 +40,12 @@ export type BuildingGlossaryJSONType = {
 };
 
 const GlossaryJSONData = glossary as unknown as BuildingGlossaryJSONType;
+
+// TODO: (ANY) Move to useBuildingCodeData
 export const BuildingCodeJSONData = buildingCode as unknown as ArticleType[];
 
 export default function transformGlossaryData(
-  data: BuildingGlossaryJSONType
+  data: BuildingGlossaryJSONType,
 ): ArticleType[] {
   return Object.entries(data).map(([term, content]) => ({
     section: term.toLocaleLowerCase(),
@@ -52,13 +55,13 @@ export default function transformGlossaryData(
 }
 
 function setMappedGlossaryData(
-  data: BuildingGlossaryJSONType
+  data: BuildingGlossaryJSONType,
 ): Map<string, string> {
   return new Map(
     Object.entries(data).map(([term, content]) => [
       term.toLowerCase(),
       content.cleanDefinition,
-    ])
+    ]),
   );
 }
 

--- a/packages/data/src/useWalkthroughData.ts
+++ b/packages/data/src/useWalkthroughData.ts
@@ -109,7 +109,7 @@ export interface QuestionMultipleChoiceData extends QuestionBaseData {
 
 export const WalkthroughItemTypeMultiChoiceMultiple = "multiChoiceMultiple";
 export const isWalkthroughItemTypeMultiChoiceMultiple = (
-  walkthroughItemType: string
+  walkthroughItemType: string,
 ) => walkthroughItemType === WalkthroughItemTypeMultiChoiceMultiple;
 export interface QuestionMultipleChoiceSelectMultipleData
   extends QuestionBaseData {

--- a/packages/data/src/useWalkthroughData.ts
+++ b/packages/data/src/useWalkthroughData.ts
@@ -1,4 +1,4 @@
-import testCase999 from "../walkthroughs/9.9.9.json";
+import testCase999 from "../json/9.9.9.json";
 
 type Walkthroughs = "9.9.9";
 
@@ -109,7 +109,7 @@ export interface QuestionMultipleChoiceData extends QuestionBaseData {
 
 export const WalkthroughItemTypeMultiChoiceMultiple = "multiChoiceMultiple";
 export const isWalkthroughItemTypeMultiChoiceMultiple = (
-  walkthroughItemType: string,
+  walkthroughItemType: string
 ) => walkthroughItemType === WalkthroughItemTypeMultiChoiceMultiple;
 export interface QuestionMultipleChoiceSelectMultipleData
   extends QuestionBaseData {

--- a/packages/data/src/useWalkthroughTestData.ts
+++ b/packages/data/src/useWalkthroughTestData.ts
@@ -29,6 +29,23 @@ export function getMultiChoiceQuestion() {
   };
 }
 
+export function getQuestion(questionId: string) {
+  // find the question for the given questionId
+  const questions: {
+    [key: string]: QuestionDisplayData | QuestionVariableData;
+  } = testCase999.questions;
+  const question = questions[questionId] as QuestionDisplayData;
+
+  if (!question) {
+    throw new Error("No question info");
+  }
+
+  return {
+    questionKey: questionId,
+    questionData: question,
+  };
+}
+
 export function getMultiChoiceMultipleQuestion() {
   // find the first question that is a multi-choice multiple question
   const questions: {

--- a/packages/data/src/useWalkthroughTestData.ts
+++ b/packages/data/src/useWalkthroughTestData.ts
@@ -1,4 +1,4 @@
-import testCase999 from "../walkthroughs/9.9.9.json";
+import testCase999 from "../json/9.9.9.json";
 import {
   QuestionDisplayData,
   QuestionMultipleChoiceData,

--- a/packages/data/tsconfig.json
+++ b/packages/data/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "@repo/typescript-config/react-library.json",
-  "include": ["src", "walkthroughs", "vite.config.mts"],
+  "include": ["src", "json", "vite.config.mts"]
 }

--- a/packages/ui/src/modal-side/ModalSide.css
+++ b/packages/ui/src/modal-side/ModalSide.css
@@ -55,6 +55,13 @@
   background-color: var(--theme-gray-white);
 }
 
+.ui-ModalSide--ModalContentHeader {
+  grid-column: span 3;
+  font-size: var(--typography-font-size-h5);
+  font-weight: var(--typography-font-weights-bold);
+  padding-left: var(--layout-margin-large);
+}
+
 .ui-ModalSide--Content {
   display: flex;
   flex-direction: column;
@@ -68,6 +75,8 @@
 
 .ui-ModalSide--Section {
   display: flex;
+  grid-column: span 4 / 6;
+
   flex-direction: column;
 }
 
@@ -77,10 +86,20 @@
   align-items: center;
 }
 
-.ui-ModalSide--SectionContentLine {
+.ui-ModalSide--SectionGlossaryContentLine {
   display: grid;
   grid-template-columns: repeat(5, 1fr);
   align-items: center;
+}
+
+.ui-ModalSide--SectionBuildingCodeContentLine {
+  display: grid;
+  padding: var(--layout-padding-medium);
+  align-items: center;
+}
+
+.ui-ModalSide--BuildingCodeList {
+  padding: revert;
 }
 
 .ui-ModalSide--SectionNumber {
@@ -109,6 +128,12 @@
   border-radius: var(--layout-margin-small, 8px);
   border: 1px solid var(--support-borderColor-info, #053662);
   background: var(--support-surfaceColor-info, #f7f9fc);
+}
+
+.ui-ModalSide-Term {
+  color: var(--typography-color-link);
+  font-weight: var(--typography-font-weights-bold);
+  text-decoration-line: underline;
 }
 
 @keyframes modal-slide-out {

--- a/packages/ui/src/modal-side/ModalSide.tsx
+++ b/packages/ui/src/modal-side/ModalSide.tsx
@@ -33,6 +33,42 @@ export interface ModalSideProps {
   "data-testid"?: string;
 }
 
+function renderDefinitionList(
+  definitionList: string[],
+  customHandler?: (location: string) => void,
+) {
+  return (
+    <ul className="ui-ModalSide--BuildingCodeList">
+      {definitionList.map((item, index) => (
+        <li key={index}>{parseStringToComponents(item, customHandler)}</li>
+      ))}
+    </ul>
+  );
+}
+
+function renderSubClauses(subClauses: string[]) {
+  return (
+    <ol type="i" className="ui-ModalSide--BuildingCodeList">
+      {subClauses.map((subClause, index) => (
+        <li key={index}>{subClause}</li>
+      ))}
+    </ol>
+  );
+}
+
+function renderSubsections(subsections: SubClauseType[]) {
+  return (
+    <ol type="a" className="ui-ModalSide--BuildingCodeList">
+      {subsections.map((subsection, index) => (
+        <li key={index}>
+          {subsection.description}
+          {subsection.subClauses && renderSubClauses(subsection.subClauses)}
+        </li>
+      ))}
+    </ol>
+  );
+}
+
 // TODO: (ANY) Move to GlossaryContent component
 function GlossaryContent({
   modalData,
@@ -73,37 +109,21 @@ function GlossaryContent({
                 <p className="ui-ModalSide--SectionContent">
                   {parseStringToComponents(
                     (data.content as GlossaryContentType).definition,
-                    setFocusSection
+                    setFocusSection,
                   )}
                 </p>
+                <div className="ui-ModalSide--SectionContent">
+                  {(data.content as GlossaryContentType).definitionList &&
+                    renderDefinitionList(
+                      data.content?.definitionList,
+                      setFocusSection,
+                    )}
+                </div>
               </article>
             </section>
-          )
+          ),
       )}
     </>
-  );
-}
-
-function renderSubClauses(subClauses: string[]) {
-  return (
-    <ol type="i" className="ui-ModalSide--BuildingCodeList">
-      {subClauses.map((subClause, index) => (
-        <li key={index}>{subClause}</li>
-      ))}
-    </ol>
-  );
-}
-
-function renderSubsections(subsections: SubClauseType[]) {
-  return (
-    <ol type="a" className="ui-ModalSide--BuildingCodeList">
-      {subsections.map((subsection, index) => (
-        <li key={index}>
-          {subsection.description}
-          {subsection.subClauses && renderSubClauses(subsection.subClauses)}
-        </li>
-      ))}
-    </ol>
   );
 }
 
@@ -149,12 +169,12 @@ function BuildingCodeContent({
                     {clauseIndex + 1}.{" "}
                     {parseStringToComponents(
                       clause.description,
-                      setFocusSection
+                      setFocusSection,
                     )}
                   </p>
                   {clause.subsections && renderSubsections(clause.subsections)}
                 </div>
-              )
+              ),
             )}
           </article>
         </section>
@@ -173,7 +193,7 @@ export default function ModalSide({
   const [isOpen, setIsOpen] = useState(false);
   const [focusSection, setFocusSection] = useState(scrollTo);
   const [highlightedSection, setHighlightedSection] = useState<string | null>(
-    null
+    null,
   );
   const modalRef = useRef<HTMLDivElement>(null);
   const sectionRefs = useRef<{ [key: string]: HTMLElement | null }>({});


### PR DESCRIPTION
<!-- You may remove any sections that are not applicable -->

[HOUSNAV-39](https://hous-bssb.atlassian.net/browse/HOUSNAV-39)

## Overview & Purpose
<!-- Please describe the purpose of your changes. Please also include relevant motivation and context. -->
Add glossary term data transformation enabling correct tooltips and adds real data to modal popout.

## Summary of Changes
<!-- Please include a HIGH LEVEL overview of the code changes. (Added xyz fields to table, modified function to handle x case instead of y case, etc. )  -->
- Update references to open building code model
    - Updated/added new building code data to match potential format
- Added new cases for `parseStringToComponents` 
- Added `terms.json` to house all glossary terms
    - Moved to `json` directory instead of just `walkthroughs`   
- Refactored Modal so that the building code and glossary terms data is formatted separately. (Easier to debug this way) 
## Side Effects
<!-- Any possible side effects? Does this change affect features that are not linked to the direct purpose? -->
- Tooltips had to be modified to account for the `major occupancy` terms and `groups`. So, tooltip content needed an override. If there is a defined term that has the incorrect tooltip then:
    - Check the `terms.json` and it's "clean definition" 
    - If that is correct then check what question/answer is using the defined term and ensure there isn't a `override-tooltip` set. If there is, ensure it's correct.

     
## Testing
<!-- Please include steps to test out the changes/fixes if applicable OR context notes to help get env in a state to test-->
- Test by opening glossary modal. Ensure tooltips and clicking on terms are correct.
- UI walkthroughs should contain terms
    -  **If walkthrough is missing a term then note the questions number and what the term is** 
    - I updated some of the defined terms in 9.9.9. If a term is a variation (ie. occupancy/occupancies) and the term does not have the correct tooltip or open the modal and scroll to it then this can easily be fixed by adding "override-term" to the attribute in the 9.9.9 json 
        - This was done so that we can quickly specify and override terms and it ensures the application is fast because it doesn't have to "loop" variations to see if one is correct. 
 - Note: Groups should display the definition or word for that group. However, when clicking on a group as a defined term it should open the glossary modal at the `major occupancy` section. 

## Notes & Resources
<!-- Please include any additional notes necessary to review PR and/or relevant links (documentation, stack overflow, etc.) that helped you arrive at your solution. -->

## Checklist
- [x] I have written or updated vitests for this work
- [ ] I have reviewed the [accessibility guidelines](https://digital.gov.bc.ca/wcag/home/) relevant to this work
    - N/A due to no new functionality 
- [ ] I have reviewed this work with at least one screen reader (when applicable)
    - Screen reader enhacements (https://hous-bssb.atlassian.net/jira/software/c/projects/HOUSNAV/boards/3/backlog?selectedIssue=HOUSNAV-89) 
- [x] I have added/updated any related documentation
