### PR TITLE
HOUSNAV-153: fixing mobile nav close focus issue

### DIFF
--- a/packages/ui/src/header/Header.css
+++ b/packages/ui/src/header/Header.css
@@ -84,6 +84,10 @@
   margin-left: auto;
 }
 
+.--mobile-open .ui-Header--NavMobileToggle {
+  display: none;
+}
+
 .ui-Header--NavMobileOverlay {
   z-index: 1;
 }

--- a/packages/ui/src/header/Header.tsx
+++ b/packages/ui/src/header/Header.tsx
@@ -177,13 +177,10 @@ export default function Header({
             {getTitle()}
           </div>
         )}
-
-        {!mobileNavIsOpen && (
-          <nav className="ui-Header--Nav" id={ID_MAIN_NAVIGATION}>
-            {getNavList(router.push)}
-            {getCloseButton(() => setMobileNavIsOpen(true), mobileNavIsOpen)}
-          </nav>
-        )}
+        <nav className="ui-Header--Nav" id={ID_MAIN_NAVIGATION}>
+          {getNavList(router.push)}
+          {getCloseButton(() => setMobileNavIsOpen(true), mobileNavIsOpen)}
+        </nav>
         <Modal
           isDismissable
           isOpen={mobileNavIsOpen}


### PR DESCRIPTION
[HOUSNAV-153](https://hous-bssb.atlassian.net/browse/HOUSNAV-153)

## Overview & Purpose
Fixing tab functionality loss on certain browsers when closing the mobile nav

## Summary of Changes
Kept mobile open trigger available in the DOM but hidden for refocus on close

## Testing
Open mobile nav and use the escape key to close
Observe the focus returned to the hamburger button and the ability to tab around the page

## Checklist
- [x] I have written or updated vitests for this work
- [x] I have reviewed the [accessibility guidelines](https://digital.gov.bc.ca/wcag/home/) relevant to this work
- [x] I have reviewed this work with at least one screen reader (when applicable)
- [x] I have added/updated any related documentation
