### PR TITLE
Fix glossary bullet points and padding issues

### DIFF
--- a/packages/ui/src/modal-building-code-content/ModalBuildingCodeContent.css
+++ b/packages/ui/src/modal-building-code-content/ModalBuildingCodeContent.css
@@ -1,7 +1,4 @@
-.ui-ModalBuildingCodeContent--OrderedList {
-  padding-left: revert;
-}
-.ui-ModalBuildingCodeContent--ListItems {
+.ui-ModalSide--ListItems {
   padding-bottom: var(--layout-padding-xsmall);
   padding-top: var(--layout-padding-xsmall);
 }

--- a/packages/ui/src/modal-building-code-content/ModalBuildingCodeContent.tsx
+++ b/packages/ui/src/modal-building-code-content/ModalBuildingCodeContent.tsx
@@ -32,9 +32,9 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
 }) => {
   const renderSubClauses = (subClauses: string[]) => {
     return (
-      <ol type="i" className="ui-ModalBuildingCodeContent--OrderedList">
+      <ol type="i" className="ui-ModalSide--List">
         {subClauses.map((subClause, index) => (
-          <li key={index} className="ui-ModalBuildingCodeContent--ListItems">
+          <li key={index} className="ui-ModalSide--ListItems">
             <span>{parseStringToComponents(subClause, setFocusSection)}</span>
           </li>
         ))}
@@ -44,14 +44,14 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
 
   const renderClauses = (clauses: SubClauseType[]) => {
     return (
-      <ol type="a" className="ui-ModalBuildingCodeContent--OrderedList">
+      <ol type="a" className="ui-ModalSide--List">
         {clauses.map((data, index) => (
           <li
             key={index}
             ref={(el) => {
               sectionRefs.current[data.numberReference] = el;
             }}
-            className={`ui-ModalBuildingCodeContent--ListItems ${
+            className={`ui-ModalSide--ListItems ${
               highlightedSection === data.numberReference
                 ? "ui-ModalSide--SectionHighlighted ui-ModalSide--SectionHighlightedPadding"
                 : ""

--- a/packages/ui/src/modal-glossary-content/ModalGlossaryContent.tsx
+++ b/packages/ui/src/modal-glossary-content/ModalGlossaryContent.tsx
@@ -19,7 +19,7 @@ function renderDefinitionList(
   customHandler?: (location: string) => void,
 ) {
   return (
-    <ul className="ui-ModalBuildingCodeContent--List">
+    <ul className="ui-ModalSide--List">
       {definitionList.map((item, index) => (
         <li key={index}>{parseStringToComponents(item, customHandler)}</li>
       ))}

--- a/packages/ui/src/modal-side/ModalSide.css
+++ b/packages/ui/src/modal-side/ModalSide.css
@@ -126,9 +126,7 @@
   grid-column: span 4 / 6;
   font-size: var(--typography-font-size-body);
   line-height: var(--typography-line-heights-dense);
-  padding: var(--layout-margin-large);
-  padding-top: 0;
-  padding-bottom: 0;
+  padding: var(--layout-margin-small);
   margin-top: 1px;
 }
 
@@ -140,6 +138,10 @@
 
 .ui-ModalSide--SectionHighlightedPadding {
   padding: var(--layout-padding-large);
+}
+
+.ui-ModalSide--List {
+  padding-left: revert;
 }
 
 @keyframes modal-slide-out {


### PR DESCRIPTION
<!-- You may remove any sections that are not applicable -->

## Overview & Purpose
<!-- Please describe the purpose of your changes. Please also include relevant motivation and context. -->
Fix a padding issue for glossary terms introduced in https://github.com/bcgov/House-Innovations-HOUSNAV/pull/60/files#diff-e2d3155f4ebcdc191fa9a9625a119404c2db9eab758f7208ea12a428465f8daa

## Summary of Changes
<!-- Please include a HIGH LEVEL overview of the code changes. (Added xyz fields to table, modified function to handle x case instead of y case, etc. )  -->
- Change css class back to `ui-ModalSide--List` since it's used for both glossary and building code lists
- Updated padding for section to reflect the padding used in the figma design
Before:
![Screenshot 2024-07-09 at 10 09 33 PM](https://github.com/bcgov/House-Innovations-HOUSNAV/assets/7059124/ca3c8785-44cb-40be-a474-479d22d8785a)

After:
![Screenshot 2024-07-10 at 9 21 20 AM](https://github.com/bcgov/House-Innovations-HOUSNAV/assets/7059124/dacb7c44-df69-449d-8d73-4dc4a8041754)

## Testing
<!-- Please include steps to test out the changes/fixes if applicable OR context notes to help get env in a state to test-->

## Notes & Resources
<!-- Please include any additional notes necessary to review PR and/or relevant links (documentation, stack overflow, etc.) that helped you arrive at your solution. -->

## Checklist
- [x] I have written or updated vitests for this work
- [x] I have reviewed the [accessibility guidelines](https://digital.gov.bc.ca/wcag/home/) relevant to this work
- [x] I have reviewed this work with at least one screen reader (when applicable)
- [x] I have added/updated any related documentation
