### PR TITLE
HOUSNAV-117 & HOUSNAV-118: step tracker updates

### DIFF
--- a/apps/web/components/step-tracker/StepTrackerItems.tsx
+++ b/apps/web/components/step-tracker/StepTrackerItems.tsx
@@ -74,7 +74,10 @@ const StepTrackerItems = observer(({ id }: { id?: string }): JSX.Element => {
                   />
                 )}
               </h3>
-              <div className="web-StepTrackerItems--SectionBody">
+              <div
+                className="web-StepTrackerItems--SectionBody"
+                aria-hidden={!isCurrentSection}
+              >
                 <ol>
                   {section.sectionQuestions.map((itemId) => {
                     const itemComplete = itemIsComplete(itemId);

--- a/apps/web/components/walkthrough/Walkthrough.css
+++ b/apps/web/components/walkthrough/Walkthrough.css
@@ -11,7 +11,6 @@
 }
 
 .web-Walkthrough--Content {
-  order: 1;
   display: grid;
   grid-template-rows: auto 67px;
   overflow: hidden;

--- a/apps/web/components/walkthrough/Walkthrough.tsx
+++ b/apps/web/components/walkthrough/Walkthrough.tsx
@@ -55,6 +55,9 @@ const Walkthrough = observer((): JSX.Element => {
         data-testid={TESTID_WALKTHROUGH}
         key={`walkthrough-wrapper-${currentItemId}`}
       >
+        <section className="web-Walkthrough--StepTracker">
+          <StepTracker />
+        </section>
         <section className="web-Walkthrough--Content">
           {currentResult ? (
             <Result
@@ -72,9 +75,6 @@ const Walkthrough = observer((): JSX.Element => {
             </Form>
           )}
           <WalkthroughFooter />
-        </section>
-        <section className="web-Walkthrough--StepTracker">
-          <StepTracker />
         </section>
       </div>
     </>


### PR DESCRIPTION
[HOUSNAV-117](https://hous-bssb.atlassian.net/browse/HOUSNAV-117)
[HOUSNAV-118](https://hous-bssb.atlassian.net/browse/HOUSNAV-118)

## Overview & Purpose
Update the step tracker to hide the non visible steps from screen readers
Update the tab order of the walkthrough so the step tracker is first for mobile

## Summary of Changes
Added aria-hidden to close sections
Removing order change to put step tracker button first on mobile

## Testing
Use a screen reader to read the text of the step tracker and notice it doesn't read the hidden steps
Tab through the page on mobile and notice that the steps button is focus first after the header

## Checklist
- [x] I have written or updated vitests for this work
- [x] I have reviewed the [accessibility guidelines](https://digital.gov.bc.ca/wcag/home/) relevant to this work
- [x] I have reviewed this work with at least one screen reader (when applicable)
- [x] I have added/updated any related documentation
