### PR TITLE
HOUSNAV-102: Error Field Updates

### DIFF
--- a/packages/ui/src/checkbox-group/CheckboxGroup.tsx
+++ b/packages/ui/src/checkbox-group/CheckboxGroup.tsx
@@ -91,6 +91,12 @@ export default function CheckboxGroup({
           {label || name}
         </Label>
       )}
+      <InputError
+        data-testid={`${TESTID_CHECKBOX_GROUP_ERROR}-${testIdNamespace}`}
+        className={"ui-CheckboxGroup--Error"}
+      >
+        {errorMessageText}
+      </InputError>
       {options.map((option) => (
         <ReactAriaCheckbox
           className={"ui-Checkbox"}
@@ -107,13 +113,6 @@ export default function CheckboxGroup({
           <span>{parseStringToComponents(option.label)}</span>
         </ReactAriaCheckbox>
       ))}
-      {/* TODO - is this data-testid applied? */}
-      <InputError
-        data-testid={`${TESTID_CHECKBOX_GROUP_ERROR}-${testIdNamespace}`}
-        className={"ui-CheckboxGroup--Error"}
-      >
-        {errorMessageText}
-      </InputError>
     </ReactAriaCheckboxGroup>
   );
 }

--- a/packages/ui/src/radio-group/RadioGroup.tsx
+++ b/packages/ui/src/radio-group/RadioGroup.tsx
@@ -89,6 +89,12 @@ export default function RadioGroup({
           {label || name}
         </Label>
       )}
+      <InputError
+        data-testid={`${TESTID_RADIO_GROUP_ERROR}-${testIdNamespace}`}
+        className={"ui-RadioGroup--Error"}
+      >
+        {errorMessageText}
+      </InputError>
       {options.map((option) => (
         <ReactAriaRadio
           className={"ui-Radio"}
@@ -105,13 +111,6 @@ export default function RadioGroup({
           <span>{parseStringToComponents(option.label)}</span>
         </ReactAriaRadio>
       ))}
-      {/* TODO - is this data-testid applied? */}
-      <InputError
-        data-testid={`${TESTID_RADIO_GROUP_ERROR}-${testIdNamespace}`}
-        className={"ui-RadioGroup--Error"}
-      >
-        {errorMessageText}
-      </InputError>
     </ReactAriaRadioGroup>
   );
 }


### PR DESCRIPTION
[HOUSNAV-102](https://hous-bssb.atlassian.net/browse/HOUSNAV-102)

## Overview & Purpose
Updating the error fields for display on smaller screens. I could not reproduce the other error noted in the ticket around it being read twice.

## Summary of Changes
Moving error field to the top of the screen when it's shown. This will display it when the top input is selected automatically when there is an error.

## Testing
Navigate to either question P02 or P03 on either walkthrough and select 'none' along with another answer.

## Checklist
- [x] I have written or updated vitests for this work
- [x] I have reviewed the [accessibility guidelines](https://digital.gov.bc.ca/wcag/home/) relevant to this work
- [x] I have reviewed this work with at least one screen reader (when applicable)
- [x] I have added/updated any related documentation
