### PR TITLE
HOUSNAV-139 & HOUSNAV-144: mobile dialog fixes

### DIFF
--- a/apps/web/components/step-tracker/StepTracker.css
+++ b/apps/web/components/step-tracker/StepTracker.css
@@ -11,6 +11,11 @@
   height: 1.25rem;
 }
 
+.web-StepTracker--MobileOverlay {
+  position: relative;
+  z-index: 1;
+}
+
 .web-StepTracker--Mobile {
   position: fixed;
   top: 0;

--- a/apps/web/components/step-tracker/StepTracker.tsx
+++ b/apps/web/components/step-tracker/StepTracker.tsx
@@ -1,7 +1,7 @@
 "use client";
 // 3rd party
 import { JSX, useState } from "react";
-import { Dialog, Modal } from "react-aria-components";
+import { Dialog, Modal, ModalOverlay } from "react-aria-components";
 // repo
 import {
   TESTID_STEP_TRACKER,
@@ -29,23 +29,25 @@ const StepTracker = (): JSX.Element => {
       >
         Steps <Icon type="accountTree" />
       </Button>
-      <Modal
+      <ModalOverlay
         isDismissable
         isOpen={stepTrackerIsOpen}
         onOpenChange={setStepTrackerIsOpen}
-        data-testid={TESTID_STEP_TRACKER_MOBILE}
+        className="web-StepTracker--MobileOverlay"
       >
-        <Dialog
-          className="web-StepTracker--Mobile"
-          aria-labelledby={ID_STEP_TRACKER_TITLE}
-        >
-          <ButtonModalClose
-            label="Close the step tracker"
-            onPress={() => setStepTrackerIsOpen(false)}
-          />
-          <StepTrackerItems id={ID_STEP_TRACKER_TITLE} />
-        </Dialog>
-      </Modal>
+        <Modal data-testid={TESTID_STEP_TRACKER_MOBILE}>
+          <Dialog
+            className="web-StepTracker--Mobile"
+            aria-labelledby={ID_STEP_TRACKER_TITLE}
+          >
+            <ButtonModalClose
+              label="Close the step tracker"
+              onPress={() => setStepTrackerIsOpen(false)}
+            />
+            <StepTrackerItems id={ID_STEP_TRACKER_TITLE} />
+          </Dialog>
+        </Modal>
+      </ModalOverlay>
       <div className="web-StepTracker--TabletUp">
         <StepTrackerItems />
       </div>

--- a/apps/web/components/walkthrough/Walkthrough.css
+++ b/apps/web/components/walkthrough/Walkthrough.css
@@ -1,5 +1,5 @@
 .web-Walkthrough {
-  height: calc(100dvh - var(--header-height));
+  height: calc(100dvh - var(--header-height-full));
   overflow: auto;
   display: grid;
   grid-template-rows: 48px 1fr;

--- a/packages/ui/src/header/Header.css
+++ b/packages/ui/src/header/Header.css
@@ -6,12 +6,16 @@
   background-color: var(--surface-color-background-white);
   border-bottom-color: var(--surface-color-border-default);
   border-bottom-style: solid;
-  border-bottom-width: var(--layout-border-width-small);
+  border-bottom-width: var(--header-border-width);
   min-height: var(--header-height);
   width: 100%;
   box-shadow: var(--surface-shadow-medium);
   z-index: 1;
   position: relative;
+}
+
+.ui-Header.--mobile-open {
+  box-shadow: none;
 }
 
 .ui-Header--Container {
@@ -75,15 +79,32 @@
   margin-left: auto;
 }
 
-.ui-Header--NavMobile {
+.ui-Header--NavMobileOverlay {
+  z-index: 1;
+}
+
+.ui-Header--NavMobileWrapper {
   position: fixed;
-  top: var(--header-height);
+  top: 0;
   bottom: 0;
   left: 0;
   right: 0;
-  background-color: var(--surface-color-background-white);
-  padding: var(--header-nav-mobile-padding);
   outline: none;
+  z-index: 1;
+  display: flex;
+}
+
+.ui-Header--NavMobileWrapper .ui-Header--NavMobileToggle {
+  position: absolute;
+  right: var(--layout-padding-container);
+  top: var(--layout-padding-10);
+}
+
+.ui-Header--NavMobile {
+  background-color: var(--surface-color-background-white);
+  margin-top: calc(var(--header-height-full));
+  padding: var(--header-nav-mobile-padding);
+  width: 100%;
 }
 
 .ui-Header--NavMobile .ui-Header--NavList {

--- a/packages/ui/src/header/Header.tsx
+++ b/packages/ui/src/header/Header.tsx
@@ -40,6 +40,27 @@ export interface HeaderProps {
   titleElement?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "span" | "p";
 }
 
+const getCloseButton = (
+  setMobileNavIsOpen: () => void,
+  mobileNavIsOpen: boolean,
+) => {
+  return (
+    <Button
+      id={ID_MAIN_NAVIGATION}
+      aria-label={
+        mobileNavIsOpen ? "Close the navigation" : "Open the navigation"
+      }
+      isIconButton
+      variant="secondary"
+      className="ui-Header--NavMobileToggle"
+      onPress={() => setMobileNavIsOpen()}
+      data-testid={TESTID_HEADER_MOBILE_NAV_BUTTON}
+    >
+      {mobileNavIsOpen ? <Icon type="close" /> : <Icon type="menu" />}
+    </Button>
+  );
+};
+
 const getNavList = (onLinkClick: (href: string) => void) => {
   return (
     <ul className="ui-Header--NavList">
@@ -99,7 +120,10 @@ export default function Header({
   }
 
   return (
-    <header className="ui-Header" data-testid={TESTID_HEADER}>
+    <header
+      className={`ui-Header ${mobileNavIsOpen ? "--mobile-open" : ""}`}
+      data-testid={TESTID_HEADER}
+    >
       <div className="u-container ui-Header--Container">
         {skipLinks && (
           <ul className="ui-Header--SkipLinks">
@@ -127,27 +151,19 @@ export default function Header({
         <nav className="ui-Header--NavDesktop" id={ID_MAIN_NAVIGATION}>
           {getNavList(router.push)}
         </nav>
-        <Button
-          id={ID_MAIN_NAVIGATION}
-          aria-label={
-            mobileNavIsOpen ? "Close the navigation" : "Open the navigation"
-          }
-          isIconButton
-          variant="secondary"
-          className="ui-Header--NavMobileToggle"
-          onPress={() => setMobileNavIsOpen(true)}
-          data-testid={TESTID_HEADER_MOBILE_NAV_BUTTON}
-        >
-          {mobileNavIsOpen ? <Icon type="close" /> : <Icon type="menu" />}
-        </Button>
+        {!mobileNavIsOpen &&
+          getCloseButton(() => setMobileNavIsOpen(true), mobileNavIsOpen)}
         <Modal
           isDismissable
           isOpen={mobileNavIsOpen}
           onOpenChange={setMobileNavIsOpen}
           data-testid={TESTID_HEADER_MOBILE_NAV}
         >
-          <Dialog className="ui-Header--NavMobile">
-            {getNavList(onMobileNavLinkClick)}
+          <Dialog className="ui-Header--NavMobileWrapper" aria-label={title}>
+            {getCloseButton(() => setMobileNavIsOpen(false), mobileNavIsOpen)}
+            <div className="ui-Header--NavMobile">
+              {getNavList(onMobileNavLinkClick)}
+            </div>
           </Dialog>
         </Modal>
       </div>

--- a/packages/ui/src/variables.css
+++ b/packages/ui/src/variables.css
@@ -233,7 +233,9 @@
   --transition-link-color: color 150ms ease-in;
   --transition-link-icon-fill-color: fill 150ms ease-in;
   --button-gap: var(--layout-padding-12);
-  --header-height: 55px;
+  --header-height: 60px;
+  --header-border-width: var(--layout-border-width-small);
+  --header-height-full: calc(var(--header-height) + var(--header-border-width));
   --header-nav-mobile-padding: var(--layout-padding-medium);
   --footer-margin-block: var(--layout-margin-large);
   --footer-main-direction: column;


### PR DESCRIPTION
[HOUSNAV-139](https://hous-bssb.atlassian.net/browse/HOUSNAV-139)
[HOUSNAV-144](https://hous-bssb.atlassian.net/browse/HOUSNAV-144)

## Overview & Purpose
Fix close button tabular access on for mobile and zoomed navigation
Fix close button appearance in step tracker

## Summary of Changes
Created close button inside modal in same spot as header hamburger so it can be tabbed to inside the modal
Added overlay to be able to position step tracker mobile dialog over header

## Testing
Zoom smaller width browser to 200% and see hamburger menu appear.
Open hamburger nav and tab between links and close button
Open mobile step tracker and see close button and no longer see header

## Checklist
- [x] I have written or updated vitests for this work
- [x] I have reviewed the [accessibility guidelines](https://digital.gov.bc.ca/wcag/home/) relevant to this work
- [x] I have reviewed this work with at least one screen reader (when applicable)
- [x] I have added/updated any related documentation
