### PR TITLE
HOUSNAV-92: tab order fix and image VO reading updates for cross browser

### DIFF
--- a/apps/web/components/question/Question.tsx
+++ b/apps/web/components/question/Question.tsx
@@ -62,7 +62,7 @@ const Question = observer(() => {
       className="u-container-walkthrough p-hide"
       data-testid={TESTID_QUESTION}
       aria-label={getStringFromComponents(questionText)}
-      tabIndex={0}
+      tabIndex={-1}
     >
       <h1
         className="web-Question--Title"
@@ -75,7 +75,7 @@ const Question = observer(() => {
         <div
           className="web-Question--Subtext"
           aria-label={getStringFromComponents(questionSubtext)}
-          tabIndex={0}
+          tabIndex={-1}
         >
           {questionSubtext}
         </div>

--- a/packages/ui/src/modal-building-code-content/ModalBuildingCodeContent.tsx
+++ b/packages/ui/src/modal-building-code-content/ModalBuildingCodeContent.tsx
@@ -90,7 +90,7 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
                 ? "ui-ModalSide--SectionHighlighted"
                 : ""
             }`}
-            tabIndex={0}
+            tabIndex={-1}
           >
             <span>
               {parseStringToComponents(data.description, setFocusSection)}
@@ -116,7 +116,7 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
                 ? "ui-ModalSide--SectionHighlighted"
                 : ""
             }`}
-            tabIndex={0}
+            tabIndex={-1}
           >
             {/* Designs do not show this high level of headings. */}
             {data.sections && renderSections(data.sections)}
@@ -153,7 +153,7 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
                 ? "ui-ModalSide--SectionHighlighted"
                 : ""
             }`}
-            tabIndex={0}
+            tabIndex={-1}
           >
             <Heading level={2} className="ui-ModalSide--SubsectionHeader">
               <span className="ui-ModalSide--SubsectionNumber">
@@ -193,7 +193,7 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
                 ? "ui-ModalSide--SectionHighlighted"
                 : ""
             }`}
-            tabIndex={0}
+            tabIndex={-1}
           >
             <Heading className="ui-ModalSide--ArticleHeader">
               <span className="ui-ModalSide--ArticleNumber">
@@ -223,7 +223,7 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
                   ? "ui-ModalSide--SectionHighlighted"
                   : ""
               }`}
-              tabIndex={0}
+              tabIndex={-1}
             >
               {sentence.description && (
                 <span>
@@ -245,50 +245,49 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
   const renderTableImage = (image: ImageModalType) => {
     return (
       image && (
-        <section
+        <figure
           key={image.numberReference}
           ref={(el) => {
             sectionRefs.current[image.numberReference] = el;
           }}
-          className={`ui-ModalSide--Image ${
+          className={`ui-ModalSide--Image ui-ModalBuildingCodeContent--Figure ${
             highlightedSection === image.numberReference
               ? "ui-ModalSide--SectionHighlighted"
               : ""
           }`}
-          tabIndex={0}
+          tabIndex={-1}
+          aria-labelledby={image.numberReference}
         >
-          <figure className="ui-ModalBuildingCodeContent--Figure">
-            <figcaption>
-              <div className="ui-ModalBuildingCodeContent--FigureCaptionBold">
-                {image.tableName}
-                <br />
-                {parseStringToComponents(image.title)}
-              </div>
-              <div className="ui-ModalBuildingCodeContent--FigureCaption">
-                {parseStringToComponents(image.imageReference, setFocusSection)}
-              </div>
-            </figcaption>
-            <Image
-              src={image.fileName}
-              alt={image.title}
-              aria-label={image.imageLabel}
-              width={800}
-              height={600}
-              loading="eager" // Will not lazy load images in Safari
-              className="ui-ModalBuildingCodeContent-ImageResponsive"
-              aria-hidden={image.imageTable ? "true" : "false"}
-            />
-            {image.imageTable && parseStringToComponents(image.imageTable)}
-            {image.imageNotes && (
-              <section className="ui-ModalBuildingCodeContent--TableImageNotes">
-                <header className="ui-ModalBuildingCodeContent--FigureCaptionBold">
-                  Notes to {image.tableName}:
-                </header>
-                {parseStringToComponents(image.imageNotes, setFocusSection)}
-              </section>
-            )}
-          </figure>
-        </section>
+          <figcaption id={image.numberReference}>
+            <div className="ui-ModalBuildingCodeContent--FigureCaptionBold">
+              {image.tableName}
+              <br />
+              {parseStringToComponents(image.title)}
+            </div>
+            <div className="ui-ModalBuildingCodeContent--FigureCaption">
+              {parseStringToComponents(image.imageReference, setFocusSection)}
+            </div>
+          </figcaption>
+          <Image
+            src={image.fileName}
+            alt={image.title}
+            aria-label={image.imageLabel}
+            width={800}
+            height={600}
+            loading="eager" // Will not lazy load images in Safari
+            className="ui-ModalBuildingCodeContent-ImageResponsive"
+            aria-hidden={image.imageTable ? "true" : "false"}
+          />
+          {image.imageTable && parseStringToComponents(image.imageTable)}
+          {image.imageNotes && (
+            <section className="ui-ModalBuildingCodeContent--TableImageNotes">
+              <header className="ui-ModalBuildingCodeContent--FigureCaptionBold">
+                Notes to {image.tableName}:
+              </header>
+              {parseStringToComponents(image.imageNotes, setFocusSection)}
+            </section>
+          )}
+        </figure>
       )
     );
   };

--- a/packages/ui/src/modal-glossary-content/ModalGlossaryContent.tsx
+++ b/packages/ui/src/modal-glossary-content/ModalGlossaryContent.tsx
@@ -96,7 +96,7 @@ const GlossaryContent: React.FC<GlossaryContentProps> = ({
                       ? "ui-ModalSide--SectionHighlighted"
                       : ""
                   }`}
-                  tabIndex={0}
+                  tabIndex={-1}
                 >
                   {parseStringToComponents(
                     (data.content as GlossaryContentType).definition,


### PR DESCRIPTION
<!-- You may remove any sections that are not applicable -->

[HOUSNAV-92](https://hous-bssb.atlassian.net/browse/HOUSNAV-92)

## Overview & Purpose
Chrome and Safari were reading different things when focus was brought to the image figure. This should fix that.
Plus a general fix for tab ordering so the items we want to focus on that aren't normally focusable aren't part of the tab order.

## Summary of Changes
Remove unneeded section element and add aria-labelled by to figure element
Update tabindexs to -1 that shouldn't be a part of the normal tab order

## Testing
Tab to link to table and hear what screen reader reads
Tab through both modals and notice tab only focuses on normally focusable items but focas can still be sent to full items when button is clicked

## Checklist
- [x] I have written or updated vitests for this work
- [x] I have reviewed the [accessibility guidelines](https://digital.gov.bc.ca/wcag/home/) relevant to this work
- [x] I have reviewed this work with at least one screen reader (when applicable)
- [x] I have added/updated any related documentation
