### PR TITLE
HOUSNAV-164: updating result logic to be greaterThanOrEqual vs greaterThan

### DIFF
--- a/apps/web/cypress/fixtures/workflow2-test-data.json
+++ b/apps/web/cypress/fixtures/workflow2-test-data.json
@@ -924,6 +924,391 @@
         }
       ],
       "result": "R30"
+    },
+    {
+      "title": "P6 = 1.5",
+      "steps": [
+        {
+          "question": "P01",
+          "type": "radio",
+          "answer": "yes"
+        },
+        {
+          "question": "P04",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P05",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P06",
+          "type": "checkbox",
+          "answer": "C"
+        },
+        {
+          "question": "P07",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P08",
+          "type": "radio",
+          "answer": "true"
+        },
+        {
+          "question": "P1",
+          "type": "checkbox",
+          "answer": "F3"
+        },
+        {
+          "question": "P3",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P4",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P5",
+          "type": "input",
+          "answer": "100"
+        },
+        {
+          "question": "P6",
+          "type": "input",
+          "answer": "3"
+        },
+        {
+          "question": "P7",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P8",
+          "type": "radio",
+          "answer": "true"
+        },
+        {
+          "question": "P13",
+          "type": "radio",
+          "answer": "false"
+        }
+      ],
+      "result": "R20",
+      "resultValue": "is: 0.78"
+    },
+    {
+      "title": "P6 = 1.2",
+      "steps": [
+        {
+          "question": "P01",
+          "type": "radio",
+          "answer": "yes"
+        },
+        {
+          "question": "P04",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P05",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P06",
+          "type": "checkbox",
+          "answer": "C"
+        },
+        {
+          "question": "P07",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P08",
+          "type": "radio",
+          "answer": "true"
+        },
+        {
+          "question": "P1",
+          "type": "checkbox",
+          "answer": "F3"
+        },
+        {
+          "question": "P3",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P4",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P5",
+          "type": "input",
+          "answer": "80"
+        },
+        {
+          "question": "P6",
+          "type": "input",
+          "answer": "2.4"
+        },
+        {
+          "question": "P7",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P8",
+          "type": "radio",
+          "answer": "true"
+        },
+        {
+          "question": "P13",
+          "type": "radio",
+          "answer": "false"
+        }
+      ],
+      "result": "R20",
+      "resultValue": "is: 0.35"
+    },
+    {
+      "title": "P6 = 2",
+      "steps": [
+        {
+          "question": "P01",
+          "type": "radio",
+          "answer": "yes"
+        },
+        {
+          "question": "P04",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P05",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P06",
+          "type": "checkbox",
+          "answer": "C"
+        },
+        {
+          "question": "P07",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P08",
+          "type": "radio",
+          "answer": "true"
+        },
+        {
+          "question": "P1",
+          "type": "checkbox",
+          "answer": "F3"
+        },
+        {
+          "question": "P3",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P4",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P5",
+          "type": "input",
+          "answer": "70"
+        },
+        {
+          "question": "P6",
+          "type": "input",
+          "answer": "4"
+        },
+        {
+          "question": "P7",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P8",
+          "type": "radio",
+          "answer": "true"
+        },
+        {
+          "question": "P13",
+          "type": "radio",
+          "answer": "false"
+        }
+      ],
+      "result": "R20",
+      "resultValue": "is: 1.88"
+    },
+    {
+      "title": "2 > P6 > 1.5",
+      "steps": [
+        {
+          "question": "P01",
+          "type": "radio",
+          "answer": "yes"
+        },
+        {
+          "question": "P04",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P05",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P06",
+          "type": "checkbox",
+          "answer": "C"
+        },
+        {
+          "question": "P07",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P08",
+          "type": "radio",
+          "answer": "true"
+        },
+        {
+          "question": "P1",
+          "type": "checkbox",
+          "answer": "F3"
+        },
+        {
+          "question": "P3",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P4",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P5",
+          "type": "input",
+          "answer": "100"
+        },
+        {
+          "question": "P6",
+          "type": "input",
+          "answer": "3.9"
+        },
+        {
+          "question": "P7",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P8",
+          "type": "radio",
+          "answer": "true"
+        },
+        {
+          "question": "P13",
+          "type": "radio",
+          "answer": "false"
+        }
+      ],
+      "result": "R20",
+      "resultValue": "is: 1.75"
+    },
+    {
+      "title": "1.5 > P6 > 1.2",
+      "steps": [
+        {
+          "question": "P01",
+          "type": "radio",
+          "answer": "yes"
+        },
+        {
+          "question": "P04",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P05",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P06",
+          "type": "checkbox",
+          "answer": "C"
+        },
+        {
+          "question": "P07",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P08",
+          "type": "radio",
+          "answer": "true"
+        },
+        {
+          "question": "P1",
+          "type": "checkbox",
+          "answer": "F3"
+        },
+        {
+          "question": "P3",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P4",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P5",
+          "type": "input",
+          "answer": "100"
+        },
+        {
+          "question": "P6",
+          "type": "input",
+          "answer": "2.7"
+        },
+        {
+          "question": "P7",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P8",
+          "type": "radio",
+          "answer": "true"
+        },
+        {
+          "question": "P13",
+          "type": "radio",
+          "answer": "false"
+        }
+      ],
+      "result": "R20",
+      "resultValue": "is: 0.54"
     }
   ]
 }

--- a/apps/web/cypress/support/helpers.ts
+++ b/apps/web/cypress/support/helpers.ts
@@ -12,6 +12,7 @@ interface Walkthrough {
   title: string;
   steps: Step[];
   result?: string;
+  resultValue?: string;
 }
 
 interface Step {
@@ -84,8 +85,14 @@ export const runWalkthrough = (walkthrough: Walkthrough, results: Results) => {
 
   if (walkthrough.result) {
     const result = results[walkthrough.result];
+    // Check if the walkthrough is on the correct result page
     if (result) {
       cy.contains(result);
+
+      // Check if the result has a specific value
+      if (walkthrough.resultValue) {
+        cy.contains(walkthrough.resultValue);
+      }
     } else {
       throw new Error("Result not defined in results data");
     }

--- a/apps/web/utils/calculations.test.ts
+++ b/apps/web/utils/calculations.test.ts
@@ -196,7 +196,7 @@ describe("calculations", () => {
 
     expect(result).toBe(0);
   });
-  it(`calculateResultDisplayNumber: calculationType is ${ResultCalculationType.MinBetween} with a type ${ResultCalculationType.Logic} and ${ResultLogicTypes.GreaterThan} and a type ${ResultCalculationType.Answer}`, () => {
+  it(`calculateResultDisplayNumber: calculationType is ${ResultCalculationType.MinBetween} with a type ${ResultCalculationType.Logic} and ${ResultLogicTypes.GreaterThanOrEqual} and a type ${ResultCalculationType.Answer}`, () => {
     const resultCalculation: ResultCalculation = {
       id: "1",
       resultCalculationType: ResultCalculationType.MinBetween,
@@ -205,7 +205,7 @@ describe("calculations", () => {
           resultCalculationType: ResultCalculationType.Logic,
           [PropertyResultLogicItems]: [
             {
-              resultLogicType: ResultLogicTypes.GreaterThan,
+              resultLogicType: ResultLogicTypes.GreaterThanOrEqual,
               answerToCheck: "1",
               answerValue: 3,
               valueToUse: 3,

--- a/apps/web/utils/calculations.ts
+++ b/apps/web/utils/calculations.ts
@@ -329,21 +329,21 @@ export const resultLogicTypeIsTrue = (
     return true;
   }
 
-  if (resultLogicType === ResultLogicTypes.GreaterThan) {
+  if (resultLogicType === ResultLogicTypes.GreaterThanOrEqual) {
     const { answerValue, answerToCheck } = resultLogicItem;
     if (answerValue && answerToCheck) {
       const answerToCheckValue = getAnswerToCheckValue(answerToCheck);
       if (isNumber(answerToCheckValue)) {
-        return answerToCheckValue > answerValue;
+        return answerToCheckValue >= answerValue;
       }
 
       throw new Error(
-        `resultLogicType ${ResultLogicTypes.GreaterThan} found no answerToCheckValue, or answerToCheckValue was not a number.`,
+        `resultLogicType ${ResultLogicTypes.GreaterThanOrEqual} found no answerToCheckValue, or answerToCheckValue was not a number.`,
       );
     }
 
     throw new Error(
-      `resultLogicType ${ResultLogicTypes.GreaterThan} must have answerValue and answerToCheck.`,
+      `resultLogicType ${ResultLogicTypes.GreaterThanOrEqual} must have answerValue and answerToCheck.`,
     );
   }
 

--- a/packages/data/json/9.10.14.json
+++ b/packages/data/json/9.10.14.json
@@ -2098,13 +2098,13 @@
                   "resultCalculationType": "logic",
                   "resultLogicItems": [
                     {
-                      "resultLogicType": "greaterThan",
+                      "resultLogicType": "greaterThanOrEqual",
                       "answerToCheck": "P6Editable",
                       "answerValue": 2,
                       "valueToUse": 1.88
                     },
                     {
-                      "resultLogicType": "greaterThan",
+                      "resultLogicType": "greaterThanOrEqual",
                       "answerToCheck": "P6Editable",
                       "answerValue": 1.5,
                       "valueToUse": 0.78

--- a/packages/data/src/useWalkthroughData.ts
+++ b/packages/data/src/useWalkthroughData.ts
@@ -200,7 +200,7 @@ export enum ResultCalculationType {
 
 export enum ResultLogicTypes {
   Fallback = "fallback",
-  GreaterThan = "greaterThan",
+  GreaterThanOrEqual = "greaterThanOrEqual",
 }
 
 export interface ResultLogicItem {


### PR DESCRIPTION
[HOUSNAV-164](https://hous-bssb.atlassian.net/browse/HOUSNAV-164)

## Overview & Purpose
Updating logic to match table in BCBC to be greaterThanOrEqual to

## Summary of Changes
Updated the logic for R20 in 9.10.14 to match the table in the BCBC as greater than or equal to

## Side Effects
Should be none as this only affects code directly related to R20 in 9.10.14

## Testing
Go through the walkthrough and verify cases where your limiting distance comes to 1.2, 1.5, and 2.0 gives you the correct response

## Checklist
- [x] I have written or updated vitests for this work
- [x] I have reviewed the [accessibility guidelines](https://digital.gov.bc.ca/wcag/home/) relevant to this work
- [x] I have reviewed this work with at least one screen reader (when applicable)
- [x] I have added/updated any related documentation
