### PR TITLE
HOUSNAV-42: Download Header Link A11y Text

### DIFF
--- a/packages/constants/src/urls.ts
+++ b/packages/constants/src/urls.ts
@@ -12,6 +12,7 @@ export const URLS_MAIN_NAVIGATION = [
     href: URL_DOWNLOAD_HREF,
     download: true,
     target: "_blank",
+    "aria-label": "Download the BC Building Code PDF in a new tab",
   },
 ];
 


### PR DESCRIPTION
[HOUSNAV-42](https://hous-bssb.atlassian.net/browse/HOUSNAV-42)

## Overview & Purpose
Adding text to the download header link to say it'll open a new tab for better accessibility.

## Checklist
- [x] I have written or updated vitests for this work
- [x] I have reviewed the [accessibility guidelines](https://digital.gov.bc.ca/wcag/home/) relevant to this work
- [x] I have reviewed this work with at least one screen reader (when applicable)
- [x] I have added/updated any related documentation
