### PR TITLE
HOUSNAV-138: Next Question Scroll to top fix

### DIFF
--- a/apps/web/components/walkthrough/Walkthrough.tsx
+++ b/apps/web/components/walkthrough/Walkthrough.tsx
@@ -50,7 +50,11 @@ const Walkthrough = observer((): JSX.Element => {
 
   return (
     <>
-      <div className="web-Walkthrough" data-testid={TESTID_WALKTHROUGH}>
+      <div
+        className="web-Walkthrough"
+        data-testid={TESTID_WALKTHROUGH}
+        key={`walkthrough-wrapper-${currentItemId}`}
+      >
         <section className="web-Walkthrough--Content">
           {currentResult ? (
             <Result


### PR DESCRIPTION
[HOUSNAV-138](https://hous-bssb.atlassian.net/browse/HOUSNAV-138)

## Overview & Purpose
Updating the rendering so each question starts at the top of the screen

## Summary of Changes
Added a key value to re-render each question

## Testing
Shrink the height of the screen to less than the step tracker height, this will make it so you have to scroll the whole page and not just the question when getting to the bottom navigation.
Answer the question and scroll down to the navigation.
Go to the next question and observe the screen now shows the top of the question.

## Checklist
- [x] I have written or updated vitests for this work
- [x] I have reviewed the [accessibility guidelines](https://digital.gov.bc.ca/wcag/home/) relevant to this work
- [x] I have reviewed this work with at least one screen reader (when applicable)
- [x] I have added/updated any related documentation
