### PR TITLE
HOUSNAV-116: Step Tracker Accessibility Fix

### DIFF
--- a/apps/web/components/step-tracker/StepTrackerItems.tsx
+++ b/apps/web/components/step-tracker/StepTrackerItems.tsx
@@ -5,7 +5,10 @@ import { observer } from "mobx-react-lite";
 // repo
 import Icon from "@repo/ui/icon";
 // local
-import { parseStringToComponents } from "../../utils/string";
+import {
+  getStringFromComponents,
+  parseStringToComponents,
+} from "../../utils/string";
 import { useWalkthroughState } from "../../stores/WalkthroughRootStore";
 import "./StepTrackerItems.css";
 import { TESTID_STEP_TRACKER_ITEMS } from "@repo/constants/src/testids";
@@ -42,13 +45,23 @@ const StepTrackerItems = observer(({ id }: { id?: string }): JSX.Element => {
           }
           const sectionComplete = sectionIsComplete(sectionId);
           const sectionSkipped = sectionWasSkipped(sectionId);
+          const isCurrentSection = sectionId === currentSectionId;
+          const sectionStatusArray = [
+            sectionComplete ? "is marked complete" : "",
+            sectionSkipped ? "is marked skipped" : "",
+            isCurrentSection ? "is the current section" : "",
+          ].filter(Boolean) as string[];
+          const sectionAriaLabel = `${section.sectionTitle} ${sectionStatusArray.join(" and ")}`;
 
           return (
             <li
               key={sectionId}
-              className={`web-StepTrackerItems--Section ${sectionId === currentSectionId ? "-currentSection" : ""} ${sectionSkipped ? "-skippedSection" : ""}`}
+              className={`web-StepTrackerItems--Section ${isCurrentSection ? "-currentSection" : ""} ${sectionSkipped ? "-skippedSection" : ""}`}
             >
-              <h3 className="web-StepTrackerItems--SectionTitle">
+              <h3
+                className="web-StepTrackerItems--SectionTitle"
+                aria-label={sectionAriaLabel}
+              >
                 <Icon
                   type="expandMore"
                   className="web-StepTrackerItems--SectionTitleToggleIcon"
@@ -70,18 +83,26 @@ const StepTrackerItems = observer(({ id }: { id?: string }): JSX.Element => {
                       sectionId,
                       sectionComplete,
                     );
+                    const isCurrentItem = itemId === currentItemId;
+                    const itemTextAsComponents = parseStringToComponents(
+                      getQuestionTextByQuestionId(itemId),
+                      undefined,
+                      true,
+                    );
+                    const itemStatusArray = [
+                      itemComplete ? "is marked complete" : "",
+                      itemSkipped ? "is marked skipped" : "",
+                      isCurrentItem ? "is the current step" : "",
+                    ].filter(Boolean) as string[];
+                    const itemAriaLabel = `${getStringFromComponents(itemTextAsComponents)} ${itemStatusArray.join(" and ")}`;
 
                     return (
                       <li
                         key={itemId}
-                        className={`web-StepTrackerItems--SectionItem ${itemId === currentItemId ? "-currentItem" : ""} ${itemSkipped ? "-skippedItem" : ""}`}
+                        className={`web-StepTrackerItems--SectionItem ${isCurrentItem ? "-currentItem" : ""} ${itemSkipped ? "-skippedItem" : ""}`}
                       >
-                        <h4 className="u-ellipsis">
-                          {parseStringToComponents(
-                            getQuestionTextByQuestionId(itemId),
-                            undefined,
-                            true,
-                          )}
+                        <h4 className="u-ellipsis" aria-label={itemAriaLabel}>
+                          {itemTextAsComponents}
                         </h4>
                         {itemComplete && <Icon type="check" />}
                       </li>
@@ -96,7 +117,10 @@ const StepTrackerItems = observer(({ id }: { id?: string }): JSX.Element => {
           key="results"
           className={`web-StepTrackerItems--Section ${currentResult ? "-currentSection" : ""}`}
         >
-          <h3 className="web-StepTrackerItems--SectionTitle">
+          <h3
+            className="web-StepTrackerItems--SectionTitle"
+            aria-label={`Results ${currentResult ? "is the current step" : ""}`}
+          >
             <span className="u-ellipsis">Results</span>
           </h3>
         </li>


### PR DESCRIPTION
[HOUSNAV-116](https://hous-bssb.atlassian.net/browse/HOUSNAV-116)

## Overview & Purpose
Add VO text so the status of the step tracker items is apparent to users using assistive technology

## Summary of Changes
Adding aria-labels to both the section names and steps that included text for all the possible states.

## Testing
As noted in the ticket, perform a few actions to get a couple parts of the step tracker into different states. Then turn on VO and have it read to you the section titles and steps names in the step tracker.

## Checklist
- [x] I have written or updated vitests for this work
- [x] I have reviewed the [accessibility guidelines](https://digital.gov.bc.ca/wcag/home/) relevant to this work
- [x] I have reviewed this work with at least one screen reader (when applicable)
- [x] I have added/updated any related documentation
