### PR TITLE
HOUSNAV-133: pdf sup formatting fix

### DIFF
--- a/packages/ui/src/print-content/PrintContent.css
+++ b/packages/ui/src/print-content/PrintContent.css
@@ -5,6 +5,10 @@
   overflow: hidden;
 }
 
+.ui-printContent--printContainer sup {
+  line-height: 0;
+}
+
 .ui-printContent--table th,
 .ui-printContent--table td {
   border: var(--print-content-table-th-td-border);

--- a/packages/ui/src/print-content/PrintContent.tsx
+++ b/packages/ui/src/print-content/PrintContent.tsx
@@ -135,8 +135,10 @@ export default function PrintContent({ contentType }: PrintContentProps) {
   ) => {
     return group.questions.map((sectionQuestions, sectionIndex) => {
       return sectionQuestions.questions.map((item, index) => {
-        const parsedQuestion = getStringFromComponents(
-          parseStringToComponents(item.question),
+        const parsedQuestion = parseStringToComponents(
+          item.question,
+          undefined,
+          true,
         );
         const parsedAnswer = getStringFromComponents(
           parseStringToComponents(item.answer),


### PR DESCRIPTION
[HOUSNAV-133](https://hous-bssb.atlassian.net/browse/HOUSNAV-133)

## Overview & Purpose
Fix formatting of the sup elements in pdf print view

## Summary of Changes
Updated parsing of question text to accomadate only removing certain HTML elements like the step tracker does

## Testing
Answer questions that have m² in them and view the PDF at the end.

## Checklist
- [x] I have written or updated vitests for this work
- [x] I have reviewed the [accessibility guidelines](https://digital.gov.bc.ca/wcag/home/) relevant to this work
- [x] I have reviewed this work with at least one screen reader (when applicable)
- [x] I have added/updated any related documentation
