### PR TITLE
HOUSNAV-146: logic updates for 9.9.9 from SME feedback

### DIFF
--- a/apps/web/cypress/fixtures/workflow1-test-data.json
+++ b/apps/web/cypress/fixtures/workflow1-test-data.json
@@ -137,6 +137,218 @@
       "result": "R10"
     },
     {
+      "title": "covers P17.1",
+      "steps": [
+        {
+          "question": "P01",
+          "type": "radio",
+          "answer": "yes"
+        },
+        {
+          "question": "P04",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P05",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P06",
+          "type": "checkbox",
+          "answer": "C"
+        },
+        {
+          "question": "P07",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P08",
+          "type": "radio",
+          "answer": "true"
+        },
+        {
+          "question": "P1",
+          "type": "radio",
+          "answer": "true"
+        },
+        {
+          "question": "P2",
+          "type": "radio",
+          "answer": "3"
+        },
+        {
+          "question": "P3",
+          "type": "checkbox",
+          "answer": "1"
+        },
+        {
+          "question": "P5",
+          "type": "checkbox",
+          "answer": "3"
+        },
+        {
+          "question": "P6",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P9",
+          "type": "checkbox",
+          "answer": "1"
+        },
+        {
+          "question": "P11",
+          "type": "radio",
+          "answer": "2"
+        },
+        {
+          "question": "P12",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P13",
+          "type": "radio",
+          "answer": "true"
+        },
+        {
+          "question": "P14",
+          "type": "radio",
+          "answer": "true"
+        },
+        {
+          "question": "P17",
+          "type": "radio",
+          "answer": "true"
+        },
+        {
+          "question": "P171",
+          "type": "radio",
+          "answer": "true"
+        },
+        {
+          "question": "P18",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P19",
+          "type": "radio",
+          "answer": "true"
+        }
+      ],
+      "result": "R10"
+    },
+    {
+      "title": "covers P17.2",
+      "steps": [
+        {
+          "question": "P01",
+          "type": "radio",
+          "answer": "yes"
+        },
+        {
+          "question": "P04",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P05",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P06",
+          "type": "checkbox",
+          "answer": "C"
+        },
+        {
+          "question": "P07",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P08",
+          "type": "radio",
+          "answer": "true"
+        },
+        {
+          "question": "P1",
+          "type": "radio",
+          "answer": "true"
+        },
+        {
+          "question": "P2",
+          "type": "radio",
+          "answer": "3"
+        },
+        {
+          "question": "P3",
+          "type": "checkbox",
+          "answer": "1"
+        },
+        {
+          "question": "P5",
+          "type": "checkbox",
+          "answer": ""
+        },
+        {
+          "question": "P6",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P7",
+          "type": "checkbox",
+          "answer": "3"
+        },
+        {
+          "question": "P8",
+          "type": "checkbox",
+          "answer": "3"
+        },
+        {
+          "question": "P9",
+          "type": "checkbox",
+          "answer": "1"
+        },
+        {
+          "question": "P11",
+          "type": "radio",
+          "answer": "2"
+        },
+        {
+          "question": "P12",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P13",
+          "type": "radio",
+          "answer": "true"
+        },
+        {
+          "question": "P14",
+          "type": "radio",
+          "answer": "true"
+        },
+        {
+          "question": "P17",
+          "type": "radio",
+          "answer": "true"
+        },
+        {
+          "question": "P172",
+          "type": "radio",
+          "answer": "false"
+        }
+      ],
+      "result": "R20"
+    },
+    {
       "title": "covers P20-22",
       "steps": [
         {
@@ -598,7 +810,7 @@
       "result": "R01"
     },
     {
-      "title": "not sure if code applies, is heratage building",
+      "title": "not sure if code applies, is heritage building",
       "steps": [
         {
           "question": "P01",

--- a/packages/data/json/9.9.9.json
+++ b/packages/data/json/9.9.9.json
@@ -36,7 +36,7 @@
     },
     "3_9992": {
       "sectionTitle": "9.9.9.2. Two Separate Exits",
-      "sectionQuestions": ["P11", "P12", "P13", "P14", "P15", "P16", "P17"]
+      "sectionQuestions": ["P11", "P12", "P13", "P14", "P15", "P16", "P17", "P171", "P172"]
     },
     "4_9993": {
       "sectionTitle": "9.9.9.3. Shared Egress Facilities",
@@ -525,7 +525,7 @@
           "nextLogicType": "equal",
           "answerToCheck": "P2",
           "answerValue": "1",
-          "nextNavigateTo": "P10"
+          "nextNavigateTo": "P11"
         },
         {
           "nextLogicType": "equal",
@@ -2021,6 +2021,28 @@
           "nextNavigateTo": "P20"
         },
         {
+          "nextLogicType": "equal",
+          "answerToCheck": "P17",
+          "answerValue": "false",
+          "nextNavigateTo": "R20"
+        },
+        {
+          "nextLogicType": "and",
+          "valuesToCheck": [
+            {
+              "nextLogicType": "equal",
+              "answerToCheck": "P17",
+              "answerValue": "true"
+            },
+            {
+              "nextLogicType": "equal",
+              "answerToCheck": "P16",
+              "answerValue": "true"
+            }
+          ],
+          "nextNavigateTo": "P18"
+        },
+        {
           "nextLogicType": "and",
           "valuesToCheck": [
             {
@@ -2033,57 +2055,123 @@
               "valuesToCheck": [
                 {
                   "nextLogicType": "equal",
-                  "answerToCheck": "P15",
+                  "answerToCheck": "P5.B",
                   "answerValue": "true"
                 },
                 {
-                  "nextLogicType": "or",
-                  "valuesToCheck": [
-                    {
-                      "nextLogicType": "equal",
-                      "answerToCheck": "P5.B",
-                      "answerValue": "true"
-                    },
-                    {
-                      "nextLogicType": "equal",
-                      "answerToCheck": "P5.1",
-                      "answerValue": "true"
-                    },
-                    {
-                      "nextLogicType": "equal",
-                      "answerToCheck": "P5.2",
-                      "answerValue": "true"
-                    },
-                    {
-                      "nextLogicType": "equal",
-                      "answerToCheck": "P5.3",
-                      "answerValue": "true"
-                    },
-                    {
-                      "nextLogicType": "equal",
-                      "answerToCheck": "P8.B",
-                      "answerValue": "true"
-                    },
-                    {
-                      "nextLogicType": "equal",
-                      "answerToCheck": "P8.1",
-                      "answerValue": "true"
-                    },
-                    {
-                      "nextLogicType": "equal",
-                      "answerToCheck": "P8.2",
-                      "answerValue": "true"
-                    },
-                    {
-                      "nextLogicType": "equal",
-                      "answerToCheck": "P8.3",
-                      "answerValue": "true"
-                    }
-                  ]
+                  "nextLogicType": "equal",
+                  "answerToCheck": "P5.1",
+                  "answerValue": "true"
+                },
+                {
+                  "nextLogicType": "equal",
+                  "answerToCheck": "P5.2",
+                  "answerValue": "true"
+                },
+                {
+                  "nextLogicType": "equal",
+                  "answerToCheck": "P5.3",
+                  "answerValue": "true"
                 }
               ]
             }
           ],
+          "nextNavigateTo": "P171"
+        },
+        {
+          "nextLogicType": "and",
+          "valuesToCheck": [
+            {
+              "nextLogicType": "equal",
+              "answerToCheck": "P17",
+              "answerValue": "true"
+            },
+            {
+              "nextLogicType": "or",
+              "valuesToCheck": [
+                {
+                  "nextLogicType": "equal",
+                  "answerToCheck": "P8.B",
+                  "answerValue": "true"
+                },
+                {
+                  "nextLogicType": "equal",
+                  "answerToCheck": "P8.1",
+                  "answerValue": "true"
+                },
+                {
+                  "nextLogicType": "equal",
+                  "answerToCheck": "P8.2",
+                  "answerValue": "true"
+                },
+                {
+                  "nextLogicType": "equal",
+                  "answerToCheck": "P8.3",
+                  "answerValue": "true"
+                }
+              ]
+            }
+          ],
+          "nextNavigateTo": "P172"
+        },
+        {
+          "nextLogicType": "fallback",
+          "nextNavigateTo": "R20"
+        }
+      ]
+    },
+    "P171": {
+      "walkthroughItemType": "multiChoice",
+      "questionText": "Does this dwelling unit have separate and direct access to the balcony(s) on level(s): <answer-value answer='P5'></answer-value>?",
+      "questionCodeReference": {
+        "displayString": "Vol 2, Div B, Article 9.9.9.2.",
+        "codeNumber": "v2-db-9.9.9.2."
+      },
+      "possibleAnswers": [
+        {
+          "answerDisplayText": "Yes",
+          "answerValue": "true"
+        },
+        {
+          "answerDisplayText": "No",
+          "answerValue": "false"
+        }
+      ],
+      "nextNavigationLogic": [
+        {
+          "nextLogicType": "equal",
+          "answerToCheck": "P171",
+          "answerValue": "true",
+          "nextNavigateTo": "P18"
+        },
+        {
+          "nextLogicType": "fallback",
+          "nextNavigateTo": "R20"
+        }
+      ]
+    },
+    "P172": {
+      "walkthroughItemType": "multiChoice",
+      "questionText": "Does this dwelling unit have separate and direct access to openable window(s) on level(s): <answer-value answer='P8'></answer-value>?",
+      "questionCodeReference": {
+        "displayString": "Vol 2, Div B, Article 9.9.9.2.",
+        "codeNumber": "v2-db-9.9.9.2."
+      },
+      "possibleAnswers": [
+        {
+          "answerDisplayText": "Yes",
+          "answerValue": "true"
+        },
+        {
+          "answerDisplayText": "No",
+          "answerValue": "false"
+        }
+      ],
+      "nextNavigationLogic": [
+        {
+          "nextLogicType": "equal",
+          "answerToCheck": "P172",
+          "answerValue": "true",
           "nextNavigateTo": "P18"
         },
         {


### PR DESCRIPTION
[HOUSNAV-146](https://hous-bssb.atlassian.net/browse/HOUSNAV-146)

## Overview & Purpose
During Phase 2, we found a few paths through walkthrough 1 that we had some questions about. Those were sent over to the external SME. They responded with updates to the flow but it was too later for us to implement those during Phase 2. These are the implemented updates.

## Summary of Changes
- Update P2 = 1 to go directly to P11 instead of P10.
- Update P17/L13 logic to match SME updates
- Add new P17.1 and P17.2 follow up questions from SME

## Testing
I've added in 2 new Cypress tests to test 1 outcome each from P17.1 and P17.2. Manually testing should still be done to test new P17 outcomes and P17.1/2 displays.

## Notes & Resources
Document with SME feedback is in the ticket

## Checklist
- [x] I have written or updated vitests for this work
- [x] I have reviewed the [accessibility guidelines](https://digital.gov.bc.ca/wcag/home/) relevant to this work
- [x] I have reviewed this work with at least one screen reader (when applicable)
- [x] I have added/updated any related documentation
