### PR TITLE
HOUSNAV-36: Fix issue where confirmation modal doesn't show sometimes

### DIFF
--- a/apps/web/components/walkthrough/Walkthrough.tsx
+++ b/apps/web/components/walkthrough/Walkthrough.tsx
@@ -54,7 +54,7 @@ const Walkthrough = observer((): JSX.Element => {
       window.removeEventListener("beforeunload", handleBeforeUnload);
       window.removeEventListener("popstate", handlePopState);
     };
-  }, [blockBackNavigation]);
+  }, [blockBackNavigation, showModal]);
 
   const handleQuestionSubmit = useCallback(
     (event: FormEvent<HTMLFormElement>) => {

--- a/packages/ui/src/confirmation-modal/ConfirmationModal.tsx
+++ b/packages/ui/src/confirmation-modal/ConfirmationModal.tsx
@@ -47,6 +47,7 @@ export default function ConfirmationModal({
                     type="button"
                     className="dialog-button"
                     variant="secondary"
+                    aria-label="Cancel back navigation"
                     onPress={() => {
                       onCancel();
                       close();
@@ -58,6 +59,7 @@ export default function ConfirmationModal({
                     type="button"
                     className="dialog-button"
                     variant="primary"
+                    aria-label="Continue back navigation"
                     onPress={() => {
                       onConfirm();
                       close();


### PR DESCRIPTION
<!-- You may remove any sections that are not applicable -->

[HOUSNAV-36](https://hous-bssb.atlassian.net/browse/HOUSNAV-36)

## Overview & Purpose
<!-- Please describe the purpose of your changes. Please also include relevant motivation and context. -->
Fix issue where confirmation modal doesn't show sometimes

## Summary of Changes
<!-- Please include a HIGH LEVEL overview of the code changes. (Added xyz fields to table, modified function to handle x case instead of y case, etc. )  -->
Add show modal to use effect to ensure the event listeners are always in the right state.

## Side Effects
<!-- Any possible side effects? Does this change affect features that are not linked to the direct purpose? -->

## Testing
<!-- Please include steps to test out the changes/fixes if applicable OR context notes to help get env in a state to test-->
- On multiple questions within a flow hit the back button and then cancel. Then next question should always have the dialog pop up if you hit back again.

## Notes & Resources
<!-- Please include any additional notes necessary to review PR and/or relevant links (documentation, stack overflow, etc.) that helped you arrive at your solution. -->

## Checklist
- [x] I have written or updated vitests for this work
- [x] I have reviewed the [accessibility guidelines](https://digital.gov.bc.ca/wcag/home/) relevant to this work
- [x] I have reviewed this work with at least one screen reader (when applicable)
- [x] I have added/updated any related documentation
