### PR TITLE
HOUSNAV-137: re-adding a11y tests for both modals

### DIFF
--- a/apps/web/components/question/Question.tsx
+++ b/apps/web/components/question/Question.tsx
@@ -11,6 +11,7 @@ import { ID_QUESTION_TEXT } from "@repo/constants/src/ids";
 import {
   TESTID_QUESTION,
   TESTID_QUESTION_CODE_REFERENCE,
+  TESTID_QUESTION_CODE_REFERENCE_BUTTON,
   TESTID_QUESTION_TITLE,
 } from "@repo/constants/src/testids";
 import Button from "@repo/ui/button";
@@ -90,6 +91,7 @@ const Question = observer(() => {
             triggerContent={
               <Button
                 variant="code"
+                data-testid={TESTID_QUESTION_CODE_REFERENCE_BUTTON}
                 aria-label={`${currentQuestion.questionCodeReference.displayString} Select to open building code reference modal.`}
               >
                 {currentQuestion.questionCodeReference.displayString}

--- a/apps/web/cypress/fixtures/workflow1-test-data.json
+++ b/apps/web/cypress/fixtures/workflow1-test-data.json
@@ -147,7 +147,8 @@
         {
           "question": "P04",
           "type": "radio",
-          "answer": "false"
+          "answer": "false",
+          "checkGlossary": true
         },
         {
           "question": "P05",
@@ -248,7 +249,8 @@
         {
           "question": "P06",
           "type": "checkbox",
-          "answer": "C"
+          "answer": "C",
+          "checkGlossary": true
         },
         {
           "question": "P07",
@@ -552,7 +554,8 @@
         {
           "question": "P1",
           "type": "radio",
-          "answer": "false"
+          "answer": "false",
+          "checkBuildingCode": true
         }
       ],
       "result": "R30"
@@ -738,7 +741,8 @@
         {
           "question": "P2",
           "type": "radio",
-          "answer": "3"
+          "answer": "3",
+          "checkBuildingCode": true
         },
         {
           "question": "P3",
@@ -793,7 +797,8 @@
         {
           "question": "P14",
           "type": "radio",
-          "answer": "false"
+          "answer": "false",
+          "checkBuildingCode": true
         },
         {
           "question": "P15",
@@ -813,7 +818,8 @@
         {
           "question": "P18",
           "type": "radio",
-          "answer": "true"
+          "answer": "true",
+          "checkBuildingCode": true
         }
       ],
       "result": "R11"
@@ -874,7 +880,8 @@
         {
           "question": "P13",
           "type": "radio",
-          "answer": "true"
+          "answer": "true",
+          "checkBuildingCode": true
         },
         {
           "question": "P14",

--- a/apps/web/cypress/fixtures/workflow2-test-data.json
+++ b/apps/web/cypress/fixtures/workflow2-test-data.json
@@ -22,7 +22,8 @@
         {
           "question": "P04",
           "type": "radio",
-          "answer": "true"
+          "answer": "true",
+          "checkGlossary": true
         }
       ],
       "result": "R02"
@@ -126,7 +127,8 @@
         {
           "question": "P07",
           "type": "radio",
-          "answer": "true"
+          "answer": "true",
+          "checkGlossary": true
         }
       ],
       "result": "R05"
@@ -266,7 +268,8 @@
         {
           "question": "P1",
           "type": "checkbox",
-          "answer": "C"
+          "answer": "C",
+          "checkBuildingCode": true
         },
         {
           "question": "P2",
@@ -327,7 +330,8 @@
         {
           "question": "P6",
           "type": "input",
-          "answer": "1"
+          "answer": "1",
+          "checkBuildingCode": true
         },
         {
           "question": "P7",

--- a/apps/web/cypress/support/commands.ts
+++ b/apps/web/cypress/support/commands.ts
@@ -42,10 +42,11 @@ import * as axe from "axe-core";
 function printAccessibilityViolations(violations: axe.Result[]) {
   cy.task(
     "table",
-    violations.map(({ id, impact, description, nodes }) => ({
+    violations.map(({ id, impact, description, nodes, helpUrl }) => ({
       impact,
       description: `${description} (${id})`,
       nodes: nodes.length,
+      helpUrl,
     })),
   );
 }

--- a/packages/constants/src/testids.ts
+++ b/packages/constants/src/testids.ts
@@ -27,6 +27,8 @@ export const GET_TESTID_PDF_DOWNLOAD_LINK = (title: string) =>
 export const TESTID_QUESTION = "question";
 export const TESTID_QUESTION_TITLE = "question-title";
 export const TESTID_QUESTION_CODE_REFERENCE = "question-code-reference";
+export const TESTID_QUESTION_CODE_REFERENCE_BUTTON =
+  "question-code-reference-button";
 export const TESTID_WALKTHROUGH = "walkthrough";
 export const TESTID_WALKTHROUGH_FOOTER_BACK = "walkthrough-footer-back";
 export const TESTID_WALKTHROUGH_FOOTER_NEXT = "walkthrough-footer-next";


### PR DESCRIPTION
[HOUSNAV-137](https://hous-bssb.atlassian.net/browse/HOUSNAV-137)

## Overview & Purpose
Add axe a11y scans for both modals during cypress tests

## Summary of Changes
Adding properties to data for specific steps to test each modal type
Adding a process to open the modal before the scan on those steps

## Checklist
- [x] I have written or updated vitests for this work
- [x] I have reviewed the [accessibility guidelines](https://digital.gov.bc.ca/wcag/home/) relevant to this work
- [x] I have reviewed this work with at least one screen reader (when applicable)
- [x] I have added/updated any related documentation
