### PR TITLE
HOUSNAV-196: Step Tracker Animation Fix

### DIFF
--- a/apps/web/components/walkthrough/Walkthrough.tsx
+++ b/apps/web/components/walkthrough/Walkthrough.tsx
@@ -50,15 +50,14 @@ const Walkthrough = observer((): JSX.Element => {
 
   return (
     <>
-      <div
-        className="web-Walkthrough"
-        data-testid={TESTID_WALKTHROUGH}
-        key={`walkthrough-wrapper-${currentItemId}`}
-      >
+      <div className="web-Walkthrough" data-testid={TESTID_WALKTHROUGH}>
         <section className="web-Walkthrough--StepTracker">
           <StepTracker />
         </section>
-        <section className="web-Walkthrough--Content">
+        <section
+          className="web-Walkthrough--Content"
+          key={`walkthrough-wrapper-${currentItemId}`}
+        >
           {currentResult ? (
             <Result
               displayMessage={currentResult.resultDisplayMessage}


### PR DESCRIPTION
[HOUSNAV-196](https://hous-bssb.atlassian.net/browse/HOUSNAV-196)

## Overview & Purpose
The animation of the step tracker sections broke when we moved the key for the walkthrough to the parent element. This key is used to reset scroll position when a question changes (re-rendering the whole question). We only need it around the question and not the step tracker IMO. This will facilitate the step tracker no wholly re-rendering when the question changes and allowing the sections to animate open and closed when moving between them.

## Summary of Changes
Moving question key to walkthrough content wrapper element

## Testing
- Answer questions and navigate between them to see the scroll position still reset to the top (most easily done by answer "not sure" on the first question to get a longer question)
- Answer all questions in the introduction to get to the next set of questions and watch the animation in the step tracker

## Checklist
- [x] I have written or updated vitests for this work
- [x] I have reviewed the [accessibility guidelines](https://digital.gov.bc.ca/wcag/home/) relevant to this work
- [x] I have reviewed this work with at least one screen reader (when applicable)
- [x] I have added/updated any related documentation
