### PR TITLE
HOUSNAV-155: updating walkthrough card a11y content

### DIFF
--- a/packages/ui/src/walkthrough-card/WalkthroughCard.tsx
+++ b/packages/ui/src/walkthrough-card/WalkthroughCard.tsx
@@ -27,7 +27,7 @@ export default function WalkthroughCard({
     <ReactAriaLink
       className="ui-WalkthroughCard--CardContainer"
       href={`${URL_WALKTHROUGH_HREF}/${walkthroughId}`}
-      aria-label={`walkthrough ${walkthroughId} - ${data.title}`}
+      aria-label={`walkthrough ${walkthroughId} - ${data.title} - ${data.description}`}
       data-testid={GET_TESTID_WALKTHROUGH_CARD(testid || walkthroughId)}
       {...props}
     >


### PR DESCRIPTION
[HOUSNAV-155](https://hous-bssb.atlassian.net/browse/HOUSNAV-155)

## Overview & Purpose
Giving VO users the full content available for the walkthrough cards.

## Summary of Changes
Adding description to the aria label

## Side Effects
This could be too much content read at once for them?

## Testing
Turn on VO and tab to a walkthrough card on the landing page
Hear all the content read

## Checklist
- [x] I have written or updated vitests for this work
- [x] I have reviewed the [accessibility guidelines](https://digital.gov.bc.ca/wcag/home/) relevant to this work
- [x] I have reviewed this work with at least one screen reader (when applicable)
- [x] I have added/updated any related documentation
