### PR TITLE
HOUSNAV-160: Updating the title and metadata

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -17,9 +17,9 @@ import { ClientProviders } from "./ClientProviders";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "BC Gov - 2024 Building Code - Walkthroughs",
+  title: "BC Gov - 2024 BC Building Code - Walkthroughs",
   description:
-    "Get step-by-step guidance through specific sections of the 2024 BC Building Code.",
+    "Get step-by-step guidance through specific subsections of the 2024 BC Building Code.",
 };
 
 export default function RootLayout({
@@ -32,7 +32,7 @@ export default function RootLayout({
       <body>
         <ClientProviders>
           <Header
-            title="2024 Building Code"
+            title="2024 BC Building Code"
             skipLinks={[
               <a href={`#${ID_MAIN_CONTENT}`}>Skip to main content</a>,
               <a href={`#${ID_MAIN_NAVIGATION}`} data-skip-link-nav>


### PR DESCRIPTION
[HOUSNAV-160](https://hous-bssb.atlassian.net/browse/HOUSNAV-160)

## Overview & Purpose
Update the title and metadata to include BC for British Columbia

## Summary of Changes
Updated the title, browser tab metadata title and description

## Testing
View the title on the landing page
Hover over the browser tab to see tab title
Inspect the page and view the `<meta>` description tag in the `<head>`
![Screenshot 2024-08-06 at 4 31 07 PM](https://github.com/user-attachments/assets/4dadcf4c-2198-47a2-a70f-0d74609080d0)

## Checklist
- [x] I have written or updated vitests for this work
- [x] I have reviewed the [accessibility guidelines](https://digital.gov.bc.ca/wcag/home/) relevant to this work
- [x] I have reviewed this work with at least one screen reader (when applicable)
- [x] I have added/updated any related documentation
