### PR TITLE
HOUSNAV-122: Modal accessibility updates

### DIFF
--- a/apps/web/components/defined-term/DefinedTerm.tsx
+++ b/apps/web/components/defined-term/DefinedTerm.tsx
@@ -34,6 +34,7 @@ export default function DefinedTerm({
 
   const tooltipButton = (
     <Tooltip
+      tooltipLabel={`${term} select to open glossary modal`}
       tooltipContent={TooltipGlossaryData.get(tooltipTerm.toLocaleLowerCase())}
       triggerContent={button}
     ></Tooltip>

--- a/apps/web/components/defined-term/DefinedTerm.tsx
+++ b/apps/web/components/defined-term/DefinedTerm.tsx
@@ -34,7 +34,7 @@ export default function DefinedTerm({
 
   const tooltipButton = (
     <Tooltip
-      tooltipLabel={`${term} select to open glossary modal`}
+      tooltipLabel={`Select to open defined term modal`}
       tooltipContent={TooltipGlossaryData.get(tooltipTerm.toLocaleLowerCase())}
       triggerContent={button}
     ></Tooltip>

--- a/apps/web/components/question/Question.tsx
+++ b/apps/web/components/question/Question.tsx
@@ -22,7 +22,10 @@ import QuestionMultiChoiceMultiple from "./question-types/QuestionMultiChoiceMul
 import QuestionMissing from "./question-types/QuestionMissing";
 import QuestionNumberFloat from "./question-types/QuestionNumberFloat";
 import { useWalkthroughState } from "../../stores/WalkthroughRootStore";
-import { parseStringToComponents } from "../../utils/string";
+import {
+  getStringFromComponents,
+  parseStringToComponents,
+} from "../../utils/string";
 import "./Question.css";
 
 // helper function to get the correct question component
@@ -47,21 +50,33 @@ const Question = observer(() => {
 
   // get question component
   const component = getQuestionComponent(currentQuestion.walkthroughItemType);
+  const questionText = parseStringToComponents(
+    currentQuestion[PropertyNameQuestionText],
+  );
+  const questionSubtext = currentQuestion.questionSubtext
+    ? parseStringToComponents(currentQuestion.questionSubtext)
+    : null;
   return (
     <div
       className="u-container-walkthrough p-hide"
       data-testid={TESTID_QUESTION}
+      aria-label={getStringFromComponents(questionText)}
+      tabIndex={0}
     >
       <h1
         className="web-Question--Title"
         id={ID_QUESTION_TEXT}
         data-testid={TESTID_QUESTION_TITLE}
       >
-        {parseStringToComponents(currentQuestion[PropertyNameQuestionText])}
+        {questionText}
       </h1>
-      {currentQuestion.questionSubtext && (
-        <div className="web-Question--Subtext">
-          {parseStringToComponents(currentQuestion.questionSubtext)}
+      {questionSubtext && (
+        <div
+          className="web-Question--Subtext"
+          aria-label={getStringFromComponents(questionSubtext)}
+          tabIndex={0}
+        >
+          {questionSubtext}
         </div>
       )}
       {currentQuestion.questionCodeReference && (
@@ -73,7 +88,10 @@ const Question = observer(() => {
           <ModalSide
             type={ModalSideDataEnum.BUILDING_CODE}
             triggerContent={
-              <Button variant="code">
+              <Button
+                variant="code"
+                aria-label={`${currentQuestion.questionCodeReference.displayString} Select to open building code reference modal.`}
+              >
                 {currentQuestion.questionCodeReference.displayString}
               </Button>
             }

--- a/apps/web/utils/string.tsx
+++ b/apps/web/utils/string.tsx
@@ -115,6 +115,7 @@ export const parseStringToComponents = (
           case definedTermModal:
             return (
               <Tooltip
+                tooltipLabel={`Select to focus on ${tooltipTerm}`}
                 tooltipContent={TooltipGlossaryData.get(tooltipTerm)}
                 triggerContent={
                   <Button

--- a/packages/ui/src/modal-building-code-content/ModalBuildingCodeContent.tsx
+++ b/packages/ui/src/modal-building-code-content/ModalBuildingCodeContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useRef } from "react";
 import {
   ArticleType,
   SubClauseType,
@@ -38,6 +38,7 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
   sectionRefs = { current: {} },
   setFocusSection,
 }) => {
+  const liveRegionRef = useRef<HTMLDivElement>(null);
   const [printReference, setPrintReference] = useState<string | null>(null);
 
   useEffect(() => {
@@ -49,6 +50,9 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
   useEffect(() => {
     if (highlightedSection && sectionRefs.current[highlightedSection]) {
       sectionRefs.current[highlightedSection]?.focus();
+    }
+    if (highlightedSection && liveRegionRef.current) {
+      liveRegionRef.current.innerText = `Scroll or tab to navigate to new building code references.`;
     }
   }, [highlightedSection]);
 
@@ -344,6 +348,11 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
 
   return (
     <>
+      <span
+        ref={liveRegionRef}
+        aria-live="assertive"
+        className="ui-ModalSide--LiveRegion"
+      ></span>
       {!printData && modalData && renderParts(modalData)}
       {printData && renderPrintData()}
       {printReference && renderBuildingCodePdf()}

--- a/packages/ui/src/modal-building-code-content/ModalBuildingCodeContent.tsx
+++ b/packages/ui/src/modal-building-code-content/ModalBuildingCodeContent.tsx
@@ -46,6 +46,12 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
     }
   }, [printReference]);
 
+  useEffect(() => {
+    if (highlightedSection && sectionRefs.current[highlightedSection]) {
+      sectionRefs.current[highlightedSection]?.focus();
+    }
+  }, [highlightedSection]);
+
   const handleDownload = (numberReference: string) => {
     if (printReference == numberReference) {
       window.print();
@@ -80,6 +86,7 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
                 ? "ui-ModalSide--SectionHighlighted"
                 : ""
             }`}
+            tabIndex={0}
           >
             <span>
               {parseStringToComponents(data.description, setFocusSection)}
@@ -105,6 +112,7 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
                 ? "ui-ModalSide--SectionHighlighted"
                 : ""
             }`}
+            tabIndex={0}
           >
             {/* Designs do not show this high level of headings. */}
             {data.sections && renderSections(data.sections)}
@@ -128,6 +136,7 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
                 ? "ui-ModalSide--SectionHighlighted"
                 : ""
             }`}
+            tabIndex={0}
           >
             {/* Designs do not show this high level of headings. */}
             {data.subsections && renderSubSections(data.subsections)}
@@ -151,6 +160,7 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
                 ? "ui-ModalSide--SectionHighlighted"
                 : ""
             }`}
+            tabIndex={0}
           >
             <header className="ui-ModalSide--SubsectionHeaderLine">
               <Heading className="ui-ModalSide--SubsectionHeader">
@@ -192,6 +202,7 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
                 ? "ui-ModalSide--SectionHighlighted"
                 : ""
             }`}
+            tabIndex={0}
           >
             <header className="ui-ModalSide--ArticleHeaderLine">
               <Heading className="ui-ModalSide--ArticleHeader">
@@ -224,6 +235,7 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
                     ? "ui-ModalSide--SectionHighlighted"
                     : ""
                 }`}
+                tabIndex={0}
               >
                 {sentence.description && (
                   <span>
@@ -256,6 +268,7 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
               ? "ui-ModalSide--SectionHighlighted"
               : ""
           }`}
+          tabIndex={0}
         >
           <figure className="ui-ModalBuildingCodeContent--Figure">
             <figcaption>

--- a/packages/ui/src/modal-glossary-content/ModalGlossaryContent.css
+++ b/packages/ui/src/modal-glossary-content/ModalGlossaryContent.css
@@ -20,6 +20,13 @@
   display: inline;
 }
 
+.ui-ModalSide--LiveRegion {
+  position: absolute;
+  overflow: hidden;
+  width: 0px;
+  height: 0px;
+}
+
 /* TABLET - 608px */
 @media (min-width: 38rem) {
   .--glossary .ui-ModalSide--Article {

--- a/packages/ui/src/modal-glossary-content/ModalGlossaryContent.tsx
+++ b/packages/ui/src/modal-glossary-content/ModalGlossaryContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useEffect } from "react";
 import {
   GlossaryType,
   GlossaryContentType,
@@ -44,6 +44,12 @@ const GlossaryContent: React.FC<GlossaryContentProps> = ({
   sectionRefs,
   setFocusSection,
 }) => {
+  useEffect(() => {
+    if (highlightedSection && sectionRefs.current[highlightedSection]) {
+      sectionRefs.current[highlightedSection]?.focus();
+    }
+  }, [highlightedSection]);
+
   const handleDownload = () => {
     window.print();
   };
@@ -81,6 +87,7 @@ const GlossaryContent: React.FC<GlossaryContentProps> = ({
                     ? "ui-ModalSide--SectionHighlighted"
                     : ""
                 }`}
+                tabIndex={0}
               >
                 <div className="ui-ModalSide--ArticleContentWrapper">
                   {parseStringToComponents(

--- a/packages/ui/src/modal-glossary-content/ModalGlossaryContent.tsx
+++ b/packages/ui/src/modal-glossary-content/ModalGlossaryContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import {
   GlossaryType,
   GlossaryContentType,
@@ -44,9 +44,14 @@ const GlossaryContent: React.FC<GlossaryContentProps> = ({
   sectionRefs,
   setFocusSection,
 }) => {
+  const liveRegionRef = useRef<HTMLDivElement>(null);
+
   useEffect(() => {
     if (highlightedSection && sectionRefs.current[highlightedSection]) {
       sectionRefs.current[highlightedSection]?.focus();
+    }
+    if (highlightedSection && liveRegionRef.current) {
+      liveRegionRef.current.innerText = `Scroll or tab to navigate to new terms.`;
     }
   }, [highlightedSection]);
 
@@ -66,7 +71,7 @@ const GlossaryContent: React.FC<GlossaryContentProps> = ({
             <Button
               variant="secondary"
               onPress={() => handleDownload()}
-              aria-label={`Download Building Code Defined Terms`}
+              aria-label={`Download Building Code Section 1.4.1.2 Defined Terms`}
               className="ui-ModalSide-pdfButton"
             >
               <Icon type="download" />
@@ -74,6 +79,11 @@ const GlossaryContent: React.FC<GlossaryContentProps> = ({
             </Button>
           </Heading>
         </header>
+        <span
+          ref={liveRegionRef}
+          aria-live="assertive"
+          className="ui-ModalSide--LiveRegion"
+        ></span>
         {modalData.map(
           (data, index) =>
             !data.content?.hideTerm && (

--- a/packages/ui/src/modal-side/ModalSide.css
+++ b/packages/ui/src/modal-side/ModalSide.css
@@ -38,13 +38,10 @@
   animation: modal-slide-out 300ms reverse ease-in;
 }
 
-.ui-ModalSide--Header {
+.ui-ModalSide--Modal .ui-ButtonModalClose.--icon {
   z-index: 1;
   position: fixed;
   top: 0;
-}
-
-.ui-ModalSide--Header .ui-ButtonModalClose.--icon {
   right: var(--layout-margin-large);
   top: var(--layout-margin-medium);
 }

--- a/packages/ui/src/modal-side/ModalSide.tsx
+++ b/packages/ui/src/modal-side/ModalSide.tsx
@@ -78,12 +78,10 @@ export default function ModalSide({
           <Dialog className="ui-ModalSide--AriaDialog">
             {({ close }) => (
               <>
-                <header className="ui-ModalSide--Header">
-                  <ButtonModalClose
-                    label={`Close ${type} popup modal and return to walkthrough`}
-                    onPress={close}
-                  />
-                </header>
+                <ButtonModalClose
+                  label={`Close ${type} popup modal and return to walkthrough`}
+                  onPress={close}
+                />
                 <div className="ui-ModalSide--Content">
                   {type === ModalSideDataEnum.GLOSSARY && (
                     <GlossaryContent

--- a/packages/ui/src/modal-side/ModalSide.tsx
+++ b/packages/ui/src/modal-side/ModalSide.tsx
@@ -79,7 +79,10 @@ export default function ModalSide({
             {({ close }) => (
               <>
                 <header className="ui-ModalSide--Header">
-                  <ButtonModalClose label="Close modal" onPress={close} />
+                  <ButtonModalClose
+                    label={`Close ${type} popup modal and return to walkthrough`}
+                    onPress={close}
+                  />
                 </header>
                 <div className="ui-ModalSide--Content">
                   {type === ModalSideDataEnum.GLOSSARY && (

--- a/packages/ui/src/tooltip/Tooltip.css
+++ b/packages/ui/src/tooltip/Tooltip.css
@@ -22,3 +22,10 @@
   width: 25px;
   height: 12px;
 }
+
+.ui-Tooltip--HiddenLabel {
+  position: absolute;
+  overflow: hidden;
+  width: 0px;
+  height: 0px;
+}

--- a/packages/ui/src/tooltip/Tooltip.tsx
+++ b/packages/ui/src/tooltip/Tooltip.tsx
@@ -11,11 +11,13 @@ import Image from "@repo/ui/image";
 import "./Tooltip.css";
 
 export interface TooltipProps extends ReactAriaTooltipProps {
+  tooltipLabel: string;
   tooltipContent: ReactNode;
   triggerContent: ReactNode;
 }
 
 export default function Tooltip({
+  tooltipLabel,
   tooltipContent,
   triggerContent,
   ...props
@@ -27,7 +29,8 @@ export default function Tooltip({
         {...props}
         className="ui-Tooltip--Aria"
         placement="bottom"
-        aria-live="polite"
+        aria-live="assertive"
+        aria-label={tooltipLabel}
       >
         <Image
           src="tooltip-triangle.svg"


### PR DESCRIPTION
<!-- You may remove any sections that are not applicable -->

[HOUSNAV-122](https://hous-bssb.atlassian.net/browse/HOUSNAV-122)

## Overview & Purpose
<!-- Please describe the purpose of your changes. Please also include relevant motivation and context. -->
Enhance the accessibility of the application by improving screen reader readouts when the modal opens and terms are highlighted.

## Summary of Changes
<!-- Please include a HIGH LEVEL overview of the code changes. (Added xyz fields to table, modified function to handle x case instead of y case, etc. )  -->
- Add tab indexes where necessary to improve keyboard accessiblity
- Focus on building code and terms when modal is open so screen reader can read that first
- Added hidden text that will be read after a building code or glossary section is read to inform user they can scroll or tab
- Improved modal close label

## Side Effects
<!-- Any possible side effects? Does this change affect features that are not linked to the direct purpose? -->

## Testing
<!-- Please include steps to test out the changes/fixes if applicable OR context notes to help get env in a state to test-->
Use a screen reader when navigating the application and check A/C in ticket
- I didn't add any new accessibility tests for the modal since they are failing and I wanted to make sure this is done before I leave.

## Notes & Resources
<!-- Please include any additional notes necessary to review PR and/or relevant links (documentation, stack overflow, etc.) that helped you arrive at your solution. -->

## Checklist
- [ ] I have written or updated vitests for this work
- [x] I have reviewed the [accessibility guidelines](https://digital.gov.bc.ca/wcag/home/) relevant to this work
- [x] I have reviewed this work with at least one screen reader (when applicable)
- [x] I have added/updated any related documentation
