### PR TITLE
HOUSNAV-67: Accessible Disabled Button

### DIFF
--- a/packages/ui/src/button/Button.css
+++ b/packages/ui/src/button/Button.css
@@ -14,9 +14,11 @@
   transition: var(--transition-link-background-color),
     var(--transition-link-color);
 }
-.ui-Button[data-disabled] {
-  cursor: not-allowed;
+.ui-Button[aria-disabled] {
+  pointer-events: none;
 }
+
+.ui-Button[aria-disabled]:focus,
 .ui-Button[data-focus-visible] {
   outline: var(--layout-border-width-medium) solid
     var(--surface-color-border-active);
@@ -54,9 +56,9 @@
   background: var(--surface-color-primary-button-default);
   color: var(--icons-color-primary-invert);
 }
-.ui-Button.--primary[data-disabled] {
+.ui-Button.--primary[aria-disabled] {
   background-color: var(--surface-color-primary-button-disabled);
-  color: var(--typography-color-disabled-accessible);
+  color: var(--typography-color-disabled);
 }
 .ui-Button.--primary[data-hovered] {
   background-color: var(--surface-color-primary-button-hover);
@@ -72,7 +74,7 @@
     var(--surface-color-border-dark);
   color: var(--typography-color-primary);
 }
-.ui-Button.--secondary[data-disabled] {
+.ui-Button.--secondary[aria-disabled] {
   background-color: var(--surface-color-secondary-button-disabled);
   border-color: var(--surface-color-border-default);
   color: var(--typography-color-disabled);
@@ -89,7 +91,7 @@
   background-color: var(--surface-color-tertiary-button-default);
   color: var(--theme-primary-blue);
 }
-.ui-Button.--tertiary[data-disabled] {
+.ui-Button.--tertiary[aria-disabled] {
   color: var(--typography-color-disabled);
 }
 .ui-Button.--tertiary[data-hovered] {
@@ -107,7 +109,7 @@
   text-underline-offset: var(--link-underline-offset);
   text-decoration: underline;
 }
-.ui-Button.--link[data-disabled] {
+.ui-Button.--link[aria-disabled] {
   color: var(--typography-color-disabled);
 }
 .ui-Button.--link[data-hovered] {
@@ -127,7 +129,7 @@
   gap: var(--layout-padding-xxsmall);
   padding: var(--layout-padding-xxsmall) var(--layout-padding-xsmall);
 }
-.ui-Button.--code[data-disabled] {
+.ui-Button.--code[aria-disabled] {
   color: var(--typography-color-disabled);
 }
 .ui-Button.--code[data-hovered] {

--- a/packages/ui/src/button/Button.tsx
+++ b/packages/ui/src/button/Button.tsx
@@ -1,5 +1,6 @@
 "use client";
 // 3rd party
+import type { ReactNode } from "react";
 import {
   Button as ReactAriaButton,
   ButtonProps as ReactAriaButtonProps,
@@ -37,29 +38,52 @@ export interface ButtonProps extends ReactAriaButtonProps {
    * eg. `data-testid="button-passedValue"`.
    */
   "data-testid"?: string;
+  children?: ReactNode;
 }
 
 export const codeIconType = "arrowOutward";
+
+const buttonChildren = (variant: ButtonVariant, children?: ReactNode) => {
+  return (
+    <>
+      {children}
+      {variant === "code" ? <Icon type={codeIconType} /> : null}
+    </>
+  );
+};
 
 export default function Button({
   variant = "primary",
   isIconButton = false,
   isLargeButton = false,
+  isDisabled,
   "data-testid": testid = "",
   className,
   children,
   ...props
 }: ButtonProps) {
+  // return html button if isDisabled is true since react-aria eats the aria-disabled prop
+  // The proposed solutions listed in this issue on GitHub don't work for our case:
+  // https://github.com/adobe/react-spectrum/issues/3662
+  if (isDisabled) {
+    return (
+      <button
+        data-testid={GET_TESTID_BUTTON(testid || variant)}
+        className={`ui-Button --${variant} ${isLargeButton ? "--large" : ""} ${isIconButton ? "--icon" : ""} ${className}`}
+        aria-disabled
+      >
+        {buttonChildren(variant, children)}
+      </button>
+    );
+  }
+
   return (
     <ReactAriaButton
       data-testid={GET_TESTID_BUTTON(testid || variant)}
       className={`ui-Button --${variant} ${isLargeButton ? "--large" : ""} ${isIconButton ? "--icon" : ""} ${className}`}
       {...props}
     >
-      <>
-        {children}
-        {variant === "code" ? <Icon type={codeIconType} /> : null}
-      </>
+      {buttonChildren(variant, children)}
     </ReactAriaButton>
   );
 }

--- a/packages/ui/src/variables.css
+++ b/packages/ui/src/variables.css
@@ -30,7 +30,7 @@
     0 25.600000381469727px 57.599998474121094px 0 #00000038; /* Primarily used for dialogs */
   --surface-color-primary-button-default: #013366;
   --surface-color-primary-button-hover: #1e5189;
-  --surface-color-primary-button-disabled: #9f9d9c;
+  --surface-color-primary-button-disabled: #edebe9;
   --surface-color-primary-danger-button-default: #ce3e39;
   --surface-color-primary-danger-button-hover: #a2312d;
   --surface-color-primary-danger-button-disabled: #edebe9;
@@ -175,7 +175,7 @@
   --typography-color-primary: #2d2d2d;
   --typography-color-secondary: #474543;
   --typography-color-placeholder: #9f9d9c;
-  --typography-color-disabled: #565353;
+  --typography-color-disabled: #6d6969;
   --typography-color-link: #255a90;
   --typography-color-danger: #ce3e39;
   --typography-color-primary-invert: #ffffff;


### PR DESCRIPTION
[HOUSNAV-67](https://hous-bssb.atlassian.net/browse/HOUSNAV-67)

## Overview & Purpose
Make disabled buttons accessible to users navigating via tabbing. 

## Summary of Changes
Returned a standard HTML <button> element for disabled buttons instead of using React Aria Components
Updated styles based on changes
Updated colors to be closer to design but still accessible

## Testing
Us a walkthrough and see the ability to tab to disabled buttons in the walkthrough footer

## Checklist
- [x] I have written or updated vitests for this work
- [x] I have reviewed the [accessibility guidelines](https://digital.gov.bc.ca/wcag/home/) relevant to this work
- [x] I have reviewed this work with at least one screen reader (when applicable)
- [x] I have added/updated any related documentation
