### PR TITLE
HOUSNAV-145: fix for result markup issue

### DIFF
--- a/packages/data/json/9.9.9.json
+++ b/packages/data/json/9.9.9.json
@@ -2379,7 +2379,7 @@
       "resultDisplayMessage": "<p>You have selected an answer that indicates that the BC Building Code 2024 does not apply to this structure. This tool is used to assist building code users in determining the applicable requirements for their building, as such all structures that are not governed by the BC Building Code 2024 are beyond the scope of this tool.</p>"
     },
     "R01": {
-      "resultDisplayMessage": "<p>You have selected: <answer-value return-markup answer='P03'></answer-value> This indicates that some or all of this structure may not be governed by the BC Building Code 2024. This tool has been designed to assist BC Building Code 2024 users in determining the Building Code requirements for Part 9 buildings. Based on your selection, some or all of your project is beyond the scope of this tool at this time.</p>"
+      "resultDisplayMessage": "<p>You have selected:</p><answer-value return-markup answer='P03'></answer-value><p>This indicates that some or all of this structure may not be governed by the BC Building Code 2024. This tool has been designed to assist BC Building Code 2024 users in determining the Building Code requirements for Part 9 buildings. Based on your selection, some or all of your project is beyond the scope of this tool at this time.</p>"
     },
     "R02": {
       "resultDisplayMessage": "<p>You have selected an option that indicates that this building is a heritage building. Heritage buildings have alternative measures for Building Code compliance. These alternative measures are beyond the scope of this tool at this time. Please see in Table 1.1.1.1.(5) of <pdf-download-link named-dest='Section 1.1. General'>Division A - Section 1.1 ‘General’</pdf-download-link> for more information.</p>"


### PR DESCRIPTION
[HOUSNAV-145](https://hous-bssb.atlassian.net/browse/HOUSNAV-145)

## Overview & Purpose
Fix error on markup for result R01 in 9.9.9

## Summary of Changes
Closed opening `<p>` and created new `<p>` after answer insertion.

## Testing
Question 1: Answer “Not Sure”
Question 2: Any answer but ‘None of the above’
Question 3: Any answer but ‘None of the above’
Observe markup for result R01

## Checklist
- [x] I have written or updated vitests for this work
- [x] I have reviewed the [accessibility guidelines](https://digital.gov.bc.ca/wcag/home/) relevant to this work
- [x] I have reviewed this work with at least one screen reader (when applicable)
- [x] I have added/updated any related documentation
