### PR TITLE
HOUSNAV-132: Widen pdf table borders to 2px

### DIFF
--- a/packages/ui/src/variables.css
+++ b/packages/ui/src/variables.css
@@ -265,7 +265,7 @@
   --step-tracker-tablet-up-display: none;
   --modal-side-number-padding: 8%;
   --modal-table-image-caption-margin-negative: -0.5rem;
-  --print-content-table-th-td-border: 1px solid #000;
+  --print-content-table-th-td-border: 2px solid #000;
   --pdf-result-download-image-border-radius: 8px 0px 0px 8px;
   --pdf-result-download-container-border: 1px solid
     var(--surface-color-border-default);


### PR DESCRIPTION
<!-- You may remove any sections that are not applicable -->

[HOUSNAV-132](https://hous-bssb.atlassian.net/browse/HOUSNAV-132)

## Overview & Purpose
<!-- Please describe the purpose of your changes. Please also include relevant motivation and context. -->
Some pdf viewers may not display 1px borders. This PR widens the border to 2px so all viewers can preview correctly.
**_This was ONLY an issue with the previewer. The downloading and printing still printed the borders correctly._**

## Summary of Changes
<!-- Please include a HIGH LEVEL overview of the code changes. (Added xyz fields to table, modified function to handle x case instead of y case, etc. )  -->
- Make table border 2px

## Side Effects
<!-- Any possible side effects? Does this change affect features that are not linked to the direct purpose? -->

## Testing
<!-- Please include steps to test out the changes/fixes if applicable OR context notes to help get env in a state to test-->
- Test on multiple browsers. They should all preview the borders now.

## Notes & Resources
<!-- Please include any additional notes necessary to review PR and/or relevant links (documentation, stack overflow, etc.) that helped you arrive at your solution. -->

## Checklist
- [x] I have written or updated vitests for this work
- [x] I have reviewed the [accessibility guidelines](https://digital.gov.bc.ca/wcag/home/) relevant to this work
- [x] I have reviewed this work with at least one screen reader (when applicable)
- [x] I have added/updated any related documentation
