### PR TITLE
HOUSNAV-199: Step Tracker updates

### DIFF
--- a/apps/web/components/step-tracker/StepTracker.css
+++ b/apps/web/components/step-tracker/StepTracker.css
@@ -2,11 +2,11 @@
   padding: var(--step-tracker-padding);
 }
 
-.web-StepTracker--MobileToggle {
+button.web-StepTracker--MobileToggle {
   display: var(--step-tracker-mobile-toggle-display);
 }
 
-.web-StepTracker--MobileToggle .ui-Icon {
+button.web-StepTracker--MobileToggle .ui-Icon {
   width: 1.25rem;
   height: 1.25rem;
 }

--- a/apps/web/components/step-tracker/StepTrackerItems.css
+++ b/apps/web/components/step-tracker/StepTrackerItems.css
@@ -96,15 +96,15 @@
   background-color: var(--theme-gray-10);
 }
 
-.web-StepTrackerItems--SectionItem h4 {
+.web-StepTrackerItems--SectionItem h5 {
   font: var(--typography-regular-small-body);
 }
 
-.web-StepTrackerItems--SectionItem.--currentItem h4 {
+.web-StepTrackerItems--SectionItem.--currentItem h5 {
   font: var(--typography-bold-small-body);
 }
 
-.web-StepTrackerItems--SectionItem.--skippedItem h4 {
+.web-StepTrackerItems--SectionItem.--skippedItem h5 {
   color: var(--typography-color-disabled);
   text-decoration: line-through;
 }

--- a/apps/web/components/step-tracker/StepTrackerItems.css
+++ b/apps/web/components/step-tracker/StepTrackerItems.css
@@ -96,15 +96,17 @@
   background-color: var(--theme-gray-10);
 }
 
-.web-StepTrackerItems--SectionItem h5 {
+.web-StepTrackerItems--SectionItem .web-StepTrackerItems--SectionItemHeader {
   font: var(--typography-regular-small-body);
 }
 
-.web-StepTrackerItems--SectionItem.--currentItem h5 {
+.web-StepTrackerItems--SectionItem.--currentItem
+  .web-StepTrackerItems--SectionItemHeader {
   font: var(--typography-bold-small-body);
 }
 
-.web-StepTrackerItems--SectionItem.--skippedItem h5 {
+.web-StepTrackerItems--SectionItem.--skippedItem
+  .web-StepTrackerItems--SectionItemHeader {
   color: var(--typography-color-disabled);
   text-decoration: line-through;
 }

--- a/apps/web/components/step-tracker/StepTrackerItems.css
+++ b/apps/web/components/step-tracker/StepTrackerItems.css
@@ -5,10 +5,24 @@
   padding-bottom: var(--layout-padding-10);
 }
 
+.web-StepTrackerItems--Walkthrough {
+  list-style-type: none;
+}
+
+.web-StepTrackerItems--Walkthrough:not(:first-child) {
+  border-top: var(--layout-border-width-small) solid
+    var(--surface-color-border-medium);
+}
+
+.web-StepTrackerItems--WalkthroughTitle.--singleWalkthrough {
+  display: none;
+}
+
 .web-StepTrackerItems--Section {
   list-style-type: none;
 }
 
+.web-StepTrackerItems--WalkthroughTitle,
 .web-StepTrackerItems--SectionTitle {
   padding: var(--layout-padding-small);
   display: flex;
@@ -18,14 +32,14 @@
   border-left: var(--layout-border-width-large) solid transparent;
 }
 
-.-currentSection .web-StepTrackerItems--SectionTitle {
+.--currentSection .web-StepTrackerItems--SectionTitle {
   color: var(--typography-color-primary);
   font: var(--typography-bold-body);
   background-color: var(--theme-blue-10);
   border-left-color: var(--surface-color-background-dark-blue);
 }
 
-.-skippedSection .web-StepTrackerItems--SectionTitle {
+.--skippedSection .web-StepTrackerItems--SectionTitle {
   color: var(--typography-color-disabled);
   text-decoration: line-through;
 }
@@ -39,7 +53,7 @@
   color: var(--icons-color-disabled);
 }
 
-.-currentSection .web-StepTrackerItems--SectionTitleToggleIcon {
+.--currentSection .web-StepTrackerItems--SectionTitleToggleIcon {
   color: var(--typography-color-primary);
   transform: rotate(0);
 }
@@ -58,7 +72,7 @@
   transition: 250ms grid-template-rows ease;
 }
 
-.-currentSection .web-StepTrackerItems--SectionBody {
+.--currentSection .web-StepTrackerItems--SectionBody {
   grid-template-rows: 1fr;
 }
 
@@ -78,7 +92,7 @@
   gap: var(--layout-padding-small);
 }
 
-.web-StepTrackerItems--SectionItem.-currentItem {
+.web-StepTrackerItems--SectionItem.--currentItem {
   background-color: var(--theme-gray-10);
 }
 
@@ -86,11 +100,11 @@
   font: var(--typography-regular-small-body);
 }
 
-.web-StepTrackerItems--SectionItem.-currentItem h4 {
+.web-StepTrackerItems--SectionItem.--currentItem h4 {
   font: var(--typography-bold-small-body);
 }
 
-.web-StepTrackerItems--SectionItem.-skippedItem h4 {
+.web-StepTrackerItems--SectionItem.--skippedItem h4 {
   color: var(--typography-color-disabled);
   text-decoration: line-through;
 }

--- a/apps/web/components/step-tracker/StepTrackerItems.tsx
+++ b/apps/web/components/step-tracker/StepTrackerItems.tsx
@@ -7,7 +7,7 @@ import { Heading } from "react-aria-components";
 import Icon from "@repo/ui/icon";
 import {
   TESTID_STEP_TRACKER_ITEMS,
-  TESTID_STEP_TRACKER_WALKTHROUGH_HEADER,
+  GET_TESTID_STEP_TRACKER_WALKTHROUGH_HEADER,
 } from "@repo/constants/src/testids";
 // local
 import {
@@ -57,7 +57,9 @@ const StepTrackerItems = observer(({ id }: { id?: string }): JSX.Element => {
             >
               <Heading
                 className={`web-StepTrackerItems--WalkthroughTitle u-ellipsis ${isSingleWalkthrough ? "--singleWalkthrough" : ""}`}
-                data-testid={TESTID_STEP_TRACKER_WALKTHROUGH_HEADER}
+                data-testid={GET_TESTID_STEP_TRACKER_WALKTHROUGH_HEADER(
+                  walkthroughId,
+                )}
                 level={3}
               >
                 {walkthrough.info.title}

--- a/apps/web/components/step-tracker/StepTrackerItems.tsx
+++ b/apps/web/components/step-tracker/StepTrackerItems.tsx
@@ -4,6 +4,7 @@ import { JSX } from "react";
 import { observer } from "mobx-react-lite";
 // repo
 import Icon from "@repo/ui/icon";
+import { TESTID_STEP_TRACKER_ITEMS } from "@repo/constants/src/testids";
 // local
 import {
   getStringFromComponents,
@@ -11,12 +12,10 @@ import {
 } from "../../utils/string";
 import { useWalkthroughState } from "../../stores/WalkthroughRootStore";
 import "./StepTrackerItems.css";
-import { TESTID_STEP_TRACKER_ITEMS } from "@repo/constants/src/testids";
 
 const StepTrackerItems = observer(({ id }: { id?: string }): JSX.Element => {
   const {
     navigationStore: {
-      currentWalkthroughId,
       currentSectionId,
       currentItemId,
       itemIsComplete,
@@ -24,7 +23,8 @@ const StepTrackerItems = observer(({ id }: { id?: string }): JSX.Element => {
       itemWasSkipped,
       sectionWasSkipped,
     },
-    currentWalkthroughSectionData,
+    walkthroughsOrder,
+    walkthroughsById,
     getQuestionTextByQuestionId,
     currentResult,
   } = useWalkthroughState();
@@ -39,105 +39,130 @@ const StepTrackerItems = observer(({ id }: { id?: string }): JSX.Element => {
         Steps
       </h2>
       <ol>
-        {/* TODO - HOUSNAV-199 - show more than one walkthrough sections */}
-        {!!currentWalkthroughSectionData &&
-          Object.keys(currentWalkthroughSectionData).map((sectionId) => {
-            const section = currentWalkthroughSectionData[sectionId];
-            if (!section) {
-              return null;
-            }
-            const sectionComplete = sectionIsComplete(
-              currentWalkthroughId,
-              sectionId,
-            );
-            const sectionSkipped = sectionWasSkipped(
-              currentWalkthroughId,
-              sectionId,
-            );
-            const isCurrentSection = sectionId === currentSectionId;
-            const sectionStatusArray = [
-              sectionComplete ? "is marked complete" : "",
-              sectionSkipped ? "is marked skipped" : "",
-              isCurrentSection ? "is the current section" : "",
-            ].filter(Boolean) as string[];
-            const sectionAriaLabel = `${section.sectionTitle} ${sectionStatusArray.join(" and ")}`;
+        {walkthroughsOrder.map((walkthroughId) => {
+          const walkthrough = walkthroughsById[walkthroughId];
+          if (!walkthrough) {
+            return null;
+          }
 
-            return (
-              <li
-                key={sectionId}
-                className={`web-StepTrackerItems--Section ${isCurrentSection ? "-currentSection" : ""} ${sectionSkipped ? "-skippedSection" : ""}`}
+          return (
+            <li
+              key={walkthroughId}
+              className="web-StepTrackerItems--Walkthrough"
+            >
+              <h3
+                className={`web-StepTrackerItems--WalkthroughTitle u-ellipsis ${walkthroughsOrder.length === 1 ? "--singleWalkthrough" : ""}`}
               >
-                <h3
-                  className="web-StepTrackerItems--SectionTitle"
-                  aria-label={sectionAriaLabel}
-                >
-                  <Icon
-                    type="expandMore"
-                    className="web-StepTrackerItems--SectionTitleToggleIcon"
-                  />
-                  <span className="u-ellipsis">{section.sectionTitle}</span>
-                  {sectionComplete && (
-                    <Icon
-                      type="check"
-                      className="web-StepTrackerItems--SectionTitleCompleteIcon"
-                    />
-                  )}
-                </h3>
-                <div
-                  className="web-StepTrackerItems--SectionBody"
-                  aria-hidden={!isCurrentSection}
-                >
-                  <ol>
-                    {section.sectionQuestions.map((itemId) => {
-                      const itemComplete = itemIsComplete(
-                        currentWalkthroughId,
-                        itemId,
-                      );
-                      const itemSkipped = itemWasSkipped(
-                        currentWalkthroughId,
-                        itemId,
-                        sectionId,
-                        sectionComplete,
-                      );
-                      const isCurrentItem = itemId === currentItemId;
-                      const itemTextAsComponents = parseStringToComponents(
-                        getQuestionTextByQuestionId(
-                          currentWalkthroughId,
-                          itemId,
-                        ),
-                        undefined,
-                        true,
-                      );
-                      const itemStatusArray = [
-                        itemComplete ? "is marked complete" : "",
-                        itemSkipped ? "is marked skipped" : "",
-                        isCurrentItem ? "is the current step" : "",
-                      ].filter(Boolean) as string[];
-                      const itemAriaLabel = `${getStringFromComponents(itemTextAsComponents)} ${itemStatusArray.join(" and ")}`;
+                {walkthrough.info.title}
+              </h3>
+              <ol>
+                {Object.keys(walkthrough.sections).map((sectionId) => {
+                  const section = walkthrough.sections[sectionId];
+                  if (!section) {
+                    return null;
+                  }
+                  const sectionComplete = sectionIsComplete(
+                    walkthroughId,
+                    sectionId,
+                  );
+                  const sectionSkipped = sectionWasSkipped(
+                    walkthroughId,
+                    sectionId,
+                  );
+                  const isCurrentSection = sectionId === currentSectionId;
+                  const sectionStatusArray = [
+                    sectionComplete ? "is marked complete" : "",
+                    sectionSkipped ? "is marked skipped" : "",
+                    isCurrentSection ? "is the current section" : "",
+                  ].filter(Boolean) as string[];
+                  const sectionAriaLabel = `${section.sectionTitle} ${sectionStatusArray.join(" and ")}`;
 
-                      return (
-                        <li
-                          key={itemId}
-                          className={`web-StepTrackerItems--SectionItem ${isCurrentItem ? "-currentItem" : ""} ${itemSkipped ? "-skippedItem" : ""}`}
-                        >
-                          <h4 className="u-ellipsis" aria-label={itemAriaLabel}>
-                            {itemTextAsComponents}
-                          </h4>
-                          {itemComplete && <Icon type="check" />}
-                        </li>
-                      );
-                    })}
-                  </ol>
-                </div>
-              </li>
-            );
-          })}
+                  return (
+                    <li
+                      key={sectionId}
+                      className={`web-StepTrackerItems--Section ${isCurrentSection ? "--currentSection" : ""} ${sectionSkipped ? "--skippedSection" : ""}`}
+                    >
+                      <h3
+                        className="web-StepTrackerItems--SectionTitle"
+                        aria-label={sectionAriaLabel}
+                      >
+                        <Icon
+                          type="expandMore"
+                          className="web-StepTrackerItems--SectionTitleToggleIcon"
+                        />
+                        <span className="u-ellipsis">
+                          {section.sectionTitle}
+                        </span>
+                        {sectionComplete && (
+                          <Icon
+                            type="check"
+                            className="web-StepTrackerItems--SectionTitleCompleteIcon"
+                          />
+                        )}
+                      </h3>
+                      <div
+                        className="web-StepTrackerItems--SectionBody"
+                        aria-hidden={!isCurrentSection}
+                      >
+                        <ol>
+                          {section.sectionQuestions.map((itemId) => {
+                            const itemComplete = itemIsComplete(
+                              walkthroughId,
+                              itemId,
+                            );
+                            const itemSkipped = itemWasSkipped(
+                              walkthroughId,
+                              itemId,
+                              sectionId,
+                              sectionComplete,
+                            );
+                            const isCurrentItem = itemId === currentItemId;
+                            const itemTextAsComponents =
+                              parseStringToComponents(
+                                getQuestionTextByQuestionId(
+                                  walkthroughId,
+                                  itemId,
+                                ),
+                                undefined,
+                                true,
+                              );
+                            const itemStatusArray = [
+                              itemComplete ? "is marked complete" : "",
+                              itemSkipped ? "is marked skipped" : "",
+                              isCurrentItem ? "is the current step" : "",
+                            ].filter(Boolean) as string[];
+                            const itemAriaLabel = `${getStringFromComponents(itemTextAsComponents)} ${itemStatusArray.join(" and ")}`;
+
+                            return (
+                              <li
+                                key={itemId}
+                                className={`web-StepTrackerItems--SectionItem ${isCurrentItem ? "--currentItem" : ""} ${itemSkipped ? "--skippedItem" : ""}`}
+                              >
+                                <h4
+                                  className="u-ellipsis"
+                                  aria-label={itemAriaLabel}
+                                >
+                                  {itemTextAsComponents}
+                                </h4>
+                                {itemComplete && <Icon type="check" />}
+                              </li>
+                            );
+                          })}
+                        </ol>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ol>
+            </li>
+          );
+        })}
         <li
           key="results"
-          className={`web-StepTrackerItems--Section ${currentResult ? "-currentSection" : ""}`}
+          className={`web-StepTrackerItems--Walkthrough ${currentResult ? "--currentSection" : ""}`}
         >
           <h3
-            className="web-StepTrackerItems--SectionTitle"
+            className="web-StepTrackerItems--WalkthroughTitle"
             aria-label={`Results ${currentResult ? "is the current step" : ""}`}
           >
             <span className="u-ellipsis">Results</span>

--- a/apps/web/components/step-tracker/StepTrackerItems.tsx
+++ b/apps/web/components/step-tracker/StepTrackerItems.tsx
@@ -4,7 +4,10 @@ import { JSX } from "react";
 import { observer } from "mobx-react-lite";
 // repo
 import Icon from "@repo/ui/icon";
-import { TESTID_STEP_TRACKER_ITEMS } from "@repo/constants/src/testids";
+import {
+  TESTID_STEP_TRACKER_ITEMS,
+  TESTID_STEP_TRACKER_WALKTHROUGH_HEADER,
+} from "@repo/constants/src/testids";
 // local
 import {
   getStringFromComponents,
@@ -52,6 +55,7 @@ const StepTrackerItems = observer(({ id }: { id?: string }): JSX.Element => {
             >
               <h3
                 className={`web-StepTrackerItems--WalkthroughTitle u-ellipsis ${walkthroughsOrder.length === 1 ? "--singleWalkthrough" : ""}`}
+                data-testid={TESTID_STEP_TRACKER_WALKTHROUGH_HEADER}
               >
                 {walkthrough.info.title}
               </h3>
@@ -82,7 +86,7 @@ const StepTrackerItems = observer(({ id }: { id?: string }): JSX.Element => {
                       key={sectionId}
                       className={`web-StepTrackerItems--Section ${isCurrentSection ? "--currentSection" : ""} ${sectionSkipped ? "--skippedSection" : ""}`}
                     >
-                      <h3
+                      <h4
                         className="web-StepTrackerItems--SectionTitle"
                         aria-label={sectionAriaLabel}
                       >
@@ -99,7 +103,7 @@ const StepTrackerItems = observer(({ id }: { id?: string }): JSX.Element => {
                             className="web-StepTrackerItems--SectionTitleCompleteIcon"
                           />
                         )}
-                      </h3>
+                      </h4>
                       <div
                         className="web-StepTrackerItems--SectionBody"
                         aria-hidden={!isCurrentSection}
@@ -138,12 +142,12 @@ const StepTrackerItems = observer(({ id }: { id?: string }): JSX.Element => {
                                 key={itemId}
                                 className={`web-StepTrackerItems--SectionItem ${isCurrentItem ? "--currentItem" : ""} ${itemSkipped ? "--skippedItem" : ""}`}
                               >
-                                <h4
+                                <h5
                                   className="u-ellipsis"
                                   aria-label={itemAriaLabel}
                                 >
                                   {itemTextAsComponents}
-                                </h4>
+                                </h5>
                                 {itemComplete && <Icon type="check" />}
                               </li>
                             );

--- a/apps/web/components/step-tracker/StepTrackerItems.tsx
+++ b/apps/web/components/step-tracker/StepTrackerItems.tsx
@@ -2,6 +2,7 @@
 // 3rd party
 import { JSX } from "react";
 import { observer } from "mobx-react-lite";
+import { Heading } from "react-aria-components";
 // repo
 import Icon from "@repo/ui/icon";
 import {
@@ -44,6 +45,7 @@ const StepTrackerItems = observer(({ id }: { id?: string }): JSX.Element => {
       <ol>
         {walkthroughsOrder.map((walkthroughId) => {
           const walkthrough = walkthroughsById[walkthroughId];
+          const isSingleWalkthrough = walkthroughsOrder.length === 1;
           if (!walkthrough) {
             return null;
           }
@@ -53,12 +55,13 @@ const StepTrackerItems = observer(({ id }: { id?: string }): JSX.Element => {
               key={walkthroughId}
               className="web-StepTrackerItems--Walkthrough"
             >
-              <h3
-                className={`web-StepTrackerItems--WalkthroughTitle u-ellipsis ${walkthroughsOrder.length === 1 ? "--singleWalkthrough" : ""}`}
+              <Heading
+                className={`web-StepTrackerItems--WalkthroughTitle u-ellipsis ${isSingleWalkthrough ? "--singleWalkthrough" : ""}`}
                 data-testid={TESTID_STEP_TRACKER_WALKTHROUGH_HEADER}
+                level={3}
               >
                 {walkthrough.info.title}
-              </h3>
+              </Heading>
               <ol>
                 {Object.keys(walkthrough.sections).map((sectionId) => {
                   const section = walkthrough.sections[sectionId];
@@ -86,9 +89,10 @@ const StepTrackerItems = observer(({ id }: { id?: string }): JSX.Element => {
                       key={sectionId}
                       className={`web-StepTrackerItems--Section ${isCurrentSection ? "--currentSection" : ""} ${sectionSkipped ? "--skippedSection" : ""}`}
                     >
-                      <h4
+                      <Heading
                         className="web-StepTrackerItems--SectionTitle"
                         aria-label={sectionAriaLabel}
+                        level={isSingleWalkthrough ? 3 : 4}
                       >
                         <Icon
                           type="expandMore"
@@ -103,7 +107,7 @@ const StepTrackerItems = observer(({ id }: { id?: string }): JSX.Element => {
                             className="web-StepTrackerItems--SectionTitleCompleteIcon"
                           />
                         )}
-                      </h4>
+                      </Heading>
                       <div
                         className="web-StepTrackerItems--SectionBody"
                         aria-hidden={!isCurrentSection}
@@ -142,12 +146,13 @@ const StepTrackerItems = observer(({ id }: { id?: string }): JSX.Element => {
                                 key={itemId}
                                 className={`web-StepTrackerItems--SectionItem ${isCurrentItem ? "--currentItem" : ""} ${itemSkipped ? "--skippedItem" : ""}`}
                               >
-                                <h5
-                                  className="u-ellipsis"
+                                <Heading
+                                  className="web-StepTrackerItems--SectionItemHeader u-ellipsis"
                                   aria-label={itemAriaLabel}
+                                  level={isSingleWalkthrough ? 4 : 5}
                                 >
                                   {itemTextAsComponents}
-                                </h5>
+                                </Heading>
                                 {itemComplete && <Icon type="check" />}
                               </li>
                             );

--- a/apps/web/cypress/e2e/multi-dwelling-9.9.9.cy.ts
+++ b/apps/web/cypress/e2e/multi-dwelling-9.9.9.cy.ts
@@ -1,0 +1,37 @@
+import { URLS_GET_WALKTHROUGH } from "@repo/constants/src/urls";
+import {
+  EnumBuildingTypes,
+  EnumWalkthroughIds,
+} from "@repo/constants/src/constants";
+import { runWalkthrough } from "../support/helpers";
+import { TESTID_STEP_TRACKER_WALKTHROUGH_HEADER } from "@repo/constants/src/testids";
+import { walkthroughs } from "../fixtures/multi-dwelling-9.9.9-test-data.json";
+import { results } from "../fixtures/results-data.json";
+
+describe("multi dwelling: 9.9.9", () => {
+  beforeEach(() => {
+    cy.visit(
+      URLS_GET_WALKTHROUGH(EnumBuildingTypes.MULTI_DWELLING, [
+        EnumWalkthroughIds._9_9_9,
+      ]),
+    );
+  });
+
+  // Test all walkthroughs defined in test data
+  walkthroughs.forEach((walkthrough) => {
+    it(walkthrough.title, () => {
+      runWalkthrough(walkthrough, results.multi_dwelling_workflow_999);
+    });
+  });
+
+  it("step tracker doesn't show section headers for single section", () => {
+    cy.getByTestID(TESTID_STEP_TRACKER_WALKTHROUGH_HEADER)
+      .eq(0)
+      .should("be.hidden");
+  });
+
+  it("default state should be accessible", () => {
+    cy.injectAxe();
+    cy.checkA11yWithErrorLogging();
+  });
+});

--- a/apps/web/cypress/e2e/multi-dwelling-9.9.9.cy.ts
+++ b/apps/web/cypress/e2e/multi-dwelling-9.9.9.cy.ts
@@ -4,7 +4,7 @@ import {
   EnumWalkthroughIds,
 } from "@repo/constants/src/constants";
 import { runWalkthrough } from "../support/helpers";
-import { TESTID_STEP_TRACKER_WALKTHROUGH_HEADER } from "@repo/constants/src/testids";
+import { GET_TESTID_STEP_TRACKER_WALKTHROUGH_HEADER } from "@repo/constants/src/testids";
 import { walkthroughs } from "../fixtures/multi-dwelling-9.9.9-test-data.json";
 import { results } from "../fixtures/results-data.json";
 
@@ -25,9 +25,9 @@ describe("multi dwelling: 9.9.9", () => {
   });
 
   it("step tracker doesn't show section headers for single section", () => {
-    cy.getByTestID(TESTID_STEP_TRACKER_WALKTHROUGH_HEADER)
-      .eq(0)
-      .should("be.hidden");
+    cy.getByTestID(
+      GET_TESTID_STEP_TRACKER_WALKTHROUGH_HEADER(EnumWalkthroughIds._9_9_9),
+    ).should("be.hidden");
   });
 
   it("default state should be accessible", () => {

--- a/apps/web/cypress/e2e/multi-dwelling-combined-walkthrough.cy.ts
+++ b/apps/web/cypress/e2e/multi-dwelling-combined-walkthrough.cy.ts
@@ -8,7 +8,7 @@ import { walkthroughs } from "../fixtures/multi-dwelling-combined-test-data.json
 import { results } from "../fixtures/results-data.json";
 import { runWalkthrough } from "../support/helpers";
 import {
-  TESTID_STEP_TRACKER_WALKTHROUGH_HEADER,
+  GET_TESTID_STEP_TRACKER_WALKTHROUGH_HEADER,
   TESTID_WALKTHROUGH_FOOTER_BACK,
 } from "@repo/constants/src/testids";
 
@@ -62,12 +62,12 @@ describe("multi dwelling: 9.9.9 and 9.10.14", () => {
   });
 
   it("combined walkthrough step tracker shows multiple section headers", () => {
-    cy.getByTestID(TESTID_STEP_TRACKER_WALKTHROUGH_HEADER)
-      .eq(0)
-      .should("be.visible");
-    cy.getByTestID(TESTID_STEP_TRACKER_WALKTHROUGH_HEADER)
-      .eq(1)
-      .should("be.visible");
+    cy.getByTestID(
+      GET_TESTID_STEP_TRACKER_WALKTHROUGH_HEADER(EnumWalkthroughIds._9_9_9),
+    ).should("be.visible");
+    cy.getByTestID(
+      GET_TESTID_STEP_TRACKER_WALKTHROUGH_HEADER(EnumWalkthroughIds._9_10_14),
+    ).should("be.visible");
   });
 
   it("default state should be accessible", () => {

--- a/apps/web/cypress/e2e/multi-dwelling-combined-walkthrough.cy.ts
+++ b/apps/web/cypress/e2e/multi-dwelling-combined-walkthrough.cy.ts
@@ -7,7 +7,10 @@ import {
 import { walkthroughs } from "../fixtures/multi-dwelling-combined-test-data.json";
 import { results } from "../fixtures/results-data.json";
 import { runWalkthrough } from "../support/helpers";
-import { TESTID_WALKTHROUGH_FOOTER_BACK } from "@repo/constants/src/testids";
+import {
+  TESTID_STEP_TRACKER_WALKTHROUGH_HEADER,
+  TESTID_WALKTHROUGH_FOOTER_BACK,
+} from "@repo/constants/src/testids";
 
 describe("multi dwelling: 9.9.9 and 9.10.14", () => {
   beforeEach(() => {
@@ -56,6 +59,15 @@ describe("multi dwelling: 9.9.9 and 9.10.14", () => {
     } else {
       throw new Error("Second walkthrough does not exist in workflow data");
     }
+  });
+
+  it("combined walkthrough step tracker shows multiple section headers", () => {
+    cy.getByTestID(TESTID_STEP_TRACKER_WALKTHROUGH_HEADER)
+      .eq(0)
+      .should("be.visible");
+    cy.getByTestID(TESTID_STEP_TRACKER_WALKTHROUGH_HEADER)
+      .eq(1)
+      .should("be.visible");
   });
 
   it("default state should be accessible", () => {

--- a/apps/web/cypress/e2e/single-dwelling-9.9.9.cy.ts
+++ b/apps/web/cypress/e2e/single-dwelling-9.9.9.cy.ts
@@ -2,7 +2,7 @@ import {
   TESTID_WALKTHROUGH_FOOTER_NEXT,
   GET_TESTID_CHECKBOX,
   GET_TESTID_RADIO,
-  TESTID_STEP_TRACKER_WALKTHROUGH_HEADER,
+  GET_TESTID_STEP_TRACKER_WALKTHROUGH_HEADER,
 } from "@repo/constants/src/testids";
 import { TEMP_GET_URL_SINGLE_DWELLING_WALKTHROUGH } from "@repo/constants/src/urls";
 import { EnumWalkthroughIds } from "@repo/constants/src/constants";
@@ -42,9 +42,9 @@ describe("single dwelling: 9.9.9", () => {
   });
 
   it("step tracker doesn't show section headers for single section", () => {
-    cy.getByTestID(TESTID_STEP_TRACKER_WALKTHROUGH_HEADER)
-      .eq(0)
-      .should("be.hidden");
+    cy.getByTestID(
+      GET_TESTID_STEP_TRACKER_WALKTHROUGH_HEADER(EnumWalkthroughIds._9_9_9),
+    ).should("be.hidden");
   });
 
   it("default state should be accessible", () => {

--- a/apps/web/cypress/e2e/single-dwelling-9.9.9.cy.ts
+++ b/apps/web/cypress/e2e/single-dwelling-9.9.9.cy.ts
@@ -2,6 +2,7 @@ import {
   TESTID_WALKTHROUGH_FOOTER_NEXT,
   GET_TESTID_CHECKBOX,
   GET_TESTID_RADIO,
+  TESTID_STEP_TRACKER_WALKTHROUGH_HEADER,
 } from "@repo/constants/src/testids";
 import { TEMP_GET_URL_SINGLE_DWELLING_WALKTHROUGH } from "@repo/constants/src/urls";
 import { EnumWalkthroughIds } from "@repo/constants/src/constants";
@@ -38,6 +39,12 @@ describe("single dwelling: 9.9.9", () => {
     // Test accessibility
     cy.injectAxe();
     cy.checkA11yWithErrorLogging();
+  });
+
+  it("step tracker doesn't show section headers for single section", () => {
+    cy.getByTestID(TESTID_STEP_TRACKER_WALKTHROUGH_HEADER)
+      .eq(0)
+      .should("be.hidden");
   });
 
   it("default state should be accessible", () => {

--- a/apps/web/cypress/fixtures/multi-dwelling-9.9.9-test-data.json
+++ b/apps/web/cypress/fixtures/multi-dwelling-9.9.9-test-data.json
@@ -1,0 +1,20 @@
+{
+  "walkthroughs": [
+    {
+      "title": "All Questions Multi-Dwelling 9.9.9",
+      "steps": [
+        {
+          "question": "P1",
+          "type": "radio",
+          "answer": "false"
+        },
+        {
+          "question": "P11",
+          "type": "radio",
+          "answer": "2"
+        }
+      ],
+      "result": "R10"
+    }
+  ]
+}

--- a/apps/web/cypress/fixtures/multi-dwelling-combined-test-data.json
+++ b/apps/web/cypress/fixtures/multi-dwelling-combined-test-data.json
@@ -6,7 +6,12 @@
         {
           "question": "P1",
           "type": "radio",
-          "answer": "true"
+          "answer": "false"
+        },
+        {
+          "question": "P11",
+          "type": "radio",
+          "answer": "2"
         },
         {
           "question": "P1",
@@ -23,6 +28,11 @@
           "question": "P1",
           "type": "radio",
           "answer": "true"
+        },
+        {
+          "question": "P6",
+          "type": "radio",
+          "answer": "false"
         },
         {
           "question": "P1",

--- a/apps/web/cypress/fixtures/results-data.json
+++ b/apps/web/cypress/fixtures/results-data.json
@@ -30,6 +30,11 @@
       "R30": "Based on the building characteristics provided this dwelling unit or building is not governed by Part 9 of the Building Code or is not a dwelling unit. This tool is only designed to address the egress from dwelling units of Part 9 buildings.",
       "R40": "this fire compartment is permitted to have unlimited unprotected openings.",
       "R51": "Based on your selection the percentage and area of unprotected openings should be calculated based on"
+    },
+    "multi_dwelling_workflow_999": {
+      "R10": "Based on the building characteristics provided, this dwelling unit meets the provision of Subsection",
+      "R30": "Based on the building characteristics provided this dwelling unit or building is not governed by Part 9 of the Building Code or is not a dwelling unit. This tool is only designed to address the egress from dwelling units of Part 9 buildings."
     }
+
   }
 }

--- a/apps/web/stores/AnswerStore.ts
+++ b/apps/web/stores/AnswerStore.ts
@@ -113,7 +113,10 @@ export class AnswerStore {
   setAnswerValueOnChange = (value: AnswerTypes, questionId: string) => {
     this.eraseAnswersAfterCurrentItem();
 
-    this.rootStore.navigationStore.setFarthestIds(questionId);
+    this.rootStore.navigationStore.setFarthestIds(
+      questionId,
+      this.rootStore.navigationStore.currentWalkthroughId,
+    );
 
     this.setAnswerValue(
       this.rootStore.navigationStore.currentWalkthroughId,
@@ -191,9 +194,9 @@ export class AnswerStore {
               ([answerId]) =>
                 // check if answer is in newly updated questionHistory
                 this.rootStore.navigationStore.questionHistory.findIndex(
-                  ({ answerVariableId, walkthroughId }) =>
+                  ({ answerVariableId, walkthroughId: historyWalkthroughId }) =>
                     answerVariableId === answerId &&
-                    walkthroughId === walkthroughId,
+                    historyWalkthroughId === walkthroughId,
                 ) > -1,
             ),
           );

--- a/packages/constants/src/testids.ts
+++ b/packages/constants/src/testids.ts
@@ -40,8 +40,8 @@ export const TESTID_STEP_TRACKER_MOBILE_BUTTON_OPEN =
   "step-tracker-mobile-button-open";
 export const TESTID_BUTTON_MODAL_CLOSE = "button-modal-close";
 export const TESTID_STEP_TRACKER_ITEMS = "step-tracker-items";
-export const TESTID_STEP_TRACKER_WALKTHROUGH_HEADER =
-  "step-tracker-walkthrough-header";
+export const GET_TESTID_STEP_TRACKER_WALKTHROUGH_HEADER = (id: string) =>
+  `step-tracker-walkthrough-header-${id}`;
 export const TESTID_RESULT = "result";
 export const TESTID_HEADER = "header";
 export const TESTID_HEADER_MOBILE_NAV = "header-mobile-nav";

--- a/packages/constants/src/testids.ts
+++ b/packages/constants/src/testids.ts
@@ -40,6 +40,8 @@ export const TESTID_STEP_TRACKER_MOBILE_BUTTON_OPEN =
   "step-tracker-mobile-button-open";
 export const TESTID_BUTTON_MODAL_CLOSE = "button-modal-close";
 export const TESTID_STEP_TRACKER_ITEMS = "step-tracker-items";
+export const TESTID_STEP_TRACKER_WALKTHROUGH_HEADER =
+  "step-tracker-walkthrough-header";
 export const TESTID_RESULT = "result";
 export const TESTID_HEADER = "header";
 export const TESTID_HEADER_MOBILE_NAV = "header-mobile-nav";

--- a/packages/data/json/building-types/multi-dwelling/wt-multi-dwelling-9.9.9.json
+++ b/packages/data/json/building-types/multi-dwelling/wt-multi-dwelling-9.9.9.json
@@ -101,7 +101,7 @@
         {
           "nextLogicType": "equal",
           "answerToCheck": "P11",
-          "answerValue": "true",
+          "answerValue": "2",
           "nextNavigateTo": "R10"
         },
         {

--- a/packages/data/json/building-types/multi-dwelling/wt-multi-dwelling-9.9.9.json
+++ b/packages/data/json/building-types/multi-dwelling/wt-multi-dwelling-9.9.9.json
@@ -10,8 +10,13 @@
     "1_9991": {
       "sectionTitle": "9.9.9.1. Travel limit to Exits or Egress Doors",
       "sectionQuestions": [
-        "P1"
+        "P1",
+        "P6"
       ]
+    },
+    "2_9992": {
+      "sectionTitle": "9.9.9.2. Two Separate Exits",
+      "sectionQuestions": ["P11"]
     }
   },
   "questions": {
@@ -36,6 +41,66 @@
         {
           "nextLogicType": "equal",
           "answerToCheck": "P1",
+          "answerValue": "true",
+          "nextNavigateTo": "P6"
+        },
+        {
+          "nextLogicType": "fallback",
+          "nextNavigateTo": "P11"
+        }
+      ]
+    },
+    "P6": {
+      "walkthroughItemType": "multiChoice",
+      "questionText": "Is this <defined-term>dwelling unit</defined-term> above another <defined-term>dwelling unit</defined-term>?",
+      "questionCodeReference": {
+        "displayString": "Vol 2, Div B, Article 9.9.9.1.",
+        "codeNumber": "v2-db-9.9.9.1."
+      },
+      "possibleAnswers": [
+        {
+          "answerDisplayText": "Yes",
+          "answerValue": "true"
+        },
+        {
+          "answerDisplayText": "No",
+          "answerValue": "false"
+        }
+      ],
+      "nextNavigationLogic": [
+        {
+          "nextLogicType": "equal",
+          "answerToCheck": "P6",
+          "answerValue": "true",
+          "nextNavigateTo": "P11"
+        },
+        {
+          "nextLogicType": "fallback",
+          "nextNavigateTo": "R30"
+        }
+      ]
+    },
+    "P11": {
+      "walkthroughItemType": "multiChoice",
+      "questionText": "How many <defined-term override-term='dwelling unit'>dwelling units</defined-term> are in this <defined-term>building</defined-term>?",
+      "questionCodeReference": {
+        "displayString": "Vol 2, Div B, Article 9.9.9.2.",
+        "codeNumber": "v2-db-9.9.9.2."
+      },
+      "possibleAnswers": [
+        {
+          "answerDisplayText": "1-2",
+          "answerValue": "2"
+        },
+        {
+          "answerDisplayText": "Greater than 2",
+          "answerValue": "3"
+        }
+      ],
+      "nextNavigationLogic": [
+        {
+          "nextLogicType": "equal",
+          "answerToCheck": "P11",
           "answerValue": "true",
           "nextNavigateTo": "R10"
         },

--- a/packages/data/src/useWalkthroughsTestData.ts
+++ b/packages/data/src/useWalkthroughsTestData.ts
@@ -1,9 +1,12 @@
 // repo
-import { EnumWalkthroughIds } from "@repo/constants/src/constants";
+import {
+  EnumBuildingTypes,
+  EnumWalkthroughIds,
+} from "@repo/constants/src/constants";
 // local
 import testCase999 from "../json/building-types/single-dwelling/wt-single-dwelling-9.9.9.json";
 import testCase91014 from "../json/building-types/single-dwelling/wt-single-dwelling-9.10.14.json";
-import {
+import useWalkthroughsData, {
   QuestionDisplayData,
   QuestionMultipleChoiceData,
   QuestionMultipleChoiceSelectMultipleData,
@@ -133,19 +136,25 @@ export function getFirstResultWithCalculations() {
   };
 }
 
-export function useWalkthroughTestData999() {
+export function useWalkthroughTestData999(): WalkthroughsDataInterface {
   // deep clone and return test data
-  const testData = JSON.parse(JSON.stringify(testCase999));
-  return {
-    startingWalkthroughId: EnumWalkthroughIds._9_9_9,
-    walkthroughsById: { [EnumWalkthroughIds._9_9_9]: testData },
-  } as WalkthroughsDataInterface;
+  return JSON.parse(
+    JSON.stringify(
+      useWalkthroughsData({
+        wtIds: [EnumWalkthroughIds._9_9_9],
+        buildingType: EnumBuildingTypes.SINGLE_DWELLING,
+      }),
+    ),
+  );
 }
 
-export function useWalkthroughTestData91014() {
-  const testData = JSON.parse(JSON.stringify(testCase91014));
-  return {
-    startingWalkthroughId: EnumWalkthroughIds._9_10_14,
-    walkthroughsById: { [EnumWalkthroughIds._9_10_14]: testData },
-  } as WalkthroughsDataInterface;
+export function useWalkthroughTestData91014(): WalkthroughsDataInterface {
+  return JSON.parse(
+    JSON.stringify(
+      useWalkthroughsData({
+        wtIds: [EnumWalkthroughIds._9_10_14],
+        buildingType: EnumBuildingTypes.SINGLE_DWELLING,
+      }),
+    ),
+  );
 }


### PR DESCRIPTION
[HOUSNAV-199](https://hous-bssb.atlassian.net/browse/HOUSNAV-199)

## Overview & Purpose
Update the step tracker to account for the new data structure and display of possible multiple sets of walkthrough sections

## Summary of Changes
- Added higher level walkthrough title display
- refactored some styles for specificity and alignment with paradigms
- Updated multi-dwelling combined cypress tests to account for updated test data
- Fixed answer store issues with farthest walkthrough id and appropriately deleting ALL future answers
- Updated navigation store check of past section to account for multiple walkthrough data
- Fixed useWalkthroughsTestData methods to return all needed data props

## Testing
Navigate to all types of walkthroughs (single dwelling & multi dwelling) and view step tracker matches design

## Checklist
- [x] I have written or updated vitests for this work
- [x] I have reviewed the [accessibility guidelines](https://digital.gov.bc.ca/wcag/home/) relevant to this work
- [x] I have reviewed this work with at least one screen reader (when applicable)
- [x] I have added/updated any related documentation