### PR TITLE
HOUSNAV-7: Migrate to artifactory

### DIFF
--- a/.github/workflows/docker-build-and-deploy.yml
+++ b/.github/workflows/docker-build-and-deploy.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Export Artifactory Image Path
         run: echo "ARTIFACTORY_IMAGE_PATH=${{ secrets.ARTIFACTORY_URL }}/${{ secrets.ARTIFACTORY_REPOSITORY_NAME }}/house-innovations-housnav-web" >> $GITHUB_ENV
 
+      - name: Export imagePullSecretsName
+        run: echo "IMAGE_PULL_SECRET_NAME=${{ secrets.IMAGE_PULL_SECRET_NAME }}" >> $GITHUB_ENV
+
       - name: Deploy Application in OpenShift
         run: envsubst < k8s/deployment.yaml | oc apply -f -
 

--- a/.github/workflows/docker-build-and-deploy.yml
+++ b/.github/workflows/docker-build-and-deploy.yml
@@ -28,24 +28,24 @@ jobs:
       - name: Tag Docker image as latest for main branch
         run: docker tag house-innovations-housnav-web:${{ env.GIT_SHA }} house-innovations-housnav-web:latest
 
-      - name: Login to OpenShift image registry with Docker
+      - name: Login to Artifactory image registry with Docker
         uses: docker/login-action@v3
         with:
-          registry: ${{ secrets.OPENSHIFT_REGISTRY_NAME }}
-          username: ${{ secrets.OPENSHIFT_SERVICEACCOUNT_NAME }}
-          password: ${{ secrets.OPENSHIFT_SERVICEACCOUNT_TOKEN }}
+          registry: ${{ secrets.ARTIFACTORY_URL }}
+          password: ${{ secrets.ARTIFACTORY_SERVICEACCOUNT_USERNAME }}
+          username: ${{ secrets.ARTIFACTORY_SERVICEACCOUNT_PASSWORD }}
 
-      - name: Tag Docker image for OpenShift registry
-        run: docker tag house-innovations-housnav-web:${{ env.GIT_SHA }} ${{ secrets.OPENSHIFT_REGISTRY_REPOSITORY }}:${{ env.GIT_SHA }}
+      - name: Tag Docker image for Artifactory
+        run: docker tag house-innovations-housnav-web:${{ env.GIT_SHA }} ${{ secrets.ARTIFACTORY_URL }}/${{ secrets.ARTIFACTORY_REPOSITORY_NAME }}/house-innovations-housnav-web:${{ env.GIT_SHA }}
 
-      - name: Push Docker image to OpenShift registry
-        run: docker push ${{ secrets.OPENSHIFT_REGISTRY_REPOSITORY }}:${{ env.GIT_SHA }}
+      - name: Push Docker image to Artifactory
+        run: docker push ${{ secrets.ARTIFACTORY_URL }}/${{ secrets.ARTIFACTORY_REPOSITORY_NAME }}/house-innovations-housnav-web:${{ env.GIT_SHA }}
 
       - name: Login to OpenShift with CLI
         run: oc login --token=${{ secrets.OPENSHIFT_SERVICEACCOUNT_TOKEN }} --server=${{ secrets.OPENSHIFT_SERVER }}
 
-      - name: Export OpenShift Registry Repository
-        run: echo "OPENSHIFT_REGISTRY_REPOSITORY=${{ secrets.OPENSHIFT_REGISTRY_REPOSITORY }}" >> $GITHUB_ENV
+      - name: Export Artifactory Image Path
+        run: echo "ARTIFACTORY_IMAGE_PATH=${{ secrets.ARTIFACTORY_URL }}/${{ secrets.ARTIFACTORY_REPOSITORY_NAME }}/house-innovations-housnav-web" >> $GITHUB_ENV
 
       - name: Deploy Application in OpenShift
         run: envsubst < k8s/deployment.yaml | oc apply -f -

--- a/.github/workflows/docker-build-and-deploy.yml
+++ b/.github/workflows/docker-build-and-deploy.yml
@@ -32,8 +32,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ secrets.ARTIFACTORY_URL }}
-          password: ${{ secrets.ARTIFACTORY_SERVICEACCOUNT_USERNAME }}
-          username: ${{ secrets.ARTIFACTORY_SERVICEACCOUNT_PASSWORD }}
+          username: ${{ secrets.ARTIFACTORY_SERVICEACCOUNT_USERNAME }}
+          password: ${{ secrets.ARTIFACTORY_SERVICEACCOUNT_PASSWORD }}
 
       - name: Tag Docker image for Artifactory
         run: docker tag house-innovations-housnav-web:${{ env.GIT_SHA }} ${{ secrets.ARTIFACTORY_URL }}/${{ secrets.ARTIFACTORY_REPOSITORY_NAME }}/house-innovations-housnav-web:${{ env.GIT_SHA }}

--- a/.github/workflows/docker-build-and-deploy.yml
+++ b/.github/workflows/docker-build-and-deploy.yml
@@ -44,11 +44,10 @@ jobs:
       - name: Login to OpenShift with CLI
         run: oc login --token=${{ secrets.OPENSHIFT_SERVICEACCOUNT_TOKEN }} --server=${{ secrets.OPENSHIFT_SERVER }}
 
-      - name: Export Artifactory Image Path
-        run: echo "ARTIFACTORY_IMAGE_PATH=${{ secrets.ARTIFACTORY_URL }}/${{ secrets.ARTIFACTORY_REPOSITORY_NAME }}/house-innovations-housnav-web" >> $GITHUB_ENV
-
-      - name: Export imagePullSecretsName
-        run: echo "IMAGE_PULL_SECRET_NAME=${{ secrets.IMAGE_PULL_SECRET_NAME }}" >> $GITHUB_ENV
+      - name: Export environment variables for OpenShift
+        run: |
+          echo "ARTIFACTORY_IMAGE_PATH=${{ secrets.ARTIFACTORY_URL }}/${{ secrets.ARTIFACTORY_REPOSITORY_NAME }}/house-innovations-housnav-web" >> $GITHUB_ENV
+          echo "IMAGE_PULL_SECRET_NAME=${{ secrets.IMAGE_PULL_SECRET_NAME }}" >> $GITHUB_ENV
 
       - name: Deploy Application in OpenShift
         run: envsubst < k8s/deployment.yaml | oc apply -f -

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -14,7 +14,7 @@ spec:
       labels:
         app: house-innovations-housnav-web
     spec:
-      imagePullSecrets: ${IMAGE_PULL_SECRET_NAME}
+      serviceAccountName: ${IMAGE_PULL_SECRET_NAME}
       containers:
         - name: house-innovations-housnav-web
           image: ${ARTIFACTORY_IMAGE_PATH}:${GIT_SHA}

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: house-innovations-housnav-web
     spec:
       imagePullSecrets: 
-        - name: artifacts-pull-github-nbhcig
+        - name: ${IMAGE_PULL_SECRET_NAME}
       containers:
         - name: house-innovations-housnav-web
           image: ${ARTIFACTORY_IMAGE_PATH}:${GIT_SHA}

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -14,7 +14,7 @@ spec:
       labels:
         app: house-innovations-housnav-web
     spec:
-      serviceAccountName: github-actions
+      imagePullSecrets: ${IMAGE_PULL_SECRET_NAME}
       containers:
         - name: house-innovations-housnav-web
           image: ${ARTIFACTORY_IMAGE_PATH}:${GIT_SHA}

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -14,7 +14,8 @@ spec:
       labels:
         app: house-innovations-housnav-web
     spec:
-      serviceAccountName: ${IMAGE_PULL_SECRET_NAME}
+      imagePullSecrets: 
+        - name: artifacts-pull-github-nbhcig
       containers:
         - name: house-innovations-housnav-web
           image: ${ARTIFACTORY_IMAGE_PATH}:${GIT_SHA}

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: github-actions
       containers:
         - name: house-innovations-housnav-web
-          image: ${OPENSHIFT_REGISTRY_REPOSITORY}:${GIT_SHA}
+          image: ${ARTIFACTORY_IMAGE_PATH}:${GIT_SHA}
           ports:
             - containerPort: 3000
           livenessProbe:


### PR DESCRIPTION
[HOUSNAV-7](https://hous-bssb.atlassian.net/browse/HOUSNAV-7)

## Overview & Purpose
Rewrite the Build and Deploy CI/CD to use Artifactory instead of the OpenShift Registry

## Summary of Changes
Update the secrets that enable connection to Artifactory
Update the image name for Kubernetes deployment.

## Testing

## Notes & Resources

## Checklist
- [ ] I have written or updated vitests for this work
- [ ] I have reviewed the [accessibility guidelines](https://digital.gov.bc.ca/wcag/home/) relevant to this work
- [ ] I have reviewed this work with at least one screen reader (when applicable)
- [ ] I have added/updated any related documentation
