### PR TITLE
HOUSNAV-113: Enable "eager" image loading for pdf building code images

### DIFF
--- a/apps/web/components/question/Question.tsx
+++ b/apps/web/components/question/Question.tsx
@@ -48,7 +48,10 @@ const Question = observer(() => {
   // get question component
   const component = getQuestionComponent(currentQuestion.walkthroughItemType);
   return (
-    <div className="u-container-walkthrough" data-testid={TESTID_QUESTION}>
+    <div
+      className="u-container-walkthrough p-hide"
+      data-testid={TESTID_QUESTION}
+    >
       <h1
         className="web-Question--Title"
         id={ID_QUESTION_TEXT}

--- a/packages/ui/src/modal-building-code-content/ModalBuildingCodeContent.tsx
+++ b/packages/ui/src/modal-building-code-content/ModalBuildingCodeContent.tsx
@@ -274,6 +274,7 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
               aria-label={image.imageLabel}
               width={800}
               height={600}
+              loading="eager" // Will not lazy load images in Safari
               className="ui-ModalBuildingCodeContent-ImageResponsive"
             />
             {image.imageNotes && (


### PR DESCRIPTION
<!-- You may remove any sections that are not applicable -->

[HOUSNAV-113](https://hous-bssb.atlassian.net/browse/HOUSNAV-113)

## Overview & Purpose
<!-- Please describe the purpose of your changes. Please also include relevant motivation and context. -->
Fix issue where Safari did not load building code images in the PDF.

## Summary of Changes
<!-- Please include a HIGH LEVEL overview of the code changes. (Added xyz fields to table, modified function to handle x case instead of y case, etc. )  -->
- Add Eager loading for those images specifically (Was lazy loading)

## Side Effects
<!-- Any possible side effects? Does this change affect features that are not linked to the direct purpose? -->

## Testing
<!-- Please include steps to test out the changes/fixes if applicable OR context notes to help get env in a state to test-->
- Verify on Safari

## Notes & Resources
<!-- Please include any additional notes necessary to review PR and/or relevant links (documentation, stack overflow, etc.) that helped you arrive at your solution. -->

## Checklist
- [x] I have written or updated vitests for this work
- [x] I have reviewed the [accessibility guidelines](https://digital.gov.bc.ca/wcag/home/) relevant to this work
- [x] I have reviewed this work with at least one screen reader (when applicable)
- [x] I have added/updated any related documentation
