### PR TITLE
HOUSNAV-122 & 137: Modal Accessibility

### DIFF
--- a/apps/web/components/defined-term/DefinedTerm.tsx
+++ b/apps/web/components/defined-term/DefinedTerm.tsx
@@ -34,6 +34,7 @@ export default function DefinedTerm({
 
   const tooltipButton = (
     <Tooltip
+      tooltipLabel={`${term} select to open glossary modal`}
       tooltipContent={TooltipGlossaryData.get(tooltipTerm.toLocaleLowerCase())}
       triggerContent={button}
     ></Tooltip>

--- a/apps/web/components/defined-term/DefinedTerm.tsx
+++ b/apps/web/components/defined-term/DefinedTerm.tsx
@@ -34,7 +34,7 @@ export default function DefinedTerm({
 
   const tooltipButton = (
     <Tooltip
-      tooltipLabel={`${term} select to open glossary modal`}
+      tooltipLabel={`Select to open defined term modal`}
       tooltipContent={TooltipGlossaryData.get(tooltipTerm.toLocaleLowerCase())}
       triggerContent={button}
     ></Tooltip>

--- a/apps/web/components/question/Question.tsx
+++ b/apps/web/components/question/Question.tsx
@@ -22,7 +22,10 @@ import QuestionMultiChoiceMultiple from "./question-types/QuestionMultiChoiceMul
 import QuestionMissing from "./question-types/QuestionMissing";
 import QuestionNumberFloat from "./question-types/QuestionNumberFloat";
 import { useWalkthroughState } from "../../stores/WalkthroughRootStore";
-import { parseStringToComponents } from "../../utils/string";
+import {
+  getStringFromComponents,
+  parseStringToComponents,
+} from "../../utils/string";
 import "./Question.css";
 
 // helper function to get the correct question component
@@ -47,21 +50,33 @@ const Question = observer(() => {
 
   // get question component
   const component = getQuestionComponent(currentQuestion.walkthroughItemType);
+  const questionText = parseStringToComponents(
+    currentQuestion[PropertyNameQuestionText],
+  );
+  const questionSubtext = currentQuestion.questionSubtext
+    ? parseStringToComponents(currentQuestion.questionSubtext)
+    : null;
   return (
     <div
       className="u-container-walkthrough p-hide"
       data-testid={TESTID_QUESTION}
+      aria-label={getStringFromComponents(questionText)}
+      tabIndex={0}
     >
       <h1
         className="web-Question--Title"
         id={ID_QUESTION_TEXT}
         data-testid={TESTID_QUESTION_TITLE}
       >
-        {parseStringToComponents(currentQuestion[PropertyNameQuestionText])}
+        {questionText}
       </h1>
-      {currentQuestion.questionSubtext && (
-        <div className="web-Question--Subtext">
-          {parseStringToComponents(currentQuestion.questionSubtext)}
+      {questionSubtext && (
+        <div
+          className="web-Question--Subtext"
+          aria-label={getStringFromComponents(questionSubtext)}
+          tabIndex={0}
+        >
+          {questionSubtext}
         </div>
       )}
       {currentQuestion.questionCodeReference && (
@@ -73,7 +88,10 @@ const Question = observer(() => {
           <ModalSide
             type={ModalSideDataEnum.BUILDING_CODE}
             triggerContent={
-              <Button variant="code">
+              <Button
+                variant="code"
+                aria-label={`${currentQuestion.questionCodeReference.displayString} Select to open building code reference modal.`}
+              >
                 {currentQuestion.questionCodeReference.displayString}
               </Button>
             }

--- a/apps/web/utils/string.tsx
+++ b/apps/web/utils/string.tsx
@@ -115,6 +115,7 @@ export const parseStringToComponents = (
           case definedTermModal:
             return (
               <Tooltip
+                tooltipLabel={`Select to focus on ${tooltipTerm}`}
                 tooltipContent={TooltipGlossaryData.get(tooltipTerm)}
                 triggerContent={
                   <Button

--- a/apps/web/utils/string.tsx
+++ b/apps/web/utils/string.tsx
@@ -6,7 +6,6 @@ import parse, {
   domToReact,
   attributesToProps,
 } from "html-react-parser";
-import { Heading } from "react-aria-components";
 // repo
 import Button from "@repo/ui/button";
 import Tooltip from "@repo/ui/tooltip";
@@ -146,9 +145,9 @@ export const parseStringToComponents = (
 
           case glossaryTerm:
             return (
-              <Heading level={3} className="ui-ModalSide--Term">
+              <span className="ui-ModalSide--Term">
                 {domToReact(domNode.children as DOMNode[]) as string}
-              </Heading>
+              </span>
             );
 
           case buildingCode:

--- a/packages/ui/src/modal-building-code-content/ModalBuildingCodeContent.tsx
+++ b/packages/ui/src/modal-building-code-content/ModalBuildingCodeContent.tsx
@@ -155,7 +155,7 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
             }`}
             tabIndex={0}
           >
-            <Heading className="ui-ModalSide--SubsectionHeader">
+            <Heading level={2} className="ui-ModalSide--SubsectionHeader">
               <span className="ui-ModalSide--SubsectionNumber">
                 {stripReferencePrefix(data.numberReference)}{" "}
               </span>

--- a/packages/ui/src/modal-building-code-content/ModalBuildingCodeContent.tsx
+++ b/packages/ui/src/modal-building-code-content/ModalBuildingCodeContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useRef } from "react";
 import {
   ArticleType,
   SubClauseType,
@@ -38,6 +38,7 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
   sectionRefs = { current: {} },
   setFocusSection,
 }) => {
+  const liveRegionRef = useRef<HTMLDivElement>(null);
   const [printReference, setPrintReference] = useState<string | null>(null);
 
   useEffect(() => {
@@ -49,6 +50,9 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
   useEffect(() => {
     if (highlightedSection && sectionRefs.current[highlightedSection]) {
       sectionRefs.current[highlightedSection]?.focus();
+    }
+    if (highlightedSection && liveRegionRef.current) {
+      liveRegionRef.current.innerText = `Scroll or tab to navigate to new building code references.`;
     }
   }, [highlightedSection]);
 
@@ -344,6 +348,11 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
 
   return (
     <>
+      <span
+        ref={liveRegionRef}
+        aria-live="assertive"
+        className="ui-ModalSide--LiveRegion"
+      ></span>
       {!printData && modalData && renderParts(modalData)}
       {printData && renderPrintData()}
       {printReference && renderBuildingCodePdf()}

--- a/packages/ui/src/modal-building-code-content/ModalBuildingCodeContent.tsx
+++ b/packages/ui/src/modal-building-code-content/ModalBuildingCodeContent.tsx
@@ -106,7 +106,7 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
     return (
       (!!parts &&
         parts.map((data, index) => (
-          <div
+          <ol
             key={index}
             ref={(el) => {
               sectionRefs.current[data.numberReference] = el;
@@ -120,7 +120,7 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
           >
             {/* Designs do not show this high level of headings. */}
             {data.sections && renderSections(data.sections)}
-          </div>
+          </ol>
         ))) ??
       null
     );
@@ -130,21 +130,10 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
     return (
       (!!sections &&
         sections.map((data, index) => (
-          <div
-            key={index}
-            ref={(el) => {
-              sectionRefs.current[data.numberReference] = el;
-            }}
-            className={`${
-              highlightedSection === data.numberReference
-                ? "ui-ModalSide--SectionHighlighted"
-                : ""
-            }`}
-            tabIndex={0}
-          >
+          <li key={index}>
             {/* Designs do not show this high level of headings. */}
-            {data.subsections && renderSubSections(data.subsections)}
-          </div>
+            <ol>{data.subsections && renderSubSections(data.subsections)}</ol>
+          </li>
         ))) ??
       null
     );
@@ -154,7 +143,7 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
     return (
       (!!subSections &&
         subSections.map((data, index) => (
-          <article
+          <li
             key={index}
             ref={(el) => {
               sectionRefs.current[data.numberReference] = el;
@@ -166,27 +155,25 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
             }`}
             tabIndex={0}
           >
-            <header className="ui-ModalSide--SubsectionHeaderLine">
-              <Heading className="ui-ModalSide--SubsectionHeader">
-                <span className="ui-ModalSide--SubsectionNumber">
-                  {stripReferencePrefix(data.numberReference)}{" "}
-                </span>
-                {data.title}
-                {!printData && (
-                  <Button
-                    variant="secondary"
-                    onPress={() => handleDownload(data.numberReference)}
-                    aria-label={`Download Building Code Subsection ${stripReferencePrefix(data.numberReference)} ${data.title}`}
-                    className="ui-ModalSide-pdfButton"
-                  >
-                    <Icon type="download" />
-                    <span>PDF</span>
-                  </Button>
-                )}
-              </Heading>
-            </header>
-            {data.articles && renderArticles(data.articles)}
-          </article>
+            <Heading className="ui-ModalSide--SubsectionHeader">
+              <span className="ui-ModalSide--SubsectionNumber">
+                {stripReferencePrefix(data.numberReference)}{" "}
+              </span>
+              {data.title}
+              {!printData && (
+                <Button
+                  variant="secondary"
+                  onPress={() => handleDownload(data.numberReference)}
+                  aria-label={`Download Building Code Subsection ${stripReferencePrefix(data.numberReference)} ${data.title}`}
+                  className="ui-ModalSide-pdfButton"
+                >
+                  <Icon type="download" />
+                  <span>PDF</span>
+                </Button>
+              )}
+            </Heading>
+            <ol>{data.articles && renderArticles(data.articles)}</ol>
+          </li>
         ))) ??
       null
     );
@@ -196,7 +183,7 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
     return (
       (!!articles &&
         articles.map((data, index) => (
-          <article
+          <li
             key={index}
             ref={(el) => {
               sectionRefs.current[data.numberReference] = el;
@@ -208,16 +195,14 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
             }`}
             tabIndex={0}
           >
-            <header className="ui-ModalSide--ArticleHeaderLine">
-              <Heading className="ui-ModalSide--ArticleHeader">
-                <span className="ui-ModalSide--ArticleNumber">
-                  {stripReferencePrefix(data.numberReference)}{" "}
-                </span>
-                {data.title}
-              </Heading>
-            </header>
-            {data.sentences && renderSentences(data.sentences)}
-          </article>
+            <Heading className="ui-ModalSide--ArticleHeader">
+              <span className="ui-ModalSide--ArticleNumber">
+                {stripReferencePrefix(data.numberReference)}{" "}
+              </span>
+              {data.title}
+            </Heading>
+            <ol>{data.sentences && renderSentences(data.sentences)}</ol>
+          </li>
         ))) ??
       null
     );
@@ -225,37 +210,35 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
 
   const renderSentences = (sentences: SentenceType[]) => {
     return (
-      <div className="ui-ModalSide--ArticleContentWrapper">
-        <div className="ui-ModalSide--ArticleContent">
-          <ol className="ui-ModalSide--Sentences">
-            {sentences.map((sentence, index) => (
-              <li
-                key={index}
-                ref={(el) => {
-                  sectionRefs.current[sentence.numberReference] = el;
-                }}
-                className={`${
-                  highlightedSection === sentence.numberReference
-                    ? "ui-ModalSide--SectionHighlighted"
-                    : ""
-                }`}
-                tabIndex={0}
-              >
-                {sentence.description && (
-                  <span>
-                    {parseStringToComponents(
-                      sentence.description,
-                      setFocusSection,
-                    )}
-                  </span>
-                )}
-                {sentence.clauses && renderClauses(sentence.clauses)}
-                {sentence.image && renderTableImage(sentence.image)}
-              </li>
-            ))}
-          </ol>
-        </div>
-      </div>
+      <li className="ui-ModalSide--ArticleContent">
+        <ol className="ui-ModalSide--Sentences">
+          {sentences.map((sentence, index) => (
+            <li
+              key={index}
+              ref={(el) => {
+                sectionRefs.current[sentence.numberReference] = el;
+              }}
+              className={`${
+                highlightedSection === sentence.numberReference
+                  ? "ui-ModalSide--SectionHighlighted"
+                  : ""
+              }`}
+              tabIndex={0}
+            >
+              {sentence.description && (
+                <span>
+                  {parseStringToComponents(
+                    sentence.description,
+                    setFocusSection,
+                  )}
+                </span>
+              )}
+              {sentence.clauses && renderClauses(sentence.clauses)}
+              {sentence.image && renderTableImage(sentence.image)}
+            </li>
+          ))}
+        </ol>
+      </li>
     );
   };
 

--- a/packages/ui/src/modal-building-code-content/ModalBuildingCodeContent.tsx
+++ b/packages/ui/src/modal-building-code-content/ModalBuildingCodeContent.tsx
@@ -46,6 +46,12 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
     }
   }, [printReference]);
 
+  useEffect(() => {
+    if (highlightedSection && sectionRefs.current[highlightedSection]) {
+      sectionRefs.current[highlightedSection]?.focus();
+    }
+  }, [highlightedSection]);
+
   const handleDownload = (numberReference: string) => {
     if (printReference == numberReference) {
       window.print();
@@ -80,6 +86,7 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
                 ? "ui-ModalSide--SectionHighlighted"
                 : ""
             }`}
+            tabIndex={0}
           >
             <span>
               {parseStringToComponents(data.description, setFocusSection)}
@@ -105,6 +112,7 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
                 ? "ui-ModalSide--SectionHighlighted"
                 : ""
             }`}
+            tabIndex={0}
           >
             {/* Designs do not show this high level of headings. */}
             {data.sections && renderSections(data.sections)}
@@ -128,6 +136,7 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
                 ? "ui-ModalSide--SectionHighlighted"
                 : ""
             }`}
+            tabIndex={0}
           >
             {/* Designs do not show this high level of headings. */}
             {data.subsections && renderSubSections(data.subsections)}
@@ -151,6 +160,7 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
                 ? "ui-ModalSide--SectionHighlighted"
                 : ""
             }`}
+            tabIndex={0}
           >
             <header className="ui-ModalSide--SubsectionHeaderLine">
               <Heading className="ui-ModalSide--SubsectionHeader">
@@ -192,6 +202,7 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
                 ? "ui-ModalSide--SectionHighlighted"
                 : ""
             }`}
+            tabIndex={0}
           >
             <header className="ui-ModalSide--ArticleHeaderLine">
               <Heading className="ui-ModalSide--ArticleHeader">
@@ -224,6 +235,7 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
                     ? "ui-ModalSide--SectionHighlighted"
                     : ""
                 }`}
+                tabIndex={0}
               >
                 {sentence.description && (
                   <span>
@@ -256,6 +268,7 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
               ? "ui-ModalSide--SectionHighlighted"
               : ""
           }`}
+          tabIndex={0}
         >
           <figure className="ui-ModalBuildingCodeContent--Figure">
             <figcaption>

--- a/packages/ui/src/modal-glossary-content/ModalGlossaryContent.css
+++ b/packages/ui/src/modal-glossary-content/ModalGlossaryContent.css
@@ -20,6 +20,13 @@
   display: inline;
 }
 
+.ui-ModalSide--LiveRegion {
+  position: absolute;
+  overflow: hidden;
+  width: 0px;
+  height: 0px;
+}
+
 /* TABLET - 608px */
 @media (min-width: 38rem) {
   .--glossary .ui-ModalSide--Article {

--- a/packages/ui/src/modal-glossary-content/ModalGlossaryContent.css
+++ b/packages/ui/src/modal-glossary-content/ModalGlossaryContent.css
@@ -1,10 +1,11 @@
-.--glossary .ui-ModalSide--ArticleContentWrapper {
-  padding-inline: var(--layout-padding-medium);
-}
-
 .--glossary .ui-ModalSide--Article {
   margin-top: var(--layout-margin-medium);
-  padding-bottom: 0;
+  padding-inline: var(--layout-padding-medium);
+  padding-block: var(--layout-padding-small);
+}
+
+.--glossary .ui-ModalSide--Subsection > ol {
+  list-style: none;
 }
 
 .ui-ModalSide--List {
@@ -23,13 +24,15 @@
 .ui-ModalSide--LiveRegion {
   position: absolute;
   overflow: hidden;
-  width: 0px;
-  height: 0px;
+  width: 0;
+  height: 0;
 }
 
 /* TABLET - 608px */
 @media (min-width: 38rem) {
   .--glossary .ui-ModalSide--Article {
-    padding-left: calc(var(--modal-bc-indent) + var(--layout-margin-large));
+    padding-left: calc(
+      var(--modal-bc-indent) + var(--layout-margin-xxlarge) + 0.2rem
+    );
   }
 }

--- a/packages/ui/src/modal-glossary-content/ModalGlossaryContent.tsx
+++ b/packages/ui/src/modal-glossary-content/ModalGlossaryContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useEffect } from "react";
 import {
   GlossaryType,
   GlossaryContentType,
@@ -44,6 +44,12 @@ const GlossaryContent: React.FC<GlossaryContentProps> = ({
   sectionRefs,
   setFocusSection,
 }) => {
+  useEffect(() => {
+    if (highlightedSection && sectionRefs.current[highlightedSection]) {
+      sectionRefs.current[highlightedSection]?.focus();
+    }
+  }, [highlightedSection]);
+
   const handleDownload = () => {
     window.print();
   };
@@ -81,6 +87,7 @@ const GlossaryContent: React.FC<GlossaryContentProps> = ({
                     ? "ui-ModalSide--SectionHighlighted"
                     : ""
                 }`}
+                tabIndex={0}
               >
                 <div className="ui-ModalSide--ArticleContentWrapper">
                   {parseStringToComponents(

--- a/packages/ui/src/modal-glossary-content/ModalGlossaryContent.tsx
+++ b/packages/ui/src/modal-glossary-content/ModalGlossaryContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import {
   GlossaryType,
   GlossaryContentType,
@@ -44,9 +44,14 @@ const GlossaryContent: React.FC<GlossaryContentProps> = ({
   sectionRefs,
   setFocusSection,
 }) => {
+  const liveRegionRef = useRef<HTMLDivElement>(null);
+
   useEffect(() => {
     if (highlightedSection && sectionRefs.current[highlightedSection]) {
       sectionRefs.current[highlightedSection]?.focus();
+    }
+    if (highlightedSection && liveRegionRef.current) {
+      liveRegionRef.current.innerText = `Scroll or tab to navigate to new terms.`;
     }
   }, [highlightedSection]);
 
@@ -66,7 +71,7 @@ const GlossaryContent: React.FC<GlossaryContentProps> = ({
             <Button
               variant="secondary"
               onPress={() => handleDownload()}
-              aria-label={`Download Building Code Defined Terms`}
+              aria-label={`Download Building Code Section 1.4.1.2 Defined Terms`}
               className="ui-ModalSide-pdfButton"
             >
               <Icon type="download" />
@@ -74,6 +79,11 @@ const GlossaryContent: React.FC<GlossaryContentProps> = ({
             </Button>
           </Heading>
         </header>
+        <span
+          ref={liveRegionRef}
+          aria-live="assertive"
+          className="ui-ModalSide--LiveRegion"
+        ></span>
         {modalData.map(
           (data, index) =>
             !data.content?.hideTerm && (

--- a/packages/ui/src/modal-glossary-content/ModalGlossaryContent.tsx
+++ b/packages/ui/src/modal-glossary-content/ModalGlossaryContent.tsx
@@ -27,12 +27,10 @@ function renderDefinitionList(
   return (
     <ul className="ui-ModalSide--List">
       {definitionList.map((item, index) => (
-        <>
-          <li key={index}>
-            {parseStringToComponents(item.definition, customHandler)}
-          </li>
+        <li key={index}>
+          {parseStringToComponents(item.definition, customHandler)}
           {item.definitionList && renderDefinitionList(item.definitionList)}
-        </>
+        </li>
       ))}
     </ul>
   );
@@ -84,22 +82,22 @@ const GlossaryContent: React.FC<GlossaryContentProps> = ({
           aria-live="assertive"
           className="ui-ModalSide--LiveRegion"
         ></span>
-        {modalData.map(
-          (data, index) =>
-            !data.content?.hideTerm && (
-              <article
-                key={index}
-                ref={(el) => {
-                  sectionRefs.current[data.reference] = el;
-                }}
-                className={`ui-ModalSide--Article ${
-                  highlightedSection === data.reference
-                    ? "ui-ModalSide--SectionHighlighted"
-                    : ""
-                }`}
-                tabIndex={0}
-              >
-                <div className="ui-ModalSide--ArticleContentWrapper">
+        <ol>
+          {modalData.map(
+            (data, index) =>
+              !data.content?.hideTerm && (
+                <li
+                  key={index}
+                  ref={(el) => {
+                    sectionRefs.current[data.reference] = el;
+                  }}
+                  className={`ui-ModalSide--Article ${
+                    highlightedSection === data.reference
+                      ? "ui-ModalSide--SectionHighlighted"
+                      : ""
+                  }`}
+                  tabIndex={0}
+                >
                   {parseStringToComponents(
                     (data.content as GlossaryContentType).definition,
                     setFocusSection,
@@ -109,10 +107,10 @@ const GlossaryContent: React.FC<GlossaryContentProps> = ({
                       data.content.definitionList,
                       setFocusSection,
                     )}
-                </div>
-              </article>
-            ),
-        )}
+                </li>
+              ),
+          )}
+        </ol>
       </article>
     </div>
   );

--- a/packages/ui/src/modal-side/ModalSide.css
+++ b/packages/ui/src/modal-side/ModalSide.css
@@ -41,7 +41,6 @@
 .ui-ModalSide--Modal .ui-ButtonModalClose.--icon {
   z-index: 1;
   position: fixed;
-  top: 0;
   right: var(--layout-margin-large);
   top: var(--layout-margin-medium);
 }
@@ -54,9 +53,14 @@
   height: 100vh;
 }
 
+.ui-ModalSide--Parts ol {
+  list-style: none;
+}
+
 .ui-ModalSide--Parts {
   padding: var(--modal-bc-padding);
   margin-top: 80px;
+  list-style: none;
 }
 
 .ui-ModalSide--Parts sup {
@@ -99,12 +103,8 @@
   margin-top: var(--layout-margin-large);
 }
 
-.ui-ModalSide--ArticleContentWrapper {
-  padding: var(--layout-padding-small);
-  margin: 0;
-}
-
 .ui-ModalSide--ArticleContent {
+  padding: var(--layout-padding-small);
   font: var(--typography-regular-body);
 }
 
@@ -247,11 +247,11 @@
     );
     margin-left: auto;
   }
-  .ui-ModalSide--ArticleContentWrapper {
-    padding-left: var(--layout-margin-large);
-  }
   .ui-ModalSide--ArticleContent {
-    padding-left: calc(var(--modal-bc-indent) + var(--layout-margin-small));
+    padding-left: calc(
+      var(--modal-bc-indent) + var(--layout-margin-small) +
+        var(--layout-margin-large)
+    );
   }
   .ui-ModalSide--Sentences > li {
     margin-left: calc(var(--layout-margin-small) * -1);

--- a/packages/ui/src/modal-side/ModalSide.css
+++ b/packages/ui/src/modal-side/ModalSide.css
@@ -38,13 +38,10 @@
   animation: modal-slide-out 300ms reverse ease-in;
 }
 
-.ui-ModalSide--Header {
+.ui-ModalSide--Modal .ui-ButtonModalClose.--icon {
   z-index: 1;
   position: fixed;
   top: 0;
-}
-
-.ui-ModalSide--Header .ui-ButtonModalClose.--icon {
   right: var(--layout-margin-large);
   top: var(--layout-margin-medium);
 }

--- a/packages/ui/src/modal-side/ModalSide.tsx
+++ b/packages/ui/src/modal-side/ModalSide.tsx
@@ -78,12 +78,10 @@ export default function ModalSide({
           <Dialog className="ui-ModalSide--AriaDialog">
             {({ close }) => (
               <>
-                <header className="ui-ModalSide--Header">
-                  <ButtonModalClose
-                    label={`Close ${type} popup modal and return to walkthrough`}
-                    onPress={close}
-                  />
-                </header>
+                <ButtonModalClose
+                  label={`Close ${type} popup modal and return to walkthrough`}
+                  onPress={close}
+                />
                 <div className="ui-ModalSide--Content">
                   {type === ModalSideDataEnum.GLOSSARY && (
                     <GlossaryContent

--- a/packages/ui/src/modal-side/ModalSide.tsx
+++ b/packages/ui/src/modal-side/ModalSide.tsx
@@ -79,7 +79,10 @@ export default function ModalSide({
             {({ close }) => (
               <>
                 <header className="ui-ModalSide--Header">
-                  <ButtonModalClose label="Close modal" onPress={close} />
+                  <ButtonModalClose
+                    label={`Close ${type} popup modal and return to walkthrough`}
+                    onPress={close}
+                  />
                 </header>
                 <div className="ui-ModalSide--Content">
                   {type === ModalSideDataEnum.GLOSSARY && (

--- a/packages/ui/src/tooltip/Tooltip.css
+++ b/packages/ui/src/tooltip/Tooltip.css
@@ -22,3 +22,10 @@
   width: 25px;
   height: 12px;
 }
+
+.ui-Tooltip--HiddenLabel {
+  position: absolute;
+  overflow: hidden;
+  width: 0px;
+  height: 0px;
+}

--- a/packages/ui/src/tooltip/Tooltip.tsx
+++ b/packages/ui/src/tooltip/Tooltip.tsx
@@ -11,11 +11,13 @@ import Image from "@repo/ui/image";
 import "./Tooltip.css";
 
 export interface TooltipProps extends ReactAriaTooltipProps {
+  tooltipLabel: string;
   tooltipContent: ReactNode;
   triggerContent: ReactNode;
 }
 
 export default function Tooltip({
+  tooltipLabel,
   tooltipContent,
   triggerContent,
   ...props
@@ -27,7 +29,8 @@ export default function Tooltip({
         {...props}
         className="ui-Tooltip--Aria"
         placement="bottom"
-        aria-live="polite"
+        aria-live="assertive"
+        aria-label={tooltipLabel}
       >
         <Image
           src="tooltip-triangle.svg"


### PR DESCRIPTION
<!-- You may remove any sections that are not applicable -->

[HOUSNAV-122](https://hous-bssb.atlassian.net/browse/HOUSNAV-122)
[HOUSNAV-137](https://hous-bssb.atlassian.net/browse/HOUSNAV-137)

## Overview & Purpose
<!-- Please describe the purpose of your changes. Please also include relevant motivation and context. -->
Enhance the accessibility of the application by improving screen reader readouts when the modal opens and terms are highlighted.

## Summary of Changes
<!-- Please include a HIGH LEVEL overview of the code changes. (Added xyz fields to table, modified function to handle x case instead of y case, etc. )  -->
- Add tab indexes where necessary to improve keyboard accessiblity
- Focus on building code and terms when modal is open so screen reader can read that first
- Added hidden text that will be read after a building code or glossary section is read to inform user they can scroll or tab
- Improved modal close label
- Updated Cypress tests to check modal accessibility on some questions. 

## Side Effects
<!-- Any possible side effects? Does this change affect features that are not linked to the direct purpose? -->

## Testing
<!-- Please include steps to test out the changes/fixes if applicable OR context notes to help get env in a state to test-->
- Screen readers may behave differently so please attempt to use multiple screen readers.
- Mac VoiceOverUtility does not work well with current changes
- Not all questions open the building code and modal if a term or reference exists, that added a few minutes which I think is too much.

## Notes & Resources
<!-- Please include any additional notes necessary to review PR and/or relevant links (documentation, stack overflow, etc.) that helped you arrive at your solution. -->

## Checklist
- [x] I have written or updated vitests for this work
- [x] I have reviewed the [accessibility guidelines](https://digital.gov.bc.ca/wcag/home/) relevant to this work
- [x] I have reviewed this work with at least one screen reader (when applicable)
- [x] I have added/updated any related documentation
