### PR TITLE
HOUSNAV-36:  Back Redirect Confirmation

### DIFF
--- a/apps/web/components/walkthrough/Walkthrough.tsx
+++ b/apps/web/components/walkthrough/Walkthrough.tsx
@@ -1,6 +1,6 @@
 "use client";
 // 3rd party
-import { FormEvent, JSX, useCallback } from "react";
+import { FormEvent, JSX, useCallback, useEffect, useState } from "react";
 import { Form } from "react-aria-components";
 import { observer } from "mobx-react-lite";
 // repo
@@ -24,6 +24,26 @@ const Walkthrough = observer((): JSX.Element => {
     handleStateError,
     answerStore: { currentAnswerValue },
   } = useWalkthroughState();
+
+  const [isBlocking, setIsBlocking] = useState(true);
+
+  useEffect(() => {
+    // Block the user from leaving the page with confirmation if they have unsaved changes
+    // (ie. they have interacted with the form)
+    const onBeforeUnload = (ev: Event) => {
+      if (isBlocking) {
+        ev.preventDefault();
+      }
+      ev.returnValue = isBlocking;
+      return isBlocking;
+    };
+
+    window.addEventListener("beforeunload", onBeforeUnload);
+    setIsBlocking(true);
+    return () => {
+      window.removeEventListener("beforeunload", onBeforeUnload);
+    };
+  }, [isBlocking]);
 
   const handleQuestionSubmit = useCallback(
     (event: FormEvent<HTMLFormElement>) => {
@@ -49,29 +69,31 @@ const Walkthrough = observer((): JSX.Element => {
   );
 
   return (
-    <div className="web-Walkthrough" data-testid={TESTID_WALKTHROUGH}>
-      <section className="web-Walkthrough--Content">
-        {currentResult ? (
-          <Result
-            displayMessage={currentResult.resultDisplayMessage}
-            relatedWalkthroughs={relatedWalkthroughs}
-          />
-        ) : (
-          <Form
-            className="web-Walkthrough--Form"
-            id={ID_QUESTION_FORM}
-            onSubmit={handleQuestionSubmit}
-            key={`question-${currentItemId}`}
-          >
-            <Question />
-          </Form>
-        )}
-        <WalkthroughFooter />
-      </section>
-      <section className="web-Walkthrough--StepTracker">
-        <StepTracker />
-      </section>
-    </div>
+    <>
+      <div className="web-Walkthrough" data-testid={TESTID_WALKTHROUGH}>
+        <section className="web-Walkthrough--Content">
+          {currentResult ? (
+            <Result
+              displayMessage={currentResult.resultDisplayMessage}
+              relatedWalkthroughs={relatedWalkthroughs}
+            />
+          ) : (
+            <Form
+              className="web-Walkthrough--Form"
+              id={ID_QUESTION_FORM}
+              onSubmit={handleQuestionSubmit}
+              key={`question-${currentItemId}`}
+            >
+              <Question />
+            </Form>
+          )}
+          <WalkthroughFooter />
+        </section>
+        <section className="web-Walkthrough--StepTracker">
+          <StepTracker />
+        </section>
+      </div>
+    </>
   );
 });
 

--- a/packages/constants/src/testids.ts
+++ b/packages/constants/src/testids.ts
@@ -46,5 +46,6 @@ export const GET_TESTID_HEADER_NAV_ITEM = (title: string) =>
   `header-nav-item-${title}`;
 export const TESTID_FOOTER = "footer";
 export const TESTID_MODAL_SIDE = "modal-side";
+export const TESTID_CONFIRMATION_MODAL = "confirmation-modal";
 export const GET_TESTID_WALKTHROUGH_CARD = (walkthrough: string) =>
   `walkthrough-card-${walkthrough}`;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "exports": {
+    "./confirmation-modal": "./src/confirmation-modal/ConfirmationModal.tsx",
     "./footer": "./src/footer/Footer.tsx",
     "./number-field": "./src/number-field/NumberField.tsx",
     "./print-content": "./src/print-content/PrintContent.tsx",

--- a/packages/ui/src/confirmation-modal/ConfirmationModal.css
+++ b/packages/ui/src/confirmation-modal/ConfirmationModal.css
@@ -1,0 +1,43 @@
+.ui-ConfirmationModal--overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1001;
+  overflow-y: auto;
+  background: var(--surface-color-overlay-default);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--layout-padding-medium);
+  text-align: center;
+}
+
+.ui-ConfirmationModal--modal {
+  width: 100%;
+  max-width: var(--confirmation-modal-max-width);
+  overflow: hidden;
+  border-radius: var(--layout-border-radius-xxlarge);
+  background: var(--surface-color-background-white);
+  padding: var(--layout-padding-large);
+  text-align: left;
+}
+
+.ui-ConfirmationModal--dialog {
+  outline: none;
+  position: relative;
+}
+
+.ui-ConfirmationModal--title {
+  font: var(--typography-bold-h5);
+}
+
+.ui-ConfirmationModal--content {
+  margin-top: var(--layout-margin-medium);
+  font: var(--typography-regular-body);
+}
+
+.ui-ConfirmationModal--actions {
+  margin-top: var(--layout-margin-large);
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}

--- a/packages/ui/src/confirmation-modal/ConfirmationModal.tsx
+++ b/packages/ui/src/confirmation-modal/ConfirmationModal.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import {
+  Dialog,
+  Modal,
+  ModalOverlay,
+  Heading,
+  DialogTrigger,
+} from "react-aria-components";
+
+import { TESTID_CONFIRMATION_MODAL } from "@repo/constants/src/testids";
+import "./ConfirmationModal.css";
+import Button from "../button/Button";
+
+import "./ConfirmationModal.css";
+
+export interface ConfirmationModalProps {
+  onConfirm: () => void;
+  onCancel: () => void;
+  "data-testid"?: string;
+}
+
+export default function ConfirmationModal({
+  onConfirm,
+  onCancel,
+  "data-testid": testid = TESTID_CONFIRMATION_MODAL,
+}: ConfirmationModalProps) {
+  return (
+    <DialogTrigger isOpen>
+      {/* Dummy button to prevent warning since dialog is triggered via browser event, not ui button*/}
+      <Button style={{ display: "none" }}></Button>
+
+      <ModalOverlay className="ui-ConfirmationModal--overlay">
+        <Modal className="ui-ConfirmationModal--modal" data-testid={testid}>
+          <Dialog className="ui-ConfirmationModal--dialog">
+            {({ close }) => (
+              <>
+                <Heading className="ui-ConfirmationModal--title">
+                  Are you sure you want to proceed?
+                </Heading>
+
+                <p className="ui-ConfirmationModal--content">
+                  You will lose your progress if you continue.
+                </p>
+                <div className="ui-ConfirmationModal--actions">
+                  <Button
+                    type="button"
+                    className="dialog-button"
+                    variant="secondary"
+                    onPress={() => {
+                      onCancel();
+                      close();
+                    }}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    type="button"
+                    className="dialog-button"
+                    variant="primary"
+                    onPress={() => {
+                      onConfirm();
+                      close();
+                    }}
+                  >
+                    Continue
+                  </Button>
+                </div>
+              </>
+            )}
+          </Dialog>
+        </Modal>
+      </ModalOverlay>
+    </DialogTrigger>
+  );
+}

--- a/packages/ui/src/variables.css
+++ b/packages/ui/src/variables.css
@@ -108,6 +108,7 @@
   --layout-border-radius-medium: 4px;
   --layout-border-radius-large: 6px;
   --layout-border-radius-xlarge: 8px;
+  --layout-border-radius-xxlarge: 12px;
   --typography-font-families-bc-sans: "BC Sans", sans-serif;
   --typography-line-heights-xxxdense: 1.125rem;
   --typography-line-heights-xxdense: 1.313rem;
@@ -271,6 +272,7 @@
   --pdf-result-download-container-max-width: 650px;
   --pdf-result-download-container-image-border: 1px solid var(#00000000);
   --pdf-result-download-container-image-container: #000000;
+  --confirmation-modal-max-width: 500px;
 }
 
 /* TABLET - 608px */


### PR DESCRIPTION
<!-- You may remove any sections that are not applicable -->

[HOUSNAV-36](https://hous-bssb.atlassian.net/browse/HOUSNAV-36)

## Overview & Purpose
<!-- Please describe the purpose of your changes. Please also include relevant motivation and context. -->
Prompt user to confirm their browser back button click due to loss of state when user leaves walkthrough.

## Summary of Changes
<!-- Please include a HIGH LEVEL overview of the code changes. (Added xyz fields to table, modified function to handle x case instead of y case, etc. )  -->
- Added `ConfirmationModal` within `Walkthrough` component
- Added back/refresh logic adding eventListeners 
    - `beforeunload` - Refresh
    - `popstate` - Back

## Side Effects
<!-- Any possible side effects? Does this change affect features that are not linked to the direct purpose? -->

## Testing
<!-- Please include steps to test out the changes/fixes if applicable OR context notes to help get env in a state to test-->
- Refreshing the page doesn't prompt the dialog because of three reasons 
_(I am handling a refresh though due to how the history state changes if a user refreshes the page)_
    1. It wasn't in scope of the ticket
    2. Adding a confirmation on the refresh will "double confirm". Meaning after clicking "continue" you will be prompted again to "stay or leave". I couldn't get this to only stick with one confirmation
    3. I felt it was pretty self explanatory like with many form sites, you lose your place if you refresh. If we are ok with a double confirmation (one ui and one browser "stay/leave") then that's simple. If we want one and no browser confirmation then I'm not exactly sure how to do that or if it's possible the way we are handling the state. Since the state is cleared BEFORE some event's take place. So, it may be tricky.

## Notes & Resources
<!-- Please include any additional notes necessary to review PR and/or relevant links (documentation, stack overflow, etc.) that helped you arrive at your solution. -->
![Screenshot 2024-07-22 at 11 21 38 AM](https://github.com/user-attachments/assets/60b597e9-6c88-4c4e-8118-35aa32c52d57)
![Screenshot 2024-07-22 at 11 21 54 AM](https://github.com/user-attachments/assets/12db2437-eb65-45d6-a4e0-901e40aa8be7)


## Checklist
- [x] I have written or updated vitests for this work
- [x] I have reviewed the [accessibility guidelines](https://digital.gov.bc.ca/wcag/home/) relevant to this work
- [x] I have reviewed this work with at least one screen reader (when applicable)
- [x] I have added/updated any related documentation
