### PR TITLE
HOUSNAV-31: Step Tracker

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -56,3 +56,8 @@ p {
 .u-hidden {
   display: none;
 }
+.u-ellipsis {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/apps/web/components/step-tracker/StepTracker.css
+++ b/apps/web/components/step-tracker/StepTracker.css
@@ -1,0 +1,34 @@
+.web-StepTracker {
+  padding: var(--step-tracker-padding);
+}
+
+.web-StepTracker--MobileToggle {
+  display: var(--step-tracker-mobile-toggle-display);
+}
+
+.web-StepTracker--MobileToggle .ui-Icon {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.web-StepTracker--Mobile {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: var(--surface-color-background-white);
+  padding: var(--layout-padding-medium);
+  outline: none;
+  display: flex;
+  flex-direction: column;
+  overflow: auto;
+}
+
+.web-StepTracker--MobileClose {
+  align-self: flex-end;
+}
+
+.web-StepTracker--TabletUp {
+  display: var(--step-tracker-tablet-up-display);
+}

--- a/apps/web/components/step-tracker/StepTracker.css
+++ b/apps/web/components/step-tracker/StepTracker.css
@@ -18,15 +18,11 @@
   left: 0;
   right: 0;
   background-color: var(--surface-color-background-white);
-  padding: var(--layout-padding-medium);
   outline: none;
   display: flex;
   flex-direction: column;
   overflow: auto;
-}
-
-.web-StepTracker--MobileClose {
-  align-self: flex-end;
+  padding-top: var(--layout-padding-64);
 }
 
 .web-StepTracker--TabletUp {

--- a/apps/web/components/step-tracker/StepTracker.test.tsx
+++ b/apps/web/components/step-tracker/StepTracker.test.tsx
@@ -5,7 +5,7 @@ import {
   GET_TESTID_BUTTON,
   TESTID_STEP_TRACKER,
   TESTID_STEP_TRACKER_MOBILE,
-  TESTID_STEP_TRACKER_MOBILE_BUTTON_CLOSE,
+  TESTID_BUTTON_MODAL_CLOSE,
   TESTID_STEP_TRACKER_MOBILE_BUTTON_OPEN,
 } from "@repo/constants/src/testids";
 // local
@@ -40,7 +40,7 @@ describe("StepTracker", () => {
     });
 
     expect(
-      getByTestId(GET_TESTID_BUTTON(TESTID_STEP_TRACKER_MOBILE_BUTTON_CLOSE)),
+      getByTestId(GET_TESTID_BUTTON(TESTID_BUTTON_MODAL_CLOSE)),
     ).toBeInTheDocument();
   });
 });

--- a/apps/web/components/step-tracker/StepTracker.test.tsx
+++ b/apps/web/components/step-tracker/StepTracker.test.tsx
@@ -1,0 +1,46 @@
+// 3rd party
+import { describe, expect, it } from "vitest";
+// repo
+import {
+  GET_TESTID_BUTTON,
+  TESTID_STEP_TRACKER,
+  TESTID_STEP_TRACKER_MOBILE,
+  TESTID_STEP_TRACKER_MOBILE_BUTTON_CLOSE,
+  TESTID_STEP_TRACKER_MOBILE_BUTTON_OPEN,
+} from "@repo/constants/src/testids";
+// local
+import StepTracker from "./StepTracker";
+import { renderWithWalkthroughProvider } from "../../tests/utils";
+import { act, waitFor } from "@testing-library/react";
+
+describe("StepTracker", () => {
+  it("renders", () => {
+    const { getByTestId } = renderWithWalkthroughProvider({
+      ui: <StepTracker />,
+    });
+
+    expect(getByTestId(TESTID_STEP_TRACKER)).toBeInTheDocument();
+  });
+  it("mobile modal appears when button clicked", async () => {
+    const { user, getByTestId, queryByTestId } = renderWithWalkthroughProvider({
+      ui: <StepTracker />,
+    });
+
+    const button = getByTestId(
+      GET_TESTID_BUTTON(TESTID_STEP_TRACKER_MOBILE_BUTTON_OPEN),
+    );
+    expect(button).toBeInTheDocument();
+    expect(queryByTestId(TESTID_STEP_TRACKER_MOBILE)).not.toBeInTheDocument();
+    await act(async () => {
+      await user.click(button);
+    });
+
+    await waitFor(() => {
+      expect(getByTestId(TESTID_STEP_TRACKER_MOBILE)).toBeInTheDocument();
+    });
+
+    expect(
+      getByTestId(GET_TESTID_BUTTON(TESTID_STEP_TRACKER_MOBILE_BUTTON_CLOSE)),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/step-tracker/StepTracker.tsx
+++ b/apps/web/components/step-tracker/StepTracker.tsx
@@ -1,0 +1,58 @@
+"use client";
+// 3rd party
+import { JSX, useState } from "react";
+import { Dialog, Modal } from "react-aria-components";
+// repo
+import {
+  TESTID_STEP_TRACKER,
+  TESTID_STEP_TRACKER_MOBILE,
+  TESTID_STEP_TRACKER_MOBILE_BUTTON_CLOSE,
+  TESTID_STEP_TRACKER_MOBILE_BUTTON_OPEN,
+} from "@repo/constants/src/testids";
+import Button from "@repo/ui/button";
+import Icon from "@repo/ui/icon";
+// local
+import StepTrackerItems from "./StepTrackerItems";
+import "./StepTracker.css";
+
+const StepTracker = (): JSX.Element => {
+  const [stepTrackerIsOpen, setStepTrackerIsOpen] = useState(false);
+  return (
+    <section className="web-StepTracker" data-testid={TESTID_STEP_TRACKER}>
+      <Button
+        aria-label="Open the step tracker"
+        variant="tertiary"
+        className="web-StepTracker--MobileToggle"
+        onPress={() => setStepTrackerIsOpen(true)}
+        data-testid={TESTID_STEP_TRACKER_MOBILE_BUTTON_OPEN}
+      >
+        Steps <Icon type="accountTree" />
+      </Button>
+      <Modal
+        isDismissable
+        isOpen={stepTrackerIsOpen}
+        onOpenChange={setStepTrackerIsOpen}
+        data-testid={TESTID_STEP_TRACKER_MOBILE}
+      >
+        <Dialog className="web-StepTracker--Mobile">
+          <Button
+            aria-label="Close the step tracker"
+            isIconButton
+            variant="secondary"
+            className="web-StepTracker--MobileClose"
+            onPress={() => setStepTrackerIsOpen(false)}
+            data-testid={TESTID_STEP_TRACKER_MOBILE_BUTTON_CLOSE}
+          >
+            <Icon type="close" />
+          </Button>
+          <StepTrackerItems />
+        </Dialog>
+      </Modal>
+      <div className="web-StepTracker--TabletUp">
+        <StepTrackerItems />
+      </div>
+    </section>
+  );
+};
+
+export default StepTracker;

--- a/apps/web/components/step-tracker/StepTracker.tsx
+++ b/apps/web/components/step-tracker/StepTracker.tsx
@@ -19,7 +19,7 @@ import { ID_STEP_TRACKER_TITLE } from "@repo/constants/src/ids";
 const StepTracker = (): JSX.Element => {
   const [stepTrackerIsOpen, setStepTrackerIsOpen] = useState(false);
   return (
-    <section className="web-StepTracker" data-testid={TESTID_STEP_TRACKER}>
+    <div className="web-StepTracker" data-testid={TESTID_STEP_TRACKER}>
       <Button
         aria-label="Open the step tracker"
         variant="tertiary"
@@ -49,7 +49,7 @@ const StepTracker = (): JSX.Element => {
       <div className="web-StepTracker--TabletUp">
         <StepTrackerItems />
       </div>
-    </section>
+    </div>
   );
 };
 

--- a/apps/web/components/step-tracker/StepTracker.tsx
+++ b/apps/web/components/step-tracker/StepTracker.tsx
@@ -14,6 +14,7 @@ import Icon from "@repo/ui/icon";
 // local
 import StepTrackerItems from "./StepTrackerItems";
 import "./StepTracker.css";
+import { ID_STEP_TRACKER_TITLE } from "@repo/constants/src/ids";
 
 const StepTracker = (): JSX.Element => {
   const [stepTrackerIsOpen, setStepTrackerIsOpen] = useState(false);
@@ -34,7 +35,10 @@ const StepTracker = (): JSX.Element => {
         onOpenChange={setStepTrackerIsOpen}
         data-testid={TESTID_STEP_TRACKER_MOBILE}
       >
-        <Dialog className="web-StepTracker--Mobile">
+        <Dialog
+          className="web-StepTracker--Mobile"
+          aria-labelledby={ID_STEP_TRACKER_TITLE}
+        >
           <Button
             aria-label="Close the step tracker"
             isIconButton
@@ -45,7 +49,7 @@ const StepTracker = (): JSX.Element => {
           >
             <Icon type="close" />
           </Button>
-          <StepTrackerItems />
+          <StepTrackerItems id={ID_STEP_TRACKER_TITLE} />
         </Dialog>
       </Modal>
       <div className="web-StepTracker--TabletUp">

--- a/apps/web/components/step-tracker/StepTracker.tsx
+++ b/apps/web/components/step-tracker/StepTracker.tsx
@@ -6,10 +6,10 @@ import { Dialog, Modal } from "react-aria-components";
 import {
   TESTID_STEP_TRACKER,
   TESTID_STEP_TRACKER_MOBILE,
-  TESTID_STEP_TRACKER_MOBILE_BUTTON_CLOSE,
   TESTID_STEP_TRACKER_MOBILE_BUTTON_OPEN,
 } from "@repo/constants/src/testids";
 import Button from "@repo/ui/button";
+import ButtonModalClose from "@repo/ui/button-modal-close";
 import Icon from "@repo/ui/icon";
 // local
 import StepTrackerItems from "./StepTrackerItems";
@@ -39,16 +39,10 @@ const StepTracker = (): JSX.Element => {
           className="web-StepTracker--Mobile"
           aria-labelledby={ID_STEP_TRACKER_TITLE}
         >
-          <Button
-            aria-label="Close the step tracker"
-            isIconButton
-            variant="secondary"
-            className="web-StepTracker--MobileClose"
+          <ButtonModalClose
+            label="Close the step tracker"
             onPress={() => setStepTrackerIsOpen(false)}
-            data-testid={TESTID_STEP_TRACKER_MOBILE_BUTTON_CLOSE}
-          >
-            <Icon type="close" />
-          </Button>
+          />
           <StepTrackerItems id={ID_STEP_TRACKER_TITLE} />
         </Dialog>
       </Modal>

--- a/apps/web/components/step-tracker/StepTrackerItems.css
+++ b/apps/web/components/step-tracker/StepTrackerItems.css
@@ -1,0 +1,102 @@
+.web-StepTrackerItems--Header {
+  font: var(--typography-bold-large-body);
+  padding-right: var(--layout-padding-10);
+  padding-bottom: var(--layout-padding-10);
+}
+
+.web-StepTrackerItems--Section {
+  list-style-type: none;
+}
+
+.web-StepTrackerItems--SectionTitle {
+  padding: var(--layout-padding-small);
+  display: flex;
+  align-items: center;
+  gap: var(--layout-padding-12);
+  font: var(--typography-regular-body);
+  border-left: var(--layout-border-width-large) solid transparent;
+}
+
+.-currentSection .web-StepTrackerItems--SectionTitle {
+  color: var(--typography-color-primary);
+  font: var(--typography-bold-body);
+  background-color: var(--theme-blue-10);
+  border-left-color: var(--surface-color-background-dark-blue);
+}
+
+.-skippedSection .web-StepTrackerItems--SectionTitle {
+  color: var(--typography-color-disabled);
+  text-decoration: line-through;
+}
+
+.web-StepTrackerItems--SectionTitleToggleIcon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  transform: rotate(-90deg);
+  transition: transform var(--transition-medium);
+  color: var(--icons-color-disabled);
+}
+
+.-currentSection .web-StepTrackerItems--SectionTitleToggleIcon {
+  color: var(--typography-color-primary);
+  transform: rotate(0);
+}
+
+.web-StepTrackerItems--SectionTitleCompleteIcon {
+  margin-left: auto;
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  color: var(--icons-color-success);
+}
+
+.web-StepTrackerItems--SectionBody {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: 250ms grid-template-rows ease;
+}
+
+.-currentSection .web-StepTrackerItems--SectionBody {
+  grid-template-rows: 1fr;
+}
+
+.web-StepTrackerItems--SectionBody > ol {
+  overflow: hidden;
+}
+
+.web-StepTrackerItems--SectionItem {
+  list-style-type: none;
+  color: var(--typography-color-secondary);
+  padding: var(--layout-padding-small);
+  margin-left: var(--layout-margin-xxlarge);
+  border-left: var(--layout-border-width-small) solid
+    var(--surface-color-border-medium);
+  display: flex;
+  align-items: center;
+  gap: var(--layout-padding-small);
+}
+
+.web-StepTrackerItems--SectionItem.-currentItem {
+  background-color: var(--theme-gray-10);
+}
+
+.web-StepTrackerItems--SectionItem h4 {
+  font: var(--typography-regular-small-body);
+}
+
+.web-StepTrackerItems--SectionItem.-currentItem h4 {
+  font: var(--typography-bold-small-body);
+}
+
+.web-StepTrackerItems--SectionItem.-skippedItem h4 {
+  color: var(--typography-color-disabled);
+  text-decoration: line-through;
+}
+
+.web-StepTrackerItems--SectionItem .ui-Icon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  color: var(--icons-color-success);
+}

--- a/apps/web/components/step-tracker/StepTrackerItems.css
+++ b/apps/web/components/step-tracker/StepTrackerItems.css
@@ -1,5 +1,6 @@
 .web-StepTrackerItems--Header {
   font: var(--typography-bold-large-body);
+  padding-left: var(--step-tracker-heading-padding-left);
   padding-right: var(--layout-padding-10);
   padding-bottom: var(--layout-padding-10);
 }

--- a/apps/web/components/step-tracker/StepTrackerItems.test.tsx
+++ b/apps/web/components/step-tracker/StepTrackerItems.test.tsx
@@ -1,0 +1,17 @@
+// 3rd party
+import { describe, expect, it } from "vitest";
+// repo
+import { TESTID_STEP_TRACKER_ITEMS } from "@repo/constants/src/testids";
+// local
+import StepTrackerItems from "./StepTrackerItems";
+import { renderWithWalkthroughProvider } from "../../tests/utils";
+
+describe("StepTrackerItems", () => {
+  it("renders", () => {
+    const { getByTestId } = renderWithWalkthroughProvider({
+      ui: <StepTrackerItems />,
+    });
+
+    expect(getByTestId(TESTID_STEP_TRACKER_ITEMS)).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/step-tracker/StepTrackerItems.tsx
+++ b/apps/web/components/step-tracker/StepTrackerItems.tsx
@@ -8,8 +8,9 @@ import Icon from "@repo/ui/icon";
 import { parseStringToComponents } from "../../utils/string";
 import { useWalkthroughState } from "../../stores/WalkthroughRootStore";
 import "./StepTrackerItems.css";
+import { TESTID_STEP_TRACKER_ITEMS } from "@repo/constants/src/testids";
 
-const StepTrackerItems = observer((): JSX.Element => {
+const StepTrackerItems = observer(({ id }: { id?: string }): JSX.Element => {
   const {
     navigationStore: {
       currentSectionId,
@@ -26,7 +27,13 @@ const StepTrackerItems = observer((): JSX.Element => {
 
   return (
     <>
-      <h2 className="web-StepTrackerItems--Header">Steps</h2>
+      <h2
+        className="web-StepTrackerItems--Header"
+        id={id}
+        data-testid={TESTID_STEP_TRACKER_ITEMS}
+      >
+        Steps
+      </h2>
       <ol>
         {Object.keys(sections).map((sectionId) => {
           const section = sections[sectionId];

--- a/apps/web/components/step-tracker/StepTrackerItems.tsx
+++ b/apps/web/components/step-tracker/StepTrackerItems.tsx
@@ -1,0 +1,101 @@
+"use client";
+// 3rd party
+import { JSX } from "react";
+import { observer } from "mobx-react-lite";
+// repo
+import Icon from "@repo/ui/icon";
+// local
+import { parseStringToComponents } from "../../utils/string";
+import { useWalkthroughState } from "../../stores/WalkthroughRootStore";
+import "./StepTrackerItems.css";
+
+const StepTrackerItems = observer((): JSX.Element => {
+  const {
+    navigationStore: {
+      currentSectionId,
+      currentItemId,
+      itemIsComplete,
+      sectionIsComplete,
+      itemWasSkipped,
+      sectionWasSkipped,
+    },
+    walkthroughData: { sections },
+    getQuestionTextByQuestionId,
+    currentResult,
+  } = useWalkthroughState();
+
+  return (
+    <>
+      <h2 className="web-StepTrackerItems--Header">Steps</h2>
+      <ol>
+        {Object.keys(sections).map((sectionId) => {
+          const section = sections[sectionId];
+          if (!section) {
+            return null;
+          }
+          const sectionComplete = sectionIsComplete(sectionId);
+          const sectionSkipped = sectionWasSkipped(sectionId);
+
+          return (
+            <li
+              key={sectionId}
+              className={`web-StepTrackerItems--Section ${sectionId === currentSectionId ? "-currentSection" : ""} ${sectionSkipped ? "-skippedSection" : ""}`}
+            >
+              <h3 className="web-StepTrackerItems--SectionTitle">
+                <Icon
+                  type="expandMore"
+                  className="web-StepTrackerItems--SectionTitleToggleIcon"
+                />
+                <span className="u-ellipsis">{section.sectionTitle}</span>
+                {sectionComplete && (
+                  <Icon
+                    type="check"
+                    className="web-StepTrackerItems--SectionTitleCompleteIcon"
+                  />
+                )}
+              </h3>
+              <div className="web-StepTrackerItems--SectionBody">
+                <ol>
+                  {section.sectionQuestions.map((itemId) => {
+                    const itemComplete = itemIsComplete(itemId);
+                    const itemSkipped = itemWasSkipped(
+                      itemId,
+                      sectionId,
+                      sectionComplete,
+                    );
+
+                    return (
+                      <li
+                        key={itemId}
+                        className={`web-StepTrackerItems--SectionItem ${itemId === currentItemId ? "-currentItem" : ""} ${itemSkipped ? "-skippedItem" : ""}`}
+                      >
+                        <h4 className="u-ellipsis">
+                          {parseStringToComponents(
+                            getQuestionTextByQuestionId(itemId),
+                            undefined,
+                            true,
+                          )}
+                        </h4>
+                        {itemComplete && <Icon type="check" />}
+                      </li>
+                    );
+                  })}
+                </ol>
+              </div>
+            </li>
+          );
+        })}
+        <li
+          key="results"
+          className={`web-StepTrackerItems--Section ${currentResult ? "-currentSection" : ""}`}
+        >
+          <h3 className="web-StepTrackerItems--SectionTitle">
+            <span className="u-ellipsis">Results</span>
+          </h3>
+        </li>
+      </ol>
+    </>
+  );
+});
+
+export default StepTrackerItems;

--- a/apps/web/components/walkthrough-footer/WalkthroughFooter.css
+++ b/apps/web/components/walkthrough-footer/WalkthroughFooter.css
@@ -2,7 +2,7 @@
   background-color: var(--surface-color-background-white);
   display: flex;
   justify-content: space-between;
-  padding: var(--layout-padding-smedium) var(--layout-padding-xlarge);
+  padding: var(--layout-padding-14) var(--layout-padding-xlarge);
   border-top: var(--layout-border-width-small) solid
     var(--surface-color-border-default);
 }

--- a/apps/web/components/walkthrough/Walkthrough.css
+++ b/apps/web/components/walkthrough/Walkthrough.css
@@ -2,15 +2,16 @@
   height: calc(100dvh - var(--header-height));
   overflow: hidden;
   display: grid;
+  grid-template-rows: 48px 1fr;
 }
 
-.web-Walkthrough--SideNav {
-  display: none;
-  border-right: var(--layout-border-width-small) solid
+.web-Walkthrough--StepTracker {
+  border-bottom: var(--layout-border-width-small) solid
     var(--surface-color-border-default);
 }
 
 .web-Walkthrough--Content {
+  order: 1;
   display: grid;
   grid-template-rows: auto 67px;
   overflow: hidden;
@@ -25,10 +26,13 @@
 /* TABLET - 608px */
 @media (min-width: 38rem) {
   .web-Walkthrough {
+    grid-template-rows: auto;
     grid-template-columns: var(--walkthrough-side-nav-width) 1fr;
   }
 
-  .web-Walkthrough--SideNav {
-    display: block;
+  .web-Walkthrough--StepTracker {
+    border-bottom: none;
+    border-right: var(--layout-border-width-small) solid
+      var(--surface-color-border-default);
   }
 }

--- a/apps/web/components/walkthrough/Walkthrough.tsx
+++ b/apps/web/components/walkthrough/Walkthrough.tsx
@@ -49,7 +49,7 @@ const Walkthrough = observer((): JSX.Element => {
 
   return (
     <div className="web-Walkthrough" data-testid={TESTID_WALKTHROUGH}>
-      <div className="web-Walkthrough--Content">
+      <section className="web-Walkthrough--Content">
         {currentResult ? (
           <Result displayMessage={currentResult.resultDisplayMessage} />
         ) : (
@@ -63,10 +63,10 @@ const Walkthrough = observer((): JSX.Element => {
           </Form>
         )}
         <WalkthroughFooter />
-      </div>
-      <div className="web-Walkthrough--StepTracker">
+      </section>
+      <section className="web-Walkthrough--StepTracker">
         <StepTracker />
-      </div>
+      </section>
     </div>
   );
 });

--- a/apps/web/components/walkthrough/Walkthrough.tsx
+++ b/apps/web/components/walkthrough/Walkthrough.tsx
@@ -10,6 +10,7 @@ import { ID_QUESTION_FORM } from "@repo/constants/src/ids";
 import Question from "../question/Question";
 import WalkthroughFooter from "../walkthrough-footer/WalkthroughFooter";
 import Result from "../result/Result";
+import StepTracker from "../step-tracker/StepTracker";
 import { useWalkthroughState } from "../../stores/WalkthroughRootStore";
 import "./Walkthrough.css";
 
@@ -48,7 +49,6 @@ const Walkthrough = observer((): JSX.Element => {
 
   return (
     <div className="web-Walkthrough" data-testid={TESTID_WALKTHROUGH}>
-      <div className="web-Walkthrough--SideNav"></div>
       <div className="web-Walkthrough--Content">
         {currentResult ? (
           <Result displayMessage={currentResult.resultDisplayMessage} />
@@ -63,6 +63,9 @@ const Walkthrough = observer((): JSX.Element => {
           </Form>
         )}
         <WalkthroughFooter />
+      </div>
+      <div className="web-Walkthrough--StepTracker">
+        <StepTracker />
       </div>
     </div>
   );

--- a/apps/web/stores/AnswerStore.ts
+++ b/apps/web/stores/AnswerStore.ts
@@ -26,9 +26,10 @@ export class AnswerStore {
 
   answers: AnswerState = {};
 
-  constructor(rootStore: WalkthroughRootStore) {
+  constructor(rootStore: WalkthroughRootStore, initialAnswers?: AnswerState) {
     makeAutoObservable(this);
     this.rootStore = rootStore;
+    if (initialAnswers) this.answers = initialAnswers;
   }
 
   handleVariableItem = (

--- a/apps/web/stores/AnswerStore.ts
+++ b/apps/web/stores/AnswerStore.ts
@@ -65,6 +65,8 @@ export class AnswerStore {
   setAnswerValueOnChange = (value: AnswerTypes, questionId: string) => {
     this.eraseAnswersAfterCurrentItem();
 
+    this.rootStore.navigationStore.farthestItemId = questionId;
+
     this.answers[questionId] = value;
   };
 
@@ -74,6 +76,8 @@ export class AnswerStore {
       currentQuestionAsMultipleChoiceMultiple,
       getPossibleAnswersFromMultipleChoiceMultiple,
     } = this.rootStore;
+
+    this.rootStore.navigationStore.farthestItemId = currentItemId;
 
     // set default value for new item if it's a multiple choice multiple question and isNotRequired
     // we want to be able to reference the answer object in the future even if the user doesn't answer it

--- a/apps/web/stores/NavigationStore.ts
+++ b/apps/web/stores/NavigationStore.ts
@@ -166,6 +166,7 @@ export class NavigationStore {
     );
   };
 
+  // an item (aka question) is skipped if it was not answered, and the section is complete, OR we are past the item in the section
   itemWasSkipped = (
     itemId: string,
     sectionId: string,
@@ -187,6 +188,7 @@ export class NavigationStore {
     );
   };
 
+  // helper function used in sectionIsComplete and sectionWasSkipped for determining if we are past the section
   pastSection = (sectionId: string) => {
     if (!this.farthestItemId) return false;
     const sections = Object.entries(this.rootStore.walkthroughData.sections);
@@ -195,9 +197,11 @@ export class NavigationStore {
       section.sectionQuestions.includes(this.farthestItemId),
     );
 
+    // -1 case covers the case when the user is on the results page because the farthestItemId is set to a result, which don't appear in the sections
     return farthestSectionIndex === -1 || farthestSectionIndex > sectionIndex;
   };
 
+  // a section is complete if the user is past the section and the section has at least one question answered
   sectionIsComplete = (sectionId: string): boolean => {
     const section = this.rootStore.walkthroughData.sections[sectionId];
     return section && this.farthestItemId && this.pastSection(sectionId)
@@ -208,6 +212,7 @@ export class NavigationStore {
       : false;
   };
 
+  // a section is skipped if the user is past the section and the section is not complete
   sectionWasSkipped = (sectionId: string): boolean => {
     return this.pastSection(sectionId) && !this.sectionIsComplete(sectionId);
   };

--- a/apps/web/stores/WalkthroughRootStore.ts
+++ b/apps/web/stores/WalkthroughRootStore.ts
@@ -5,7 +5,6 @@ import { makeAutoObservable, toJS } from "mobx";
 import {
   isWalkthroughItemTypeMultiChoice,
   isWalkthroughItemTypeMultiChoiceMultiple,
-  QuestionBaseData,
   QuestionDisplayData,
   QuestionMultipleChoiceData,
   QuestionMultipleChoiceSelectMultipleData,
@@ -160,21 +159,18 @@ export class WalkthroughRootStore {
   };
 
   getQuestionAnswerValueDisplay = (questionId: string): string => {
-    const answer = this.answerStore.answers[questionId];
-    const { possibleAnswers } = this.walkthroughData.questions[
-      questionId
-    ] as QuestionBaseData;
-    if (!possibleAnswers) return "";
+    const question = this.getQuestionAsDisplayType(questionId);
+    if (!question) return "";
 
+    const answer = this.answerStore.answers[questionId];
     if (isString(answer)) {
-      const answerValue = possibleAnswers.find(
+      const answerValue = question.possibleAnswers.find(
         (possibleAnswer) => possibleAnswer.answerValue === answer,
       );
       const displayValue =
         answerValue?.answerValueDisplay ?? answerValue?.answerDisplayText;
       return displayValue ?? "";
     }
-    console.warn(`Unsupported "answer-value" type for question ${questionId}.`);
     return "";
   };
 

--- a/apps/web/stores/WalkthroughRootStore.ts
+++ b/apps/web/stores/WalkthroughRootStore.ts
@@ -16,7 +16,7 @@ import {
 import { NEXT_NAVIGATION_ID_ERROR } from "@repo/constants/src/constants";
 // local
 import { NavigationStore } from "./NavigationStore";
-import { AnswerStore } from "./AnswerStore";
+import { AnswerState, AnswerStore } from "./AnswerStore";
 import { getPossibleAnswers } from "../utils/logic/showAnswer";
 import { isString } from "../utils/typeChecking";
 
@@ -26,12 +26,15 @@ export class WalkthroughRootStore {
 
   walkthroughData: WalkthroughJSONType = {} as WalkthroughJSONType;
 
-  constructor(walkthroughData: WalkthroughJSONType) {
+  constructor(
+    walkthroughData: WalkthroughJSONType,
+    initialAnswers?: AnswerState,
+  ) {
     makeAutoObservable(this);
     this.walkthroughData = walkthroughData;
 
     this.navigationStore = new NavigationStore(this);
-    this.answerStore = new AnswerStore(this);
+    this.answerStore = new AnswerStore(this, initialAnswers);
 
     // set first question as the first question of the starting section
     if (walkthroughData?.info?.startingSectionId && walkthroughData.sections) {
@@ -207,8 +210,9 @@ export class WalkthroughRootStore {
 
 export const CreateWalkthroughStore = (
   walkthroughData: WalkthroughJSONType,
+  initialAnswers?: AnswerState,
 ) => {
-  return new WalkthroughRootStore(walkthroughData);
+  return new WalkthroughRootStore(walkthroughData, initialAnswers);
 };
 
 // create context

--- a/apps/web/stores/WalkthroughRootStore.ts
+++ b/apps/web/stores/WalkthroughRootStore.ts
@@ -175,6 +175,19 @@ export class WalkthroughRootStore {
     return "";
   };
 
+  getQuestionTextByQuestionId = (questionId: string) => {
+    const question = this.walkthroughData.questions[questionId];
+
+    if (!question || !("questionText" in question)) {
+      console.warn(
+        `Question with id ${questionId} not found or has no questionText.`,
+      );
+      return "";
+    }
+
+    return question.questionText;
+  };
+
   questionIsVariable = (questionId: string) => {
     const question = this.walkthroughData.questions[questionId];
     return question && VariableToSetPropertyName in question;

--- a/apps/web/tests/utils.tsx
+++ b/apps/web/tests/utils.tsx
@@ -8,23 +8,26 @@ import {
   WalkthroughStateContext,
 } from "../stores/WalkthroughRootStore";
 import { WalkthroughJSONType } from "@repo/data/useWalkthroughData";
+import { AnswerState } from "../stores/AnswerStore";
 
 interface RenderWithWalkthroughProviderOptions extends RenderOptions {
   ui: ReactElement;
   data?: WalkthroughJSONType;
   options?: Omit<RenderOptions, "wrapper">;
+  initialAnswers?: AnswerState;
 }
 
 export const renderWithWalkthroughProvider = ({
   ui,
   data,
   options,
+  initialAnswers,
 }: RenderWithWalkthroughProviderOptions) => {
-  // get data
-  const walkthroughData = useWalkthroughTestData();
-
   // create store
-  const WalkthroughStore = CreateWalkthroughStore(data || walkthroughData);
+  const WalkthroughStore = CreateWalkthroughStore(
+    data || useWalkthroughTestData(),
+    initialAnswers,
+  );
 
   return {
     user: userEvent.setup(),

--- a/apps/web/utils/__snapshots__/string.test.tsx.snap
+++ b/apps/web/utils/__snapshots__/string.test.tsx.snap
@@ -1,0 +1,19 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`string > getAnswerValueDisplay: no displayValue 1`] = `
+<div>
+  <span
+    aria-label="blank"
+  >
+    _____
+  </span>
+</div>
+`;
+
+exports[`string > getAnswerValueDisplay: no questionId 1`] = `<AnswerDisplayValuePlaceholder />`;
+
+exports[`string > getAnswerValueDisplay: with displayValue 1`] = `
+<div>
+  Yes
+</div>
+`;

--- a/apps/web/utils/string.test.tsx
+++ b/apps/web/utils/string.test.tsx
@@ -4,8 +4,17 @@ import { JSX } from "react";
 // repo
 import { getQuestion } from "@repo/data/useWalkthroughTestData";
 // local
-import { getStringFromComponents, parseStringToComponents } from "./string";
+import {
+  getStringFromComponents,
+  parseStringToComponents,
+  getAnswerValueDisplay,
+} from "./string";
 import { isArray } from "./typeChecking";
+import { renderWithWalkthroughProvider } from "../tests/utils";
+
+const AnswerValueTestComponent = ({ questionId }: { questionId?: string }) => {
+  return <>{getAnswerValueDisplay(questionId)}</>;
+};
 
 describe("string", () => {
   /*
@@ -149,5 +158,27 @@ describe("string", () => {
     const boolean = true;
     const result = getStringFromComponents(boolean);
     expect(result).toBe("");
+  });
+  /*
+   * getAnswerValueDisplay
+   */
+  it("getAnswerValueDisplay: no questionId", () => {
+    const result = getAnswerValueDisplay();
+    expect(result).toMatchSnapshot();
+  });
+  it("getAnswerValueDisplay: no displayValue", () => {
+    const { container } = renderWithWalkthroughProvider({
+      ui: <AnswerValueTestComponent questionId={"test"} />,
+    });
+    expect(container).toMatchSnapshot();
+  });
+  it("getAnswerValueDisplay: with displayValue", () => {
+    const { container } = renderWithWalkthroughProvider({
+      ui: <AnswerValueTestComponent questionId={"P01"} />,
+      initialAnswers: {
+        P01: "yes",
+      },
+    });
+    expect(container).toMatchSnapshot();
   });
 });

--- a/apps/web/utils/string.tsx
+++ b/apps/web/utils/string.tsx
@@ -54,10 +54,15 @@ type CustomHandler = (section: string) => void;
 export const parseStringToComponents = (
   html: string,
   customHandler?: CustomHandler,
+  ignoreComponentMarkup?: boolean,
 ) => {
   const options = {
     replace: (domNode: DOMNode) => {
-      if (domNode instanceof Element && domNode.attribs) {
+      if (
+        domNode instanceof Element &&
+        domNode.attribs &&
+        !ignoreComponentMarkup
+      ) {
         const props = attributesToProps(domNode.attribs);
         let term = domToReact(domNode.children as DOMNode[]) as string;
         try {
@@ -156,6 +161,12 @@ export const parseStringToComponents = (
             return <span>{displayValue}</span>;
           }
         }
+      } else if (
+        domNode instanceof Element &&
+        domNode.attribs &&
+        ignoreComponentMarkup
+      ) {
+        return <>{domToReact(domNode.children as DOMNode[], options)}</>;
       }
     },
   };

--- a/apps/web/utils/string.tsx
+++ b/apps/web/utils/string.tsx
@@ -14,7 +14,10 @@ import {
   TooltipGlossaryData,
 } from "@repo/data/useGlossaryData";
 import ModalSide from "@repo/ui/modal-side";
-import { ANSWER_DISPLAY_VALUE_PLACEHOLDER } from "@repo/constants/src/constants";
+import {
+  ANSWER_DISPLAY_VALUE_PLACEHOLDER,
+  ANSWER_DISPLAY_VALUE_PLACEHOLDER_A11Y,
+} from "@repo/constants/src/constants";
 // local
 import DefinedTerm, {
   DefinedTermProps,
@@ -177,13 +180,25 @@ export const parseStringToComponents = (
 const getAnswerValueDisplay = (questionId?: string) => {
   if (!questionId) {
     console.warn("Missing question ID - incorrect json data.");
-    return ANSWER_DISPLAY_VALUE_PLACEHOLDER;
+    return (
+      <span aria-label={ANSWER_DISPLAY_VALUE_PLACEHOLDER_A11Y}>
+        ANSWER_DISPLAY_VALUE_PLACEHOLDER
+      </span>
+    );
   }
 
   const { getQuestionAnswerValueDisplay } = useWalkthroughState();
   const displayValue = getQuestionAnswerValueDisplay(questionId);
 
-  return <>{displayValue || ANSWER_DISPLAY_VALUE_PLACEHOLDER}</>;
+  if (!displayValue) {
+    return (
+      <span aria-label={ANSWER_DISPLAY_VALUE_PLACEHOLDER_A11Y}>
+        {ANSWER_DISPLAY_VALUE_PLACEHOLDER}
+      </span>
+    );
+  }
+
+  return <>{displayValue}</>;
 };
 
 export const getStringFromComponents = (node: ReactNode): string => {

--- a/apps/web/utils/string.tsx
+++ b/apps/web/utils/string.tsx
@@ -189,11 +189,11 @@ export const getAnswerValueDisplay = (questionId?: string) => {
   }
 
   const { getQuestionAnswerValueDisplay } = useWalkthroughState();
-  try {
-    const displayValue = getQuestionAnswerValueDisplay(questionId);
+  const displayValue = getQuestionAnswerValueDisplay(questionId);
+
+  if (displayValue) {
     return <>{displayValue}</>;
-  } catch {
-    console.warn("Error getting answer value display for question", questionId);
+  } else {
     return <AnswerDisplayValuePlaceholder />;
   }
 };

--- a/apps/web/utils/string.tsx
+++ b/apps/web/utils/string.tsx
@@ -9,15 +9,16 @@ import parse, {
 // repo
 import Button from "@repo/ui/button";
 import Tooltip from "@repo/ui/tooltip";
-// local
-import DefinedTerm, {
-  DefinedTermProps,
-} from "../components/defined-term/DefinedTerm";
 import {
   ModalSideDataEnum,
   TooltipGlossaryData,
 } from "@repo/data/useGlossaryData";
 import ModalSide from "@repo/ui/modal-side";
+import { ANSWER_DISPLAY_VALUE_PLACEHOLDER } from "@repo/constants/src/constants";
+// local
+import DefinedTerm, {
+  DefinedTermProps,
+} from "../components/defined-term/DefinedTerm";
 import PDFDownloadLink, {
   PDFDownloadLinkProps,
 } from "../components/pdf-download-link/PDFDownloadLink";
@@ -149,16 +150,7 @@ export const parseStringToComponents = (
             );
 
           case answerValue: {
-            const { getQuestionAnswerValueDisplay } = useWalkthroughState();
-            const questionId = domNode.attribs["answer"];
-
-            if (!questionId) {
-              console.warn("Missing question ID - incorrect json data.");
-              return "";
-            }
-            const displayValue = getQuestionAnswerValueDisplay(questionId);
-
-            return <span>{displayValue}</span>;
+            return getAnswerValueDisplay(domNode.attribs["answer"]);
           }
         }
       } else if (
@@ -166,11 +158,32 @@ export const parseStringToComponents = (
         domNode.attribs &&
         ignoreComponentMarkup
       ) {
-        return <>{domToReact(domNode.children as DOMNode[], options)}</>;
+        const isComponent =
+          !!customComponents[domNode.name as CustomComponentTypes];
+
+        if (isComponent) {
+          return <>{domToReact(domNode.children as DOMNode[], options)}</>;
+        } else if (domNode.name === answerValue) {
+          return getAnswerValueDisplay(domNode.attribs["answer"]);
+        }
+
+        return domToReact(domNode.children as DOMNode[], options);
       }
     },
   };
   return parse(html, options);
+};
+
+const getAnswerValueDisplay = (questionId?: string) => {
+  if (!questionId) {
+    console.warn("Missing question ID - incorrect json data.");
+    return ANSWER_DISPLAY_VALUE_PLACEHOLDER;
+  }
+
+  const { getQuestionAnswerValueDisplay } = useWalkthroughState();
+  const displayValue = getQuestionAnswerValueDisplay(questionId);
+
+  return <>{displayValue || ANSWER_DISPLAY_VALUE_PLACEHOLDER}</>;
 };
 
 export const getStringFromComponents = (node: ReactNode): string => {

--- a/apps/web/utils/string.tsx
+++ b/apps/web/utils/string.tsx
@@ -177,28 +177,25 @@ export const parseStringToComponents = (
   return parse(html, options);
 };
 
-const getAnswerValueDisplay = (questionId?: string) => {
+const AnswerDisplayValuePlaceholder = () => (
+  <span aria-label={ANSWER_DISPLAY_VALUE_PLACEHOLDER_A11Y}>
+    {ANSWER_DISPLAY_VALUE_PLACEHOLDER}
+  </span>
+);
+export const getAnswerValueDisplay = (questionId?: string) => {
   if (!questionId) {
     console.warn("Missing question ID - incorrect json data.");
-    return (
-      <span aria-label={ANSWER_DISPLAY_VALUE_PLACEHOLDER_A11Y}>
-        ANSWER_DISPLAY_VALUE_PLACEHOLDER
-      </span>
-    );
+    return <AnswerDisplayValuePlaceholder />;
   }
 
   const { getQuestionAnswerValueDisplay } = useWalkthroughState();
-  const displayValue = getQuestionAnswerValueDisplay(questionId);
-
-  if (!displayValue) {
-    return (
-      <span aria-label={ANSWER_DISPLAY_VALUE_PLACEHOLDER_A11Y}>
-        {ANSWER_DISPLAY_VALUE_PLACEHOLDER}
-      </span>
-    );
+  try {
+    const displayValue = getQuestionAnswerValueDisplay(questionId);
+    return <>{displayValue}</>;
+  } catch {
+    console.warn("Error getting answer value display for question", questionId);
+    return <AnswerDisplayValuePlaceholder />;
   }
-
-  return <>{displayValue}</>;
 };
 
 export const getStringFromComponents = (node: ReactNode): string => {

--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -1,6 +1,7 @@
 export const IMAGES_BASE_PATH = "/assets/images";
 // empty string is the default value for nextNavigationId and will show the question error screen
 export const NEXT_NAVIGATION_ID_ERROR = "";
+export const ANSWER_DISPLAY_VALUE_PLACEHOLDER = "_____";
 
 export const DEFINED_TERMS_SECTION_NUMBER = "1.4.1.2";
 

--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -2,6 +2,7 @@ export const IMAGES_BASE_PATH = "/assets/images";
 // empty string is the default value for nextNavigationId and will show the question error screen
 export const NEXT_NAVIGATION_ID_ERROR = "";
 export const ANSWER_DISPLAY_VALUE_PLACEHOLDER = "_____";
+export const ANSWER_DISPLAY_VALUE_PLACEHOLDER_A11Y = "blank";
 
 export const DEFINED_TERMS_SECTION_NUMBER = "1.4.1.2";
 

--- a/packages/constants/src/ids.ts
+++ b/packages/constants/src/ids.ts
@@ -3,3 +3,4 @@ export const ID_QUESTION_FORM = "questionForm";
 export const ID_MAIN_CONTENT = "main-content";
 export const ID_MAIN_NAVIGATION = "main-navigation";
 export const ID_FOOTER = "footer";
+export const ID_STEP_TRACKER_TITLE = "stepTrackerTitle";

--- a/packages/constants/src/testids.ts
+++ b/packages/constants/src/testids.ts
@@ -32,6 +32,7 @@ export const TESTID_STEP_TRACKER_MOBILE_BUTTON_OPEN =
   "step-tracker-mobile-button-open";
 export const TESTID_STEP_TRACKER_MOBILE_BUTTON_CLOSE =
   "step-tracker-mobile-button-close";
+export const TESTID_STEP_TRACKER_ITEMS = "step-tracker-items";
 export const TESTID_RESULT = "result";
 export const TESTID_HEADER = "header";
 export const TESTID_HEADER_MOBILE_NAV = "header-mobile-nav";

--- a/packages/constants/src/testids.ts
+++ b/packages/constants/src/testids.ts
@@ -30,8 +30,7 @@ export const TESTID_STEP_TRACKER = "step-tracker";
 export const TESTID_STEP_TRACKER_MOBILE = "step-tracker-mobile";
 export const TESTID_STEP_TRACKER_MOBILE_BUTTON_OPEN =
   "step-tracker-mobile-button-open";
-export const TESTID_STEP_TRACKER_MOBILE_BUTTON_CLOSE =
-  "step-tracker-mobile-button-close";
+export const TESTID_BUTTON_MODAL_CLOSE = "button-modal-close";
 export const TESTID_STEP_TRACKER_ITEMS = "step-tracker-items";
 export const TESTID_RESULT = "result";
 export const TESTID_HEADER = "header";

--- a/packages/constants/src/testids.ts
+++ b/packages/constants/src/testids.ts
@@ -26,6 +26,12 @@ export const TESTID_QUESTION_CODE_REFERENCE = "question-code-reference";
 export const TESTID_WALKTHROUGH = "walkthrough";
 export const TESTID_WALKTHROUGH_FOOTER_BACK = "walkthrough-footer-back";
 export const TESTID_WALKTHROUGH_FOOTER_NEXT = "walkthrough-footer-next";
+export const TESTID_STEP_TRACKER = "step-tracker";
+export const TESTID_STEP_TRACKER_MOBILE = "step-tracker-mobile";
+export const TESTID_STEP_TRACKER_MOBILE_BUTTON_OPEN =
+  "step-tracker-mobile-button-open";
+export const TESTID_STEP_TRACKER_MOBILE_BUTTON_CLOSE =
+  "step-tracker-mobile-button-close";
 export const TESTID_RESULT = "result";
 export const TESTID_HEADER = "header";
 export const TESTID_HEADER_MOBILE_NAV = "header-mobile-nav";

--- a/packages/data/json/9.10.14.json
+++ b/packages/data/json/9.10.14.json
@@ -3,10 +3,10 @@
     "title": "Spatial Separation Between Buildings",
     "subtitle": "Volume II - 9.10.14.1-4",
     "description": "Ensure a building’s separation passes code.",
-    "startingSectionId": "intro"
+    "startingSectionId": "1_intro"
   },
   "sections": {
-    "intro": {
+    "1_intro": {
       "sectionTitle": "Introduction",
       "sectionQuestions": [
         "P01",
@@ -19,7 +19,7 @@
         "P08"
       ]
     },
-    "91014": {
+    "2_91014": {
       "sectionTitle": "9.10.14. Spatial Separation Between Buildings",
       "sectionQuestions": [
         "P1",

--- a/packages/data/json/9.9.9.json
+++ b/packages/data/json/9.9.9.json
@@ -3,10 +3,10 @@
     "title": "Egress from Dwelling Units",
     "subtitle": "Volume II - 9.9.9.",
     "description": "Ensure your dwelling unit has exits or egress doors that pass code.",
-    "startingSectionId": "intro"
+    "startingSectionId": "1_intro"
   },
   "sections": {
-    "intro": {
+    "1_intro": {
       "sectionTitle": "Introduction",
       "sectionQuestions": [
         "P01",
@@ -19,7 +19,7 @@
         "P08"
       ]
     },
-    "9991": {
+    "2_9991": {
       "sectionTitle": "9.9.9.1. Travel limit to Exits or Egress Doors",
       "sectionQuestions": [
         "P1",
@@ -33,11 +33,11 @@
         "P10"
       ]
     },
-    "9992": {
+    "3_9992": {
       "sectionTitle": "9.9.9.2. Two Separate Exits",
       "sectionQuestions": ["P11", "P12", "P13", "P14", "P15", "P16", "P17"]
     },
-    "9993": {
+    "4_9993": {
       "sectionTitle": "9.9.9.3. Shared Egress Facilities",
       "sectionQuestions": ["P18", "P19", "P20", "P21", "P22", "P23", "P24"]
     }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -3,8 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "exports": {
-    "./modal-building-code-content": "./src/modal-building-code-content/ModalBuildingCodeContent.tsx",
-    "./modal-glossary-content": "./src/modal-glossary-content/ModalGlossaryContent.tsx",
+    "./button-modal-close": "./src/button-modal-close/ButtonModalClose.tsx",
     "./walkthrough-card": "./src/walkthrough-card/WalkthroughCard.tsx",
     "./image": "./src/image/Image.tsx",
     "./tooltip": "./src/tooltip/Tooltip.tsx",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "exports": {
     "./button-modal-close": "./src/button-modal-close/ButtonModalClose.tsx",
+    "./modal-building-code-content": "./src/modal-building-code-content/ModalBuildingCodeContent.tsx",
+    "./modal-glossary-content": "./src/modal-glossary-content/ModalGlossaryContent.tsx",
     "./walkthrough-card": "./src/walkthrough-card/WalkthroughCard.tsx",
     "./image": "./src/image/Image.tsx",
     "./tooltip": "./src/tooltip/Tooltip.tsx",

--- a/packages/ui/src/button-modal-close/ButtonModalClose.css
+++ b/packages/ui/src/button-modal-close/ButtonModalClose.css
@@ -1,0 +1,17 @@
+/* modal close button */
+.ui-ButtonModalClose.--icon {
+  height: 48px;
+  width: 48px;
+  min-width: 48px;
+  background-color: rgba(255, 255, 255, 0.8);
+  color: var(--typography-color-primary);
+  border: none;
+  position: fixed;
+  right: var(--layout-padding-medium);
+  top: var(--layout-padding-small);
+}
+
+.ui-ButtonModalClose .ui-Icon {
+  height: 32px;
+  width: 32px;
+}

--- a/packages/ui/src/button-modal-close/ButtonModalClose.tsx
+++ b/packages/ui/src/button-modal-close/ButtonModalClose.tsx
@@ -1,0 +1,27 @@
+// repo
+import { TESTID_BUTTON_MODAL_CLOSE } from "@repo/constants/src/testids";
+// local
+import Button from "../button/Button";
+import Icon from "../icon/Icon";
+import "./ButtonModalClose.css";
+
+export default function ButtonModalClose({
+  label,
+  onPress,
+}: {
+  label: string;
+  onPress: (isOpen: boolean) => void;
+}) {
+  return (
+    <Button
+      aria-label={label}
+      isIconButton
+      variant="tertiary"
+      className="ui-ButtonModalClose"
+      onPress={() => onPress(false)}
+      data-testid={TESTID_BUTTON_MODAL_CLOSE}
+    >
+      <Icon type="close" />
+    </Button>
+  );
+}

--- a/packages/ui/src/icon/Icon.test.tsx
+++ b/packages/ui/src/icon/Icon.test.tsx
@@ -207,6 +207,54 @@ describe("Icon", () => {
     expect(getByTestId(getIconTestId("arrowForward"))).toBeInTheDocument();
     expect(queryByTitle("Go forward")).not.toBeInTheDocument();
   });
+  // expandMore
+  it("renders expandMore icon with title", () => {
+    const { getByTestId, getByTitle } = render(
+      <Icon type="expandMore" id="expandMoreIcon" title="Expand more" />,
+    );
+    const ExpandMoreIcon = getByTestId(getIconTestId("expandMore"));
+    expect(ExpandMoreIcon).toBeInTheDocument();
+    expect(ExpandMoreIcon).toHaveAttribute("aria-labelledby", "expandMoreIcon");
+    expect(getByTitle("Expand more")).toBeInTheDocument();
+  });
+  it("renders expandMore icon without title", () => {
+    const { getByTestId, queryByTitle } = render(<Icon type="expandMore" />);
+    expect(getByTestId(getIconTestId("expandMore"))).toBeInTheDocument();
+    expect(queryByTitle("Expand more")).not.toBeInTheDocument();
+  });
+  // check
+  it("renders check icon with title", () => {
+    const { getByTestId, getByTitle } = render(
+      <Icon type="check" id="checkIcon" title="Check" />,
+    );
+    const CheckIcon = getByTestId(getIconTestId("check"));
+    expect(CheckIcon).toBeInTheDocument();
+    expect(CheckIcon).toHaveAttribute("aria-labelledby", "checkIcon");
+    expect(getByTitle("Check")).toBeInTheDocument();
+  });
+  it("renders check icon without title", () => {
+    const { getByTestId, queryByTitle } = render(<Icon type="check" />);
+    expect(getByTestId(getIconTestId("check"))).toBeInTheDocument();
+    expect(queryByTitle("Check")).not.toBeInTheDocument();
+  });
+  // accountTree
+  it("renders accountTree icon with title", () => {
+    const { getByTestId, getByTitle } = render(
+      <Icon type="accountTree" id="accountTreeIcon" title="Account tree" />,
+    );
+    const AccountTreeIcon = getByTestId(getIconTestId("accountTree"));
+    expect(AccountTreeIcon).toBeInTheDocument();
+    expect(AccountTreeIcon).toHaveAttribute(
+      "aria-labelledby",
+      "accountTreeIcon",
+    );
+    expect(getByTitle("Account tree")).toBeInTheDocument();
+  });
+  it("renders accountTree icon without title", () => {
+    const { getByTestId, queryByTitle } = render(<Icon type="accountTree" />);
+    expect(getByTestId(getIconTestId("accountTree"))).toBeInTheDocument();
+    expect(queryByTitle("Account tree")).not.toBeInTheDocument();
+  });
   // className
   it("renders icon with className", () => {
     const { getByTestId } = render(

--- a/packages/ui/src/icon/Icon.tsx
+++ b/packages/ui/src/icon/Icon.tsx
@@ -13,6 +13,9 @@ import CheckboxChecked from "./icons/CheckboxChecked";
 import CheckboxUnchecked from "./icons/CheckboxUnchecked";
 import ArrowBack from "./icons/ArrowBack";
 import ArrowForward from "./icons/ArrowForward";
+import ExpandMore from "./icons/ExpandMore";
+import Check from "./icons/Check";
+import AccountTree from "./icons/AccountTree";
 
 // NOTE: When adding a new icon, make sure to add the string here, and the icon component below in the ICONS object
 export type IconType =
@@ -25,7 +28,10 @@ export type IconType =
   | "checkboxChecked"
   | "checkboxUnchecked"
   | "arrowBack"
-  | "arrowForward";
+  | "arrowForward"
+  | "expandMore"
+  | "check"
+  | "accountTree"; // NOTE: account tree is the name in Material Icons, this is used for the mobile step tracker toggle
 
 export interface IconComponentProps extends SVGProps<SVGSVGElement> {
   /**
@@ -66,6 +72,9 @@ const ICONS: Record<IconType, FunctionComponent<IconProps>> = {
   checkboxUnchecked: CheckboxUnchecked,
   arrowBack: ArrowBack,
   arrowForward: ArrowForward,
+  expandMore: ExpandMore,
+  check: Check,
+  accountTree: AccountTree,
 };
 
 export default function Icon({

--- a/packages/ui/src/icon/icons/AccountTree.tsx
+++ b/packages/ui/src/icon/icons/AccountTree.tsx
@@ -1,0 +1,24 @@
+import { IconProps } from "../Icon";
+
+export default function AccountTree({ title, id, ...props }: IconProps) {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-labelledby={id ? id : undefined}
+      aria-hidden="true"
+      {...props}
+    >
+      {id === undefined || title === undefined ? null : (
+        <title id={id}>{title}</title>
+      )}
+      <path
+        d="M22 11V3H15V6H9V3H2V11H9V8H11V18H15V21H22V13H15V16H13V8H15V11H22ZM7 9H4V5H7V9ZM17 15H20V19H17V15ZM17 5H20V9H17V5Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}

--- a/packages/ui/src/icon/icons/Check.tsx
+++ b/packages/ui/src/icon/icons/Check.tsx
@@ -1,0 +1,24 @@
+import { IconProps } from "../Icon";
+
+export default function Check({ title, id, ...props }: IconProps) {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-labelledby={id ? id : undefined}
+      aria-hidden="true"
+      {...props}
+    >
+      {id === undefined || title === undefined ? null : (
+        <title id={id}>{title}</title>
+      )}
+      <path
+        d="M8.79502 15.8749L4.62502 11.7049L3.20502 13.1149L8.79502 18.7049L20.795 6.70492L19.385 5.29492L8.79502 15.8749Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}

--- a/packages/ui/src/icon/icons/ExpandMore.tsx
+++ b/packages/ui/src/icon/icons/ExpandMore.tsx
@@ -1,0 +1,24 @@
+import { IconProps } from "../Icon";
+
+export default function ExpandMore({ title, id, ...props }: IconProps) {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-labelledby={id ? id : undefined}
+      aria-hidden="true"
+      {...props}
+    >
+      {id === undefined || title === undefined ? null : (
+        <title id={id}>{title}</title>
+      )}
+      <path
+        d="M16.59 8.29492L12 12.8749L7.41 8.29492L6 9.70492L12 15.7049L18 9.70492L16.59 8.29492Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}

--- a/packages/ui/src/variables.css
+++ b/packages/ui/src/variables.css
@@ -90,6 +90,7 @@
   --layout-padding-large: 1.5rem;
   --layout-padding-26: 1.625rem;
   --layout-padding-xlarge: 2rem;
+  --layout-padding-64: 4rem;
   --layout-padding-container: var(--layout-padding-medium);
   --layout-padding-radio-x: var(--layout-padding-medium);
   --layout-padding-radio-y: var(--layout-padding-medium);
@@ -245,6 +246,7 @@
   --walkthrough-card-title-text-decoration-hidden: underline 1px #00000000;
   --walkthrough-card-title-text-decoration-color-transition: underline 1px;
   --walkthrough-card-title-text-underline-offset: 0.2em;
+  --step-tracker-heading-padding-left: var(--layout-padding-xlarge);
   --step-tracker-padding-top: var(--layout-padding-xsmall);
   --step-tracker-padding-left: var(--layout-padding-medium);
   --step-tracker-padding: var(--step-tracker-padding-top)
@@ -270,6 +272,7 @@
     --walkthrough-footer-next-width: auto;
     --step-tracker-mobile-toggle-display: none;
     --step-tracker-tablet-up-display: block;
+    --step-tracker-heading-padding-left: 0;
     --step-tracker-padding-top: var(--layout-padding-medium);
     --step-tracker-padding: var(--step-tracker-padding-top) 0
       var(--step-tracker-padding-top) var(--step-tracker-padding-left);

--- a/packages/ui/src/variables.css
+++ b/packages/ui/src/variables.css
@@ -83,10 +83,12 @@
   --layout-padding-xxsmall: 0.125rem;
   --layout-padding-xsmall: 0.25rem;
   --layout-padding-small: 0.5rem;
-  --layout-padding-smallium: 0.75rem;
-  --layout-padding-smedium: 0.875rem;
+  --layout-padding-10: 0.625rem;
+  --layout-padding-12: 0.75rem;
+  --layout-padding-14: 0.875rem;
   --layout-padding-medium: 1rem;
   --layout-padding-large: 1.5rem;
+  --layout-padding-26: 1.625rem;
   --layout-padding-xlarge: 2rem;
   --layout-padding-container: var(--layout-padding-medium);
   --layout-padding-radio-x: var(--layout-padding-medium);
@@ -213,6 +215,10 @@
   --theme-gray-white: #ffffff;
   --theme-primary-blue: #013366;
   --theme-primary-gold: #fcba19;
+}
+
+/* CUSTOM */
+:root {
   --size-button: 40px;
   --size-button-large: 52px;
   --outline-offset: 2px;
@@ -220,7 +226,7 @@
   --transition-link-background-color: background-color 150ms ease-in;
   --transition-link-color: color 150ms ease-in;
   --transition-link-icon-fill-color: fill 150ms ease-in;
-  --button-gap: var(--layout-padding-smallium);
+  --button-gap: var(--layout-padding-12);
   --header-height: 55px;
   --header-nav-mobile-padding: var(--layout-padding-medium);
   --walkthrough-side-nav-width: 0;
@@ -230,6 +236,23 @@
   --question-form-margin-top: var(--layout-margin-small);
   --walkthrough-footer-back-width: 44px;
   --walkthrough-footer-next-width: 228px;
+  --transition-medium: 300ms;
+  --theme-black-opacity-40: #00000040;
+  --walkthrough-card-max-width: 27.5rem;
+  --walkthrough-card-border-transparent: 1px solid #00000000;
+  --walkthrough-card-border-default: 1px solid
+    var(--surface-color-border-default);
+  --walkthrough-card-title-text-decoration-hidden: underline 1px #00000000;
+  --walkthrough-card-title-text-decoration-color-transition: underline 1px;
+  --walkthrough-card-title-text-underline-offset: 0.2em;
+  --step-tracker-padding-top: var(--layout-padding-xsmall);
+  --step-tracker-padding-left: var(--layout-padding-medium);
+  --step-tracker-padding: var(--step-tracker-padding-top)
+    var(--step-tracker-padding-left);
+  --step-tracker-mobile-toggle-display: flex;
+  --step-tracker-tablet-up-display: none;
+  --modal-side-number-padding: 8%;
+  --modal-table-image-caption-margin-negative: -0.5rem;
 }
 
 /* TABLET - 608px */
@@ -245,6 +268,11 @@
     --question-form-margin-top: var(--layout-margin-large);
     --walkthrough-footer-back-width: auto;
     --walkthrough-footer-next-width: auto;
+    --step-tracker-mobile-toggle-display: none;
+    --step-tracker-tablet-up-display: block;
+    --step-tracker-padding-top: var(--layout-padding-medium);
+    --step-tracker-padding: var(--step-tracker-padding-top) 0
+      var(--step-tracker-padding-top) var(--step-tracker-padding-left);
   }
 }
 
@@ -253,6 +281,8 @@
   :root {
     --header-height: 65px;
     --walkthrough-side-nav-width: 21.25rem; /* 340px */
+    --step-tracker-padding-top: var(--layout-padding-26);
+    --step-tracker-padding-left: var(--layout-padding-xlarge);
   }
 }
 
@@ -262,19 +292,4 @@
     --walkthrough-side-nav-width: 27.5rem; /* 440px */
     --question-container-max-width: 53.5rem; /* 856px */
   }
-}
-
-/* CUSTOM */
-:root {
-  --transition-medium: 300ms;
-  --theme-black-opacity-40: #00000040;
-  --walkthrough-card-max-width: 27.5rem;
-  --walkthrough-card-border-transparent: 1px solid #00000000;
-  --walkthrough-card-border-default: 1px solid
-    var(--surface-color-border-default);
-  --walkthrough-card-title-text-decoration-hidden: underline 1px #00000000;
-  --walkthrough-card-title-text-decoration-color-transition: underline 1px;
-  --walkthrough-card-title-text-underline-offset: 0.2em;
-  --modal-side-number-padding: 8%;
-  --modal-table-image-caption-margin-negative: -0.5rem;
 }


### PR DESCRIPTION
[HOUSNAV-31](https://hous-bssb.atlassian.net/browse/HOUSNAV-31)

## Overview & Purpose
Add a step tracker to the display the matches the design at all screen sizes and appropriately reflects the state of the application steps.

## Summary of Changes

- Created StepTracker component
- Created `farthestItemId` in the store to reflect the current farthest item the user is on while they may navigate back to previously answered questions
- Added logic to navigation store to figure out the state of each question in the Step Tracker display
- Updated `parseStringToComponents` to account for case where we want to show questionText without any included HTML markup
- Updated section IDs in JSON to be prefixed with a number so they stay in order when turned into an Array
- Added some icons

## Side Effects
Re-named some some CSS variables to more appropriately reflect their values when they differentiate from the imported BC Design Library values

## Testing
Navigate through 9.9.9 and see the updated Step Tracker status based on questions that are complete and skipped and sections that are complete and skipped.

## Checklist
- [x] I have written or updated vitests for this work
- [x] I have reviewed the [accessibility guidelines](https://digital.gov.bc.ca/wcag/home/) relevant to this work
- [x] I have reviewed this work with at least one screen reader (when applicable)
- [x] I have added/updated any related documentation
