### PR TITLE
HOUSNAV-128: Add Accessibility scans to all walkthrough questions and results

### DIFF
--- a/apps/web/components/result/Result.tsx
+++ b/apps/web/components/result/Result.tsx
@@ -27,7 +27,7 @@ export default function Result({
         <div className="u-container-walkthrough">
           <header className="web-Result--Header p-hide">
             <Icon type={"checkCircle"} />
-            <Heading level={1} className="h4">
+            <Heading level={2} className="h4">
               Walkthrough Complete
             </Heading>
           </header>

--- a/apps/web/cypress/support/helpers.ts
+++ b/apps/web/cypress/support/helpers.ts
@@ -41,16 +41,21 @@ export const runWalkthrough = (walkthrough: Walkthrough, results: Results) => {
         .type(step.answer);
     }
     cy.getByGeneralTestID(TESTID_WALKTHROUGH_FOOTER_NEXT).click();
+
+    // Test accessibility for the current step
+    cy.injectAxe();
+    cy.checkA11yWithErrorLogging();
   });
 
   if (walkthrough.result) {
-    if (walkthrough.result) {
-      const result = results[walkthrough.result];
-      if (result) {
-        cy.contains(result);
-      } else {
-        throw new Error("Result not defined in results data");
-      }
+    const result = results[walkthrough.result];
+    if (result) {
+      cy.contains(result);
+    } else {
+      throw new Error("Result not defined in results data");
     }
+    // Test accessibility for the result
+    cy.injectAxe();
+    cy.checkA11yWithErrorLogging();
   }
 };

--- a/packages/ui/src/button/Button.css
+++ b/packages/ui/src/button/Button.css
@@ -56,7 +56,7 @@
 }
 .ui-Button.--primary[data-disabled] {
   background-color: var(--surface-color-primary-button-disabled);
-  color: var(--typography-color-disabled);
+  color: var(--typography-color-disabled-accessible);
 }
 .ui-Button.--primary[data-hovered] {
   background-color: var(--surface-color-primary-button-hover);

--- a/packages/ui/src/header/Header.tsx
+++ b/packages/ui/src/header/Header.tsx
@@ -66,7 +66,7 @@ const getNavList = (onLinkClick: (href: string) => void) => {
 export default function Header({
   skipLinks,
   title = "",
-  titleElement = "span",
+  titleElement = "h1",
   logoSrc,
 }: PropsWithChildren<HeaderProps>) {
   // setup state

--- a/packages/ui/src/pdf-result-download/PdfResultDownload.css
+++ b/packages/ui/src/pdf-result-download/PdfResultDownload.css
@@ -79,6 +79,10 @@
   margin: var(--layout-margin-small);
 }
 
+.ui-PdfResultDownload-button:hover {
+  background-color: var(--surface-color-primary-button-hover);
+}
+
 .ui-PdfResultDownload-aside {
   display: flex;
   flex-direction: column;

--- a/packages/ui/src/pdf-result-download/PdfResultDownload.tsx
+++ b/packages/ui/src/pdf-result-download/PdfResultDownload.tsx
@@ -4,7 +4,6 @@
 import { ButtonProps as ReactAriaButtonProps } from "react-aria-components";
 
 import "./PdfResultDownload.css";
-import Button from "../button/Button";
 import Image from "../image/Image";
 import Icon from "@repo/ui/icon";
 import PrintContent, { PrintContentType } from "../print-content/PrintContent";
@@ -50,15 +49,10 @@ export default function PdfResultDownload({
           <h3 className="ui-PdfResultDownload-title">
             Download results & references as PDF
           </h3>
-          <Button
-            variant="primary"
-            onPress={handleDownload}
-            aria-label="Download walkthrough questions, answers, and references as PDF"
-            className="ui-PdfResultDownload-button"
-          >
+          <div className="ui-PdfResultDownload-button ui-Button --primary">
             <Icon type="download" />
             <span>Download</span>
-          </Button>
+          </div>
         </div>
       </div>
       <PrintContent contentType={PrintContentType.RESULTS} />

--- a/packages/ui/src/print-content/PrintContent.tsx
+++ b/packages/ui/src/print-content/PrintContent.tsx
@@ -209,9 +209,9 @@ export default function PrintContent({ contentType }: PrintContentProps) {
               <thead>
                 <tr>
                   <th colSpan={2}>
-                    <h5 className="ui-printContent--sectionTitle">
+                    <h4 className="ui-printContent--sectionTitle">
                       {group.sectionTitle}
-                    </h5>
+                    </h4>
                   </th>
                 </tr>
               </thead>
@@ -226,9 +226,9 @@ export default function PrintContent({ contentType }: PrintContentProps) {
                   <thead>
                     <tr>
                       <th className="ui-printContent--questionColumn">
-                        <h5 className="ui-printContent--sectionTitle">
+                        <h4 className="ui-printContent--sectionTitle">
                           {group.sectionTitle}
-                        </h5>
+                        </h4>
                       </th>
                     </tr>
                   </thead>

--- a/packages/ui/src/variables.css
+++ b/packages/ui/src/variables.css
@@ -171,7 +171,7 @@
   --typography-color-primary: #2d2d2d;
   --typography-color-secondary: #474543;
   --typography-color-placeholder: #9f9d9c;
-  --typography-color-disabled: #9f9d9c;
+  --typography-color-disabled: #565353;
   --typography-color-link: #255a90;
   --typography-color-danger: #ce3e39;
   --typography-color-primary-invert: #ffffff;

--- a/packages/ui/src/variables.css
+++ b/packages/ui/src/variables.css
@@ -30,7 +30,7 @@
     0 25.600000381469727px 57.599998474121094px 0 #00000038; /* Primarily used for dialogs */
   --surface-color-primary-button-default: #013366;
   --surface-color-primary-button-hover: #1e5189;
-  --surface-color-primary-button-disabled: #edebe9;
+  --surface-color-primary-button-disabled: #9f9d9c;
   --surface-color-primary-danger-button-default: #ce3e39;
   --surface-color-primary-danger-button-hover: #a2312d;
   --surface-color-primary-danger-button-disabled: #edebe9;
@@ -69,6 +69,7 @@
   --icons-color-primary: #2d2d2d;
   --icons-color-secondary: #474543;
   --icons-color-disabled: #9f9d9c;
+  --icons-color-disabled-accessible: #edebe9;
   --icons-color-link: #255a90;
   --icons-color-info: #053662;
   --icons-color-danger: #ce3e39;


### PR DESCRIPTION
<!-- You may remove any sections that are not applicable -->

[HOUSNAV-#](https://hous-bssb.atlassian.net/browse/HOUSNAV-#)

## Overview & Purpose
<!-- Please describe the purpose of your changes. Please also include relevant motivation and context. -->
Add `axe-core` accessibility testing to cypress test cases for each step and result.

## Summary of Changes
<!-- Please include a HIGH LEVEL overview of the code changes. (Added xyz fields to table, modified function to handle x case instead of y case, etc. )  -->
- Update `runWalkthrough` helper to run accessibility for each question and result
- Update application to correct any accessibility issues that came up
- Fixed the following issues on walkthrough questions and result pages:
    - Ensures the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds (color-contrast)
    - Heading levels should only increase by one
    - Interactive controls must not be nested

## Side Effects
<!-- Any possible side effects? Does this change affect features that are not linked to the direct purpose? -->
Time to run tests when from about `1:20s` to about `1:50s`. Which I think is an acceptable increase to run it for each question for every test case at this point.

Before:
![Screenshot 2024-07-23 at 10 12 44 AM](https://github.com/user-attachments/assets/319788ea-9fff-4709-afd8-c3719645f5d4)
After:
![Screenshot 2024-07-23 at 10 11 11 AM](https://github.com/user-attachments/assets/c1c9e564-e926-48a4-9f47-8c86fcc6ba0b)


## Testing
<!-- Please include steps to test out the changes/fixes if applicable OR context notes to help get env in a state to test-->
- e2e tests should pass. To verify they are actually running on each question you can locally change something like adding a h3 & h5 back to back which is out of order. This should trigger the accessibility test to fail.

**EXAMPLE**
If a test fails it will look like this and highlight the question in red that failed.
![Screenshot 2024-07-23 at 10 26 43 AM](https://github.com/user-attachments/assets/7b6d5bb0-1919-4401-a235-1361d0b37fa9)



## Notes & Resources
<!-- Please include any additional notes necessary to review PR and/or relevant links (documentation, stack overflow, etc.) that helped you arrive at your solution. -->
https://dequeuniversity.com/rules/axe/4.9/color-contrast?application=axeAPI
https://dequeuniversity.com/rules/axe/4.9

![Screenshot 2024-07-23 at 10 16 39 AM](https://github.com/user-attachments/assets/96032de4-109d-432c-9fad-b398744ead93)
![Screenshot 2024-07-23 at 10 16 24 AM](https://github.com/user-attachments/assets/2f108eda-92c6-45fc-ab89-4d31830620c3)
![Screenshot 2024-07-23 at 10 16 54 AM](https://github.com/user-attachments/assets/09f3de0e-5f70-4d68-804e-047908624452)

## Checklist
- [x] I have written or updated vitests for this work
- [x] I have reviewed the [accessibility guidelines](https://digital.gov.bc.ca/wcag/home/) relevant to this work
- [x] I have reviewed this work with at least one screen reader (when applicable)
- [x] I have added/updated any related documentation
