### PR TITLE
HOUSNAV-225: JSON schema

### DIFF
--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -1,3 +1,7 @@
 # `@repo/data`
 
 JSON data files for the `@repo` package plus interfaces to access them. This contains all current data for each walkthrough, the defined terms, and the digital building code content.
+
+## Walkthrough Schema
+
+All walkthrough type JSON files follow the same schema outlined in `schema/walkthrough.schema.json`. Each JSON with the `wt-` prefix follows this schema. They point to the schema file for validation and their associated unit tests verify data not verified by the schema.

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -1,7 +1,32 @@
 # `@repo/data`
 
-JSON data files for the `@repo` package plus interfaces to access them. This contains all current data for each walkthrough, the defined terms, and the digital building code content.
+JSON data files for the `@repo` package plus interfaces to access them. This contains all current data for each
+walkthrough, the defined terms, and the digital building code content.
 
-## Walkthrough Schema
+## JSON & Schemas
 
-All walkthrough type JSON files follow the same schema outlined in `schema/walkthrough.schema.json`. Each JSON with the `wt-` prefix follows this schema. They point to the schema file for validation and their associated unit tests verify data not verified by the schema.
+The schemas for the data files are located in the `schema` directory. Each schema is defined in a separate JSON file.
+The schemas are used to validate the data files and ensure they conform to the expected structure.
+
+### Walkthrough JSON
+
+All walkthrough type JSON files follow the same schema outlined in `schema/walkthrough.schema.json`. Each JSON with the
+`wt-` prefix follows this schema. They point to the schema file for validation and their associated unit tests verify
+data not verified by the schema.
+
+#### Creating a new walkthrough JSON file
+
+To create a new walkthrough, follow these steps:
+
+1. Create a new JSON file in appropriate `json/building-types/[building-type]` directory with naming convention of
+   `wt-[building-type]-[code.section].json` a la `wt-multi-dwelling-9.9.9.json`.
+2. Ensure the JSON file adheres to the schema defined in `schema/walkthrough.schema.json` by defining the first item in
+   the schema as `"$schema": "../../../schema/walkthrough.schema.json"`.
+3. Populate the JSON file with the necessary data, ensuring it follows the structure defined in the schema.
+4. Add unit tests to verify the data in the new walkthrough file. The unit test file should be in the same location as
+   the json data and use the same name as the JSON file but with a `.test.ts` extension (e.g.,
+   `wt-multi-dwelling-9.9.9.test.ts`). See current tests for examples.
+   1. At a minimum, this file should verify data not covered by the schema, such as ensuring that:
+      1. All questions either appear in a section or are of variable type
+      2. all question ids in the sections are valid question ids
+5. Import the file into `useWalkthroughsData.ts` and follow the paradigms used by existing walkthroughs.

--- a/packages/data/json/building-types/multi-dwelling/wt-multi-dwelling-9.10.14.json
+++ b/packages/data/json/building-types/multi-dwelling/wt-multi-dwelling-9.10.14.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../../../schema/walkthrough.schema.json",
   "info": {
     "title": "Spatial Separation Between Buildings",
     "subtitle": "Volume II - 9.10.14.1-4",

--- a/packages/data/json/building-types/multi-dwelling/wt-multi-dwelling-9.9.9.json
+++ b/packages/data/json/building-types/multi-dwelling/wt-multi-dwelling-9.9.9.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../../../schema/walkthrough.schema.json",
   "info": {
     "title": "Egress from Dwelling Units",
     "subtitle": "Volume II - 9.9.9.",

--- a/packages/data/json/building-types/single-dwelling/wt-single-dwelling-9.10.14.json
+++ b/packages/data/json/building-types/single-dwelling/wt-single-dwelling-9.10.14.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../../../schema/walkthrough.schema.json",
   "info": {
     "title": "Spatial Separation Between Buildings",
     "subtitle": "Volume II - 9.10.14.1-4",

--- a/packages/data/json/building-types/single-dwelling/wt-single-dwelling-9.10.14.test.ts
+++ b/packages/data/json/building-types/single-dwelling/wt-single-dwelling-9.10.14.test.ts
@@ -5,6 +5,9 @@ import { isWalkthroughItemTypeVariable } from "../../../src/useWalkthroughsData"
 import data from "./wt-single-dwelling-9.10.14.json";
 
 describe("Data - 9.10.14", () => {
+  it("verify the $schema property is present", () => {
+    expect(data).toHaveProperty("$schema");
+  });
   it("verify all questions either appear in a section or are of variable type", () => {
     // iterate through each question and check if it appears in a section or is of variable type
     const possibleUnusedQuestion = Object.entries(data.questions).find(

--- a/packages/data/json/building-types/single-dwelling/wt-single-dwelling-9.9.9.json
+++ b/packages/data/json/building-types/single-dwelling/wt-single-dwelling-9.9.9.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../../../schema/walkthrough.schema.json",
   "info": {
     "title": "Egress from Dwelling Units",
     "subtitle": "Volume II - 9.9.9.",

--- a/packages/data/json/building-types/single-dwelling/wt-single-dwelling-9.9.9.test.ts
+++ b/packages/data/json/building-types/single-dwelling/wt-single-dwelling-9.9.9.test.ts
@@ -5,6 +5,9 @@ import { isWalkthroughItemTypeVariable } from "../../../src/useWalkthroughsData"
 import data from "./wt-single-dwelling-9.9.9.json";
 
 describe("Data - 9.9.9", () => {
+  it("verify the $schema property is present", () => {
+    expect(data).toHaveProperty("$schema");
+  });
   it("verify all questions either appear in a section or are of variable type", () => {
     // iterate through each question and check if it appears in a section or is of variable type
     const possibleUnusedQuestion = Object.entries(data.questions).find(

--- a/packages/data/json/buildingCode.json
+++ b/packages/data/json/buildingCode.json
@@ -1,403 +1,406 @@
-[
-  {
-    "numberReference": "v2-db-9",
-    "title": "Housing and Small Buildings",
-    "sections": [
-      {
-        "numberReference": "v2-db-9.9.",
-        "title": "Means of Egress",
-        "subsections": [
-          {
-            "numberReference": "v2-db-9.9.9.",
-            "title": "Egress from Dwelling Units",
-            "articles": [
-              {
-                "numberReference": "v2-db-9.9.9.1.",
-                "title": "Travel Limit to Exits or Egress Doors",
-                "sentences": [
-                  {
-                    "numberReference": "v2-db-9.9.9.1.(1)",
-                    "description": "Except as provided in <building-code-modal reference='v2-db-9.9.9.1.(2)'>Sentences (2)</building-code-modal> and <building-code-modal reference='v2-db-9.9.9.1.(3)'>(3)</building-code-modal>, every <defined-term>dwelling unit</defined-term> containing more than 1 <defined-term>storey</defined-term> shall have <defined-term override-term='exit'>exits</defined-term> or egress doors located so that it shall not be necessary to travel up or down more than 1 <defined-term>storey</defined-term> to reach a level served by:",
-                    "clauses": [
-                      {
-                        "numberReference": "v2-db-9.9.9.1.(1)(a)",
-                        "description": "an egress door to a <defined-term>public corridor</defined-term>, enclosed <defined-term>exit</defined-term> stair or exterior passageway, or"
-                      },
-                      {
-                        "numberReference": "v2-db-9.9.9.1.(1)(b)",
-                        "description": "an <defined-term>exit</defined-term> doorway not more than 1.5m above adjacent ground level."
-                      }
-                    ]
-                  },
-                  {
-                    "numberReference": "v2-db-9.9.9.1.(2)",
-                    "description": "Where a <defined-term>dwelling unit</defined-term> is not located above or below another <defined-term>suite</defined-term>, the travel limit from a floor level in the <defined-term>dwelling unit</defined-term> to an <defined-term>exit</defined-term> or egress door may exceed 1 <defined-term>storey</defined-term> where that floor level is served by an openable window",
-                    "clauses": [
-                      {
-                        "numberReference": "v2-db-9.9.9.1.(2)(a)",
-                        "description": "providing an unobstructed opening of not less than 1m in height and 0.55m in width, and"
-                      },
-                      {
-                        "numberReference": "v2-db-9.9.9.1.(2)(b)",
-                        "description": "located so that the sill is not more than",
-                        "subClauses": [
-                          "1m above the floor, and",
-                          "7m above adjacent ground level."
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "numberReference": "v2-db-9.9.9.1.(3)",
-                    "description": "The travel limit from a floor level in a <defined-term>dwelling unit</defined-term> to an <defined-term>exit</defined-term> or egress door may exceed 1 <defined-term>storey</defined-term> where that floor level has direct access to a balcony."
-                  }
-                ]
-              },
-              {
-                "numberReference": "v2-db-9.9.9.2.",
-                "title": "Two Separate exits",
-                "sentences": [
-                  {
-                    "numberReference": "v2-db-9.9.9.2.(1)",
-                    "description": "Except as provided in <building-code-modal reference='v2-db-9.9.9.2.(2)'>Sentence (2)</building-code-modal> and <pdf-download-link number='99731' named-dest='9.9.7.3. Dead-End Corridors'>Sentence 9.9.7.3.(1)</pdf-download-link>, where an egress door from a <defined-term>dwelling unit</defined-term> opens onto a <defined-term>public corridor</defined-term> or exterior passageway it shall be possible from the location where the egress door opens onto the corridor or exterior passageway to go in opposite directions to 2 separate <defined-term override-term='exit'>exits</defined-term> unless the <defined-term>dwelling unit</defined-term> has a second and separate <defined-term>means of egress</defined-term>."
-                  },
-                  {
-                    "numberReference": "v2-db-9.9.9.2.(2)",
-                    "description": "For <defined-term override-term='dwelling unit'>dwelling units</defined-term> in a house with a <defined-term>secondary suite</defined-term>, it need not be possible to go in more than one direction to an <defined-term>exit</defined-term> from the location where the egress door opens into a <defined-term>public corridor</defined-term> or exterior passageway if the <defined-term>building</defined-term> is <defined-term>sprinklered</defined-term> or if each <defined-term>dwelling unit</defined-term> has separate and direct access from each <defined-term>storey</defined-term> to",
-                    "clauses": [
-                      {
-                        "numberReference": "v2-db-9.9.9.2.(2)(a)",
-                        "description": "a balcony, or"
-                      },
-                      {
-                        "numberReference": "v2-db-9.9.9.2.(2)(b)",
-                        "description": "an openable window conforming to sentences <building-code-modal reference='v2-db-9.9.9.1.(2)(a)'>9.9.9.1.(2)(a)</building-code-modal> and <building-code-modal reference='v2-db-9.9.9.1.(2)(b)'>(b)</building-code-modal>."
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "numberReference": "v2-db-9.9.9.3.",
-                "title": "Shared Egress Facilities",
-                "sentences": [
-                  {
-                    "numberReference": "v2-db-9.9.9.3.(1)",
-                    "description": "Except for as provided in <building-code-modal reference='v2-db-9.9.9.3.(2)'>Sentences (2)</building-code-modal>  and <building-code-modal reference='v2-db-9.9.9.3.(3)'>(3)</building-code-modal>, a <defined-term>dwelling unit</defined-term> shall be provided with a second and separate <defined-term>means of egress</defined-term> where an egress door from the <defined-term>dwelling unit</defined-term> opens onto",
-                    "clauses": [
-                      {
-                        "numberReference": "v2-db-9.9.9.3.(1)(a)",
-                        "description": "an <defined-term>exit</defined-term> stairway serving more than one <defined-term>suite</defined-term>,"
-                      },
-                      {
-                        "numberReference": "v2-db-9.9.9.3.(1)(b)",
-                        "description": "a <defined-term>public corridor</defined-term>",
-                        "subClauses": [
-                          "serving more than one <defined-term>suite</defined-term>, and",
-                          "served by a single <defined-term>exit</defined-term>"
-                        ]
-                      },
-                      {
-                        "numberReference": "v2-db-9.9.9.3.(1)(c)",
-                        "description": "an exterior passageway",
-                        "subClauses": [
-                          "serving more than one <defined-term>suite</defined-term>,",
-                          "served by a single <defined-term>exit</defined-term> stairway or <defined-term>ramp</defined-term>, and",
-                          "more than 1.5m above adjacent ground level, or"
-                        ]
-                      },
-                      {
-                        "numberReference": "v2-db-9.9.9.3.(1)(d)",
-                        "description": "a balcony",
-                        "subClauses": [
-                          "serving more than one <defined-term>suite</defined-term>,",
-                          "served by a single <defined-term>exit</defined-term> stairway or <defined-term>ramp</defined-term>, and",
-                          "more than 1.5m above adjacent ground level."
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "numberReference": "v2-db-9.9.9.3.(2)",
-                    "description": "Where a <defined-term>dwelling unit</defined-term> is located above another <defined-term>dwelling unit</defined-term> or common space in a house with a <defined-term>secondary suite</defined-term>, the upper <defined-term>dwelling unit</defined-term> shall be provided with a second  and separate <defined-term>means of egress</defined-term> where an egress door from that <defined-term>dwelling unit</defined-term> opens onto an exterior passageway that",
-                    "clauses": [
-                      {
-                        "numberReference": "v2-db-9.9.9.3.(2)(a)",
-                        "description": "has a floor assembly with a <defined-term>fire-resistance rating</defined-term> less than 45 min,"
-                      },
-                      {
-                        "numberReference": "v2-db-9.9.9.3.(2)(b)",
-                        "description": "is served by a single <defined-term>exit</defined-term> stairway or <defined-term>ramp</defined-term>, and"
-                      },
-                      {
-                        "numberReference": "v2-db-9.9.9.3.(2)(c)",
-                        "description": "is located more than 1.5m above adjacent ground level."
-                      }
-                    ]
-                  },
-                  {
-                    "numberReference": "v2-db-9.9.9.3.(3)",
-                    "description": "For <defined-term override-term='dwelling unit'>dwelling units</defined-term> in a house with a <defined-term>secondary suite</defined-term> where an egress door from either <defined-term>dwelling unit</defined-term> opens onto a shared egress facility served by a single <defined-term>exit</defined-term> stairway or <defined-term>ramp</defined-term>, other than as described in <building-code-modal reference='v2-db-9.9.9.3.(2)'>Sentence (2)</building-code-modal>, a second and separate <defined-term>means of egress</defined-term> need not be provided if the <defined-term>building</defined-term> is <defined-term>sprinklered</defined-term> or if the <defined-term override-term='dwelling unit'>dwelling units</defined-term> have separate and direct access from each <defined-term>storey</defined-term> to",
-                    "clauses": [
-                      {
-                        "numberReference": "v2-db-9.9.9.3.(3)(a)",
-                        "description": "a balcony, or"
-                      },
-                      {
-                        "numberReference": "v2-db-9.9.9.3.(3)(b)",
-                        "description": " an openable window conforming to sentences <building-code-modal reference='v2-db-9.9.9.1.(2)(a)'>9.9.9.1.(2)(a)</building-code-modal> and <building-code-modal reference='v2-db-9.9.9.1.(2)(b)'>(b)</building-code-modal>."
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "numberReference": "v2-db-9.10.",
-        "title": "Fire Protection",
-        "subsections": [
-          {
-            "numberReference": "v2-db-9.10.14.",
-            "title": "Spatial Separation Between Buildings",
-            "articles": [
-              {
-                "numberReference": "v2-db-9.10.14.1.",
-                "title": "Application",
-                "sentences": [
-                  {
-                    "numberReference": "v2-db-9.10.14.1.(1)",
-                    "description": "This Subsection applies to <defined-term override-term='building'>buildings</defined-term> other than those to which <pdf-download-link named-dest='9.10.15. Spatial Separation Between Houses'>Subsection 9.10.15.</pdf-download-link> applies."
-                  },
-                  {
-                    "numberReference": "v2-db-9.10.14.1.(2)",
-                    "description": "This Subsection does not apply to detached carports conforming to <pdf-download-link named-dest='Section 9.35. Garages and Carports'>Section 9.35.</pdf-download-link> that serve not more than one <defined-term>dwelling unit</defined-term> or a house with a <defined-term>secondary suite</defined-term>."
-                  }
-                ]
-              },
-              {
-                "numberReference": "v2-db-9.10.14.2.",
-                "title": "Area and Location of Exposing Building Face",
-                "sentences": [
-                  {
-                    "numberReference": "v2-db-9.10.14.2.(1)",
-                    "description": "Except as permitted by <building-code-modal reference='v2-db-9.10.14.2.(4)'>Sentence (4)</building-code-modal>, the area of an <defined-term>exposing building face</defined-term> shall be",
-                    "clauses": [
-                      {
-                        "numberReference": "v2-db-9.10.14.2.(1)(a)",
-                        "description": "taken as the exterior wall area facing in one direction on any side of a <defined-term>building</defined-term>, and"
-                      },
-                      {
-                        "numberReference": "v2-db-9.10.14.2.(1)(b)",
-                        "description": "calculated as",
-                        "subClauses": [
-                          "the total area measured from the finished ground level to the uppermost ceiling, or",
-                          " the area for each <defined-term>fire compartment</defined-term>, where a <defined-term>building</defined-term> is divided into <defined-term override-term='fire compartment'>fire compartments</defined-term> by <defined-term override-term='fire separation'>fire separations</defined-term> with <defined-term override-term='fire-resistance rating'>fire-resistance ratings</defined-term> not less than 45 min."
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "numberReference": "v2-db-9.10.14.2.(2)",
-                    "description": "For the purpose of using <building-code-modal reference='v2-db-9.10.14.4.-a'>Table 9.10.14.4.-A</building-code-modal> to determine the maximum aggregate area of <defined-term>unprotected openings</defined-term> in an irregularly shaped or skewed exterior wall, the location of the <defined-term>exposing building face</defined-term> shall be taken as a vertical plane located so that there are no <defined-term>unprotected openings</defined-term> between the vertical plane and the line to which the <defined-term>limiting distance</defined-term> is measured. (<pdf-download-link named-dest='A-3.2.3.1.(4) Spatial Separation Design.'>See Note A-3.2.3.1.(4).</pdf-download-link>)"
-                  },
-                  {
-                    "numberReference": "v2-db-9.10.14.2.(3)",
-                    "description": "For the purpose of using <pdf-download-link named-dest='9.10.14.5. Construction of Exposing Building Face and Walls above Exposing Building Face'>Table 9.10.14.5.-A</pdf-download-link> to determine the required type of construction, cladding and <defined-term>fire-resistance rating</defined-term> for an irregularly shaped or skewed exterior wall,",
-                    "clauses": [
-                      {
-                        "numberReference": "v2-db-9.10.14.2.(1)(a)",
-                        "description": "the location of the <defined-term>exposing building face</defined-term> shall be taken as a vertical plane located so that no portion of the actual <defined-term>exposing building face</defined-term> is between the vertical plane and the line to which the <defined-term>limiting distance</defined-term> is measured, and"
-                      },
-                      {
-                        "numberReference": "v2-db-9.10.14.2.(1)(b)",
-                        "description": "the value for the maximum area of <defined-term>unprotected openings</defined-term> (see second column of <pdf-download-link named-dest='9.10.14.5. Construction of Exposing Building Face and Walls above Exposing Building Face'>Table 9.10.14.5.-A</pdf-download-link>) shall be determined using the <defined-term>limiting distance</defined-term> measured from the location described in Clause (a). (<pdf-download-link named-dest='A-3.2.3.1.(4) Spatial Separation Design.'>See Note A-3.2.3.1.(4).</pdf-download-link>)"
-                      }
-                    ]
-                  },
-                  {
-                    "numberReference": "v2-db-9.10.14.2.(4)",
-                    "description": "If a <defined-term>building</defined-term> is divided by <defined-term override-term='fire separation'>fire separations</defined-term> into <defined-term-glossary override-term='fire compartment'>fire compartments</defined-term-glossary>, the area of <defined-term>exposing building face</defined-term> is permitted to be calculated for each <defined-term-glossary>fire compartment</defined-term-glossary>, provided the <defined-term override-term='fire separation'>fire separations</defined-term> have a <defined-term>fire-resistance rating</defined-term> not less than 45 min."
-                  }
-                ]
-              },
-              {
-                "numberReference": "v2-db-9.10.14.3.",
-                "title": "Limiting Distance and Fire Department Response",
-                "sentences": [
-                  {
-                    "numberReference": "v2-db-9.10.14.3.(1)",
-                    "description": "Except for the purpose of applying <building-code-modal reference='v2-db-9.10.14.4'>Sentences 9.10.14.4.</building-code-modal> <building-code-modal reference='v2-db-9.10.14.4.(2)'>(2)</building-code-modal>, <building-code-modal reference='v2-db-9.10.14.4.(3)'>(3)</building-code-modal>, <building-code-modal reference='v2-db-9.10.14.4.(8)'>(8)</building-code-modal> and <building-code-modal reference='v2-db-9.10.14.4.(9)'>(9)</building-code-modal>, and <pdf-download-link named-dest='9.10.14.5. Construction of Exposing Building Face and Walls above Exposing Building Face'>Sentences 9.10.14.5.(3)</pdf-download-link>, <pdf-download-link named-dest='9.10.14.5. Construction of Exposing Building Face and Walls above Exposing Building Face'>(8)</pdf-download-link> and <pdf-download-link named-dest='9.10.14.5. Construction of Exposing Building Face and Walls above Exposing Building Face'>(13)</pdf-download-link>, a <defined-term>limiting distance</defined-term> equal to half the actual <defined-term>limiting distance</defined-term> shall be used as input to the requirements of this Subsection, where (<pdf-download-link named-dest='A-3.2.3. Fire Protection Related to Limiting Distance versus Separation Between Buildings.'>See Notes A-3.2.3.</pdf-download-link> and <pdf-download-link named-dest='A-3.2.3.1.(8) Intervention Time and Limiting Distance.'>A-3.2.3.1.(8).</pdf-download-link></pdf-download-link>)",
-                    "clauses": [
-                      {
-                        "numberReference": "v2-db-9.10.14.3.(1)(a)",
-                        "description": "the time from receipt of notification of a fire by the fire department until the first fire department vehicle arrives at the <defined-term>building</defined-term> exceeds 10 min in 10% or more of all calls to the building, and"
-                      },
-                      {
-                        "numberReference": "v2-db-9.10.14.3.(1)(b)",
-                        "description": "any storey in the <defined-term>building</defined-term> is not <defined-term>sprinklered</defined-term>."
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "numberReference": "v2-db-9.10.14.4.",
-                "title": "Openings in Exposing Building Face",
-                "sentences": [
-                  {
-                    "numberReference": "v2-db-9.10.14.4.(1)",
-                    "description": "Except as provided in <building-code-modal reference='v2-db-9.10.14.4.(6)'>Sentences (6)</building-code-modal> to <building-code-modal reference='v2-db-9.10.14.4.(10)'>(10)</building-code-modal>, the maximum aggregate area of <defined-term>unprotected openings</defined-term> in an <defined-term>exposing building face</defined-term> shall",
-                    "clauses": [
-                      {
-                        "numberReference": "v2-db-9.10.14.4.(1)(a)",
-                        "description": "conform to <building-code-modal reference='v2-db-9.10.14.4.-a'>Table 9.10.14.4.-A</building-code-modal>,"
-                      },
-                      {
-                        "numberReference": "v2-db-9.10.14.4.(1)(b)",
-                        "description": "conform to <pdf-download-link named-dest='3.2.3. Spatial Separation and Exposure Protection'>Subsection 3.2.3.</pdf-download-link>, or"
-                      },
-                      {
-                        "numberReference": "v2-db-9.10.14.4.(1)(c)",
-                        "description": "where the <defined-term>limiting distance</defined-term> is not less than 1.2 m, be equal to or less than",
-                        "subClauses": [
-                          "the <defined-term>limiting distance</defined-term> squared, for <defined-term override-term='residential occupancy'>residential occupancies</defined-term>, <defined-term override-term='business and personal services occupancy'>business and personal services occupancies</defined-term> and <defined-term override-term='low-hazard industrial occupancy'>low-hazard industrial occupancies</defined-term>, and",
-                          "half the <defined-term>limiting distance</defined-term> squared, for <defined-term override-term='mercantile occupancy'>mercantile occupancies</defined-term> and <defined-term-glossary override-term='medium-hazard industrial occupancy'>medium hazard industrial occupancies</defined-term-glossary>."
-                        ]
-                      }
-                    ],
-                    "image": {
-                      "fileName": "table-9.10.14.4.-a.png",
-                      "tableName": "Table: 9.10.14.4.-A",
-                      "numberReference": "v2-db-9.10.14.4.-a",
-                      "title": "Maximum Aggregate Area of Unprotected Openings in Exterior Walls <sup>(1)</sup>",
-                      "imageReference": "Forming Part of <building-code-modal reference='v2-db-9.10.14.4.(1)'>Sentence 9.10.14.4.(1)</building-code-modal>",
-                      "imageNotes": "<building-code-modal reference='v2-db-9.10.14.4.(1)'>(1)</building-code-modal> See also Sentences <building-code-modal reference='v2-db-9.10.14.4.(6)'>(6)</building-code-modal> and <building-code-modal reference='v2-db-9.10.14.4.(7)'>(7)</building-code-modal> to calculate the maximum permitted area of <defined-term>unprotected openings</defined-term> in <defined-term>sprinklered</defined-term> <defined-term override-term='building'>buildings</defined-term> or where wired glass or glass blocks are used.",
-                      "imageTable": "<table class='u-screen-reader-only'><thead><tr><th scope='col' rowSpan='3'>Occupancy Classification of Building</th><th scope='col' rowSpan='3'>Maximum Total Area of Exposing Building Face, in meters squared</th><th scope='col' colSpan='12'>Maximum Aggregate Area of Unprotected Openings, as a % ofExposing Building Face Area</th></tr><tr><th scope='col' colSpan='12'>Limiting Distance in meters</th></tr><tr><th scope='col'>Less than 1.2</th><th scope='col'>1.2</th><th scope='col'>1.5</th><th scope='col'>2.0</th><th scope='col'>4.0</th><th scope='col'>6.0</th><th scope='col'>8.0</th><th scope='col'>10.0</th><th scope='col'>12.0</th><th scope='col'>16.0</th><th scope='col'>20.0</th><th scope='col'>25.0</th></tr></thead><tbody><tr><th scope='row' rowSpan='5'>Residential, business and personal services, and low-hazard industrial</th><th scope='row'>30</th><td>0</td><td>7</td><td>9</td><td>12</td><td>39</td><td>88</td><td>100</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><th scope='row'>40</th><td>0</td><td>7</td><td>8</td><td>11</td><td>32</td><td>69</td><td>100</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><th scope='row'>50</th><td>0</td><td>7</td><td>8</td><td>10</td><td>28</td><td>57</td><td>100</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><th scope='row'>100</th><td>0</td><td>7</td><td>8</td><td>9</td><td>18</td><td>34</td><td>56</td><td>84</td><td>100</td><td>-</td><td>-</td><td>-</td></tr><tr><th scope='row'>Over 100</th><td>0</td><td>7</td><td>7</td><td>8</td><td>12</td><td>19</td><td>28</td><td>40</td><td>55</td><td>92</td><td>100</td><td>-</td></tr><tr><th scope='row' rowSpan='5'>Mercantile and medium-hazard industrial</th><th scope='row'>30</th><td>0</td><td>4</td><td>4</td><td>6</td><td>20</td><td>44</td><td>80</td><td>100</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><th scope='row'>40</th><td>0</td><td>4</td><td>4</td><td>6</td><td>16</td><td>34</td><td>61</td><td>97</td><td>100</td><td>-</td><td>-</td><td>-</td></tr><tr><th scope='row'>50</th><td>0</td><td>4</td><td>4</td><td>5</td><td>14</td><td>29</td><td>50</td><td>79</td><td>100</td><td>-</td><td>-</td><td>-</td></tr><tr><th scope='row'>100</th><td>0</td><td>4</td><td>4</td><td>4</td><td>9</td><td>17</td><td>28</td><td>42</td><td>60</td><td>100</td><td>-</td><td>-</td></tr><tr><th scope='row'>Over 100</th><td>0</td><td>4</td><td>4</td><td>4</td><td>6</td><td>10</td><td>14</td><td>20</td><td>27</td><td>46</td><td>70</td><td>100</td></tr></tbody></table>",
-                      "imageLabel": "Maximum Aggregate Area of Unprotected Openings in Exterior Walls"
+{
+  "$schema": "../schema/buildingCode.schema.json",
+  "data": [
+    {
+      "numberReference": "v2-db-9",
+      "title": "Housing and Small Buildings",
+      "sections": [
+        {
+          "numberReference": "v2-db-9.9.",
+          "title": "Means of Egress",
+          "subsections": [
+            {
+              "numberReference": "v2-db-9.9.9.",
+              "title": "Egress from Dwelling Units",
+              "articles": [
+                {
+                  "numberReference": "v2-db-9.9.9.1.",
+                  "title": "Travel Limit to Exits or Egress Doors",
+                  "sentences": [
+                    {
+                      "numberReference": "v2-db-9.9.9.1.(1)",
+                      "description": "Except as provided in <building-code-modal reference='v2-db-9.9.9.1.(2)'>Sentences (2)</building-code-modal> and <building-code-modal reference='v2-db-9.9.9.1.(3)'>(3)</building-code-modal>, every <defined-term>dwelling unit</defined-term> containing more than 1 <defined-term>storey</defined-term> shall have <defined-term override-term='exit'>exits</defined-term> or egress doors located so that it shall not be necessary to travel up or down more than 1 <defined-term>storey</defined-term> to reach a level served by:",
+                      "clauses": [
+                        {
+                          "numberReference": "v2-db-9.9.9.1.(1)(a)",
+                          "description": "an egress door to a <defined-term>public corridor</defined-term>, enclosed <defined-term>exit</defined-term> stair or exterior passageway, or"
+                        },
+                        {
+                          "numberReference": "v2-db-9.9.9.1.(1)(b)",
+                          "description": "an <defined-term>exit</defined-term> doorway not more than 1.5m above adjacent ground level."
+                        }
+                      ]
+                    },
+                    {
+                      "numberReference": "v2-db-9.9.9.1.(2)",
+                      "description": "Where a <defined-term>dwelling unit</defined-term> is not located above or below another <defined-term>suite</defined-term>, the travel limit from a floor level in the <defined-term>dwelling unit</defined-term> to an <defined-term>exit</defined-term> or egress door may exceed 1 <defined-term>storey</defined-term> where that floor level is served by an openable window",
+                      "clauses": [
+                        {
+                          "numberReference": "v2-db-9.9.9.1.(2)(a)",
+                          "description": "providing an unobstructed opening of not less than 1m in height and 0.55m in width, and"
+                        },
+                        {
+                          "numberReference": "v2-db-9.9.9.1.(2)(b)",
+                          "description": "located so that the sill is not more than",
+                          "subClauses": [
+                            "1m above the floor, and",
+                            "7m above adjacent ground level."
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "numberReference": "v2-db-9.9.9.1.(3)",
+                      "description": "The travel limit from a floor level in a <defined-term>dwelling unit</defined-term> to an <defined-term>exit</defined-term> or egress door may exceed 1 <defined-term>storey</defined-term> where that floor level has direct access to a balcony."
                     }
-                  },
-                  {
-                    "numberReference": "v2-db-9.10.14.4.(2)",
-                    "description": "Openings in a wall having a <defined-term>limiting distance</defined-term> of less than 1.2m shall be protected by <defined-term override-term='closure'>closures</defined-term>, of other than wired glass or glass block, whose <defined-term>fire-protection rating</defined-term> is in conformance with the <defined-term>fire-resistance rating</defined-term> required for the wall. (<pdf-download-link named-dest='9.10.13.1. Closures'>See Table 9.10.13.1.</pdf-download-link>)"
-                  },
-                  {
-                    "numberReference": "v2-db-9.10.14.4.(3)",
-                    "description": "Except for <defined-term override-term='building'>buildings</defined-term> that are <defined-term>sprinklered</defined-term> and for openable windows having an unobstructed opening equal to 0.35 m<sup>2</sup> installed in accordance with <pdf-download-link named-dest='9.9.10.1. Egress Windows or Doors for Bedrooms'>Sentences 9.9.10.1.(1)</pdf-download-link> and <pdf-download-link named-dest='9.9.10.1. Egress Windows or Doors for Bedrooms'>(2)</pdf-download-link>, where the <defined-term>limiting distance</defined-term> is 2m or less, individual <defined-term>unprotected openings</defined-term> shall be no greater than",
-                    "clauses": [
-                      {
-                        "numberReference": "v2-db-9.10.14.4.(3)(a)",
-                        "description": "the area stated in <building-code-modal reference='v2-db-9.10.14.4.-b'>Table 9.10.14.4.-B</building-code-modal>, or"
-                      },
-                      {
-                        "numberReference": "v2-db-9.10.14.4.(3)(b)",
-                        "description": "where the <defined-term>limiting distance</defined-term> is equal to or greater than 1.2m, the area calculated by<br/><strong>Area = 0.24(2 x LD - 1.2)<sup>2</sup></strong><br/>where<br/>Area = area of the <defined-term override-term='unprotected openings'>unprotected opening</defined-term>, and<br/>LD = <defined-term>limiting distance</defined-term>."
-                      }
-                    ],
-                    "image": {
-                      "fileName": "table-9.10.14.4.-b.png",
-                      "tableName": "Table: 9.10.14.4.-B",
-                      "numberReference": "v2-db-9.10.14.4.-b",
-                      "title": "Maximum Concentrated Area of Unprotected Openings",
-                      "imageReference": "Forming Part of <building-code-modal reference='v2-db-9.10.14.4.(3)'>Sentence 9.10.14.4.(3)</building-code-modal>",
-                      "imageTable": "<table class='u-screen-reader-only'><thead><tr><th>limiting distance in meters</th><th>Maximum Area of Individual Unprotected Openings in meters squared</th></tr></thead><tbody><tr><td>1.2</td><td>0.35</td></tr><tr><td>1.5</td><td>0.78</td></tr><tr><td>2.0</td><td>1.88</td></tr></tbody></table>",
-                      "imageLabel": "Maximum Concentrated Area of Unprotected Openings"
+                  ]
+                },
+                {
+                  "numberReference": "v2-db-9.9.9.2.",
+                  "title": "Two Separate exits",
+                  "sentences": [
+                    {
+                      "numberReference": "v2-db-9.9.9.2.(1)",
+                      "description": "Except as provided in <building-code-modal reference='v2-db-9.9.9.2.(2)'>Sentence (2)</building-code-modal> and <pdf-download-link number='99731' named-dest='9.9.7.3. Dead-End Corridors'>Sentence 9.9.7.3.(1)</pdf-download-link>, where an egress door from a <defined-term>dwelling unit</defined-term> opens onto a <defined-term>public corridor</defined-term> or exterior passageway it shall be possible from the location where the egress door opens onto the corridor or exterior passageway to go in opposite directions to 2 separate <defined-term override-term='exit'>exits</defined-term> unless the <defined-term>dwelling unit</defined-term> has a second and separate <defined-term>means of egress</defined-term>."
+                    },
+                    {
+                      "numberReference": "v2-db-9.9.9.2.(2)",
+                      "description": "For <defined-term override-term='dwelling unit'>dwelling units</defined-term> in a house with a <defined-term>secondary suite</defined-term>, it need not be possible to go in more than one direction to an <defined-term>exit</defined-term> from the location where the egress door opens into a <defined-term>public corridor</defined-term> or exterior passageway if the <defined-term>building</defined-term> is <defined-term>sprinklered</defined-term> or if each <defined-term>dwelling unit</defined-term> has separate and direct access from each <defined-term>storey</defined-term> to",
+                      "clauses": [
+                        {
+                          "numberReference": "v2-db-9.9.9.2.(2)(a)",
+                          "description": "a balcony, or"
+                        },
+                        {
+                          "numberReference": "v2-db-9.9.9.2.(2)(b)",
+                          "description": "an openable window conforming to sentences <building-code-modal reference='v2-db-9.9.9.1.(2)(a)'>9.9.9.1.(2)(a)</building-code-modal> and <building-code-modal reference='v2-db-9.9.9.1.(2)(b)'>(b)</building-code-modal>."
+                        }
+                      ]
                     }
-                  },
-                  {
-                    "numberReference": "v2-db-9.10.14.4.(4)",
-                    "description": "The spacing between individual <defined-term>unprotected openings</defined-term> described in <building-code-modal reference='v2-db-9.10.14.4.(3)'>Sentence (3)</building-code-modal> that serve a single room or space described in <building-code-modal reference='v2-db-9.10.14.4.(5)'>Sentence (5)</building-code-modal> shall be not less than",
-                    "clauses": [
-                      {
-                        "numberReference": "v2-db-9.10.14.4.(4)(a)",
-                        "description": "2m horizontally of another <defined-term override-term='unprotected openings'>unprotected opening</defined-term> that is on the same <defined-term>exposing building face</defined-term> and serves the single room or space, or"
-                      },
-                      {
-                        "numberReference": "v2-db-9.10.14.4.(4)(b)",
-                        "description": "2m vertically of another <defined-term override-term='unprotected openings'>unprotected opening</defined-term> that serves the single room or space, or another room or space on the same <defined-term>storey</defined-term>."
+                  ]
+                },
+                {
+                  "numberReference": "v2-db-9.9.9.3.",
+                  "title": "Shared Egress Facilities",
+                  "sentences": [
+                    {
+                      "numberReference": "v2-db-9.9.9.3.(1)",
+                      "description": "Except for as provided in <building-code-modal reference='v2-db-9.9.9.3.(2)'>Sentences (2)</building-code-modal>  and <building-code-modal reference='v2-db-9.9.9.3.(3)'>(3)</building-code-modal>, a <defined-term>dwelling unit</defined-term> shall be provided with a second and separate <defined-term>means of egress</defined-term> where an egress door from the <defined-term>dwelling unit</defined-term> opens onto",
+                      "clauses": [
+                        {
+                          "numberReference": "v2-db-9.9.9.3.(1)(a)",
+                          "description": "an <defined-term>exit</defined-term> stairway serving more than one <defined-term>suite</defined-term>,"
+                        },
+                        {
+                          "numberReference": "v2-db-9.9.9.3.(1)(b)",
+                          "description": "a <defined-term>public corridor</defined-term>",
+                          "subClauses": [
+                            "serving more than one <defined-term>suite</defined-term>, and",
+                            "served by a single <defined-term>exit</defined-term>"
+                          ]
+                        },
+                        {
+                          "numberReference": "v2-db-9.9.9.3.(1)(c)",
+                          "description": "an exterior passageway",
+                          "subClauses": [
+                            "serving more than one <defined-term>suite</defined-term>,",
+                            "served by a single <defined-term>exit</defined-term> stairway or <defined-term>ramp</defined-term>, and",
+                            "more than 1.5m above adjacent ground level, or"
+                          ]
+                        },
+                        {
+                          "numberReference": "v2-db-9.9.9.3.(1)(d)",
+                          "description": "a balcony",
+                          "subClauses": [
+                            "serving more than one <defined-term>suite</defined-term>,",
+                            "served by a single <defined-term>exit</defined-term> stairway or <defined-term>ramp</defined-term>, and",
+                            "more than 1.5m above adjacent ground level."
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "numberReference": "v2-db-9.9.9.3.(2)",
+                      "description": "Where a <defined-term>dwelling unit</defined-term> is located above another <defined-term>dwelling unit</defined-term> or common space in a house with a <defined-term>secondary suite</defined-term>, the upper <defined-term>dwelling unit</defined-term> shall be provided with a second  and separate <defined-term>means of egress</defined-term> where an egress door from that <defined-term>dwelling unit</defined-term> opens onto an exterior passageway that",
+                      "clauses": [
+                        {
+                          "numberReference": "v2-db-9.9.9.3.(2)(a)",
+                          "description": "has a floor assembly with a <defined-term>fire-resistance rating</defined-term> less than 45 min,"
+                        },
+                        {
+                          "numberReference": "v2-db-9.9.9.3.(2)(b)",
+                          "description": "is served by a single <defined-term>exit</defined-term> stairway or <defined-term>ramp</defined-term>, and"
+                        },
+                        {
+                          "numberReference": "v2-db-9.9.9.3.(2)(c)",
+                          "description": "is located more than 1.5m above adjacent ground level."
+                        }
+                      ]
+                    },
+                    {
+                      "numberReference": "v2-db-9.9.9.3.(3)",
+                      "description": "For <defined-term override-term='dwelling unit'>dwelling units</defined-term> in a house with a <defined-term>secondary suite</defined-term> where an egress door from either <defined-term>dwelling unit</defined-term> opens onto a shared egress facility served by a single <defined-term>exit</defined-term> stairway or <defined-term>ramp</defined-term>, other than as described in <building-code-modal reference='v2-db-9.9.9.3.(2)'>Sentence (2)</building-code-modal>, a second and separate <defined-term>means of egress</defined-term> need not be provided if the <defined-term>building</defined-term> is <defined-term>sprinklered</defined-term> or if the <defined-term override-term='dwelling unit'>dwelling units</defined-term> have separate and direct access from each <defined-term>storey</defined-term> to",
+                      "clauses": [
+                        {
+                          "numberReference": "v2-db-9.9.9.3.(3)(a)",
+                          "description": "a balcony, or"
+                        },
+                        {
+                          "numberReference": "v2-db-9.9.9.3.(3)(b)",
+                          "description": " an openable window conforming to sentences <building-code-modal reference='v2-db-9.9.9.1.(2)(a)'>9.9.9.1.(2)(a)</building-code-modal> and <building-code-modal reference='v2-db-9.9.9.1.(2)(b)'>(b)</building-code-modal>."
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "numberReference": "v2-db-9.10.",
+          "title": "Fire Protection",
+          "subsections": [
+            {
+              "numberReference": "v2-db-9.10.14.",
+              "title": "Spatial Separation Between Buildings",
+              "articles": [
+                {
+                  "numberReference": "v2-db-9.10.14.1.",
+                  "title": "Application",
+                  "sentences": [
+                    {
+                      "numberReference": "v2-db-9.10.14.1.(1)",
+                      "description": "This Subsection applies to <defined-term override-term='building'>buildings</defined-term> other than those to which <pdf-download-link named-dest='9.10.15. Spatial Separation Between Houses'>Subsection 9.10.15.</pdf-download-link> applies."
+                    },
+                    {
+                      "numberReference": "v2-db-9.10.14.1.(2)",
+                      "description": "This Subsection does not apply to detached carports conforming to <pdf-download-link named-dest='Section 9.35. Garages and Carports'>Section 9.35.</pdf-download-link> that serve not more than one <defined-term>dwelling unit</defined-term> or a house with a <defined-term>secondary suite</defined-term>."
+                    }
+                  ]
+                },
+                {
+                  "numberReference": "v2-db-9.10.14.2.",
+                  "title": "Area and Location of Exposing Building Face",
+                  "sentences": [
+                    {
+                      "numberReference": "v2-db-9.10.14.2.(1)",
+                      "description": "Except as permitted by <building-code-modal reference='v2-db-9.10.14.2.(4)'>Sentence (4)</building-code-modal>, the area of an <defined-term>exposing building face</defined-term> shall be",
+                      "clauses": [
+                        {
+                          "numberReference": "v2-db-9.10.14.2.(1)(a)",
+                          "description": "taken as the exterior wall area facing in one direction on any side of a <defined-term>building</defined-term>, and"
+                        },
+                        {
+                          "numberReference": "v2-db-9.10.14.2.(1)(b)",
+                          "description": "calculated as",
+                          "subClauses": [
+                            "the total area measured from the finished ground level to the uppermost ceiling, or",
+                            " the area for each <defined-term>fire compartment</defined-term>, where a <defined-term>building</defined-term> is divided into <defined-term override-term='fire compartment'>fire compartments</defined-term> by <defined-term override-term='fire separation'>fire separations</defined-term> with <defined-term override-term='fire-resistance rating'>fire-resistance ratings</defined-term> not less than 45 min."
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "numberReference": "v2-db-9.10.14.2.(2)",
+                      "description": "For the purpose of using <building-code-modal reference='v2-db-9.10.14.4.-a'>Table 9.10.14.4.-A</building-code-modal> to determine the maximum aggregate area of <defined-term>unprotected openings</defined-term> in an irregularly shaped or skewed exterior wall, the location of the <defined-term>exposing building face</defined-term> shall be taken as a vertical plane located so that there are no <defined-term>unprotected openings</defined-term> between the vertical plane and the line to which the <defined-term>limiting distance</defined-term> is measured. (<pdf-download-link named-dest='A-3.2.3.1.(4) Spatial Separation Design.'>See Note A-3.2.3.1.(4).</pdf-download-link>)"
+                    },
+                    {
+                      "numberReference": "v2-db-9.10.14.2.(3)",
+                      "description": "For the purpose of using <pdf-download-link named-dest='9.10.14.5. Construction of Exposing Building Face and Walls above Exposing Building Face'>Table 9.10.14.5.-A</pdf-download-link> to determine the required type of construction, cladding and <defined-term>fire-resistance rating</defined-term> for an irregularly shaped or skewed exterior wall,",
+                      "clauses": [
+                        {
+                          "numberReference": "v2-db-9.10.14.2.(1)(a)",
+                          "description": "the location of the <defined-term>exposing building face</defined-term> shall be taken as a vertical plane located so that no portion of the actual <defined-term>exposing building face</defined-term> is between the vertical plane and the line to which the <defined-term>limiting distance</defined-term> is measured, and"
+                        },
+                        {
+                          "numberReference": "v2-db-9.10.14.2.(1)(b)",
+                          "description": "the value for the maximum area of <defined-term>unprotected openings</defined-term> (see second column of <pdf-download-link named-dest='9.10.14.5. Construction of Exposing Building Face and Walls above Exposing Building Face'>Table 9.10.14.5.-A</pdf-download-link>) shall be determined using the <defined-term>limiting distance</defined-term> measured from the location described in Clause (a). (<pdf-download-link named-dest='A-3.2.3.1.(4) Spatial Separation Design.'>See Note A-3.2.3.1.(4).</pdf-download-link>)"
+                        }
+                      ]
+                    },
+                    {
+                      "numberReference": "v2-db-9.10.14.2.(4)",
+                      "description": "If a <defined-term>building</defined-term> is divided by <defined-term override-term='fire separation'>fire separations</defined-term> into <defined-term-glossary override-term='fire compartment'>fire compartments</defined-term-glossary>, the area of <defined-term>exposing building face</defined-term> is permitted to be calculated for each <defined-term-glossary>fire compartment</defined-term-glossary>, provided the <defined-term override-term='fire separation'>fire separations</defined-term> have a <defined-term>fire-resistance rating</defined-term> not less than 45 min."
+                    }
+                  ]
+                },
+                {
+                  "numberReference": "v2-db-9.10.14.3.",
+                  "title": "Limiting Distance and Fire Department Response",
+                  "sentences": [
+                    {
+                      "numberReference": "v2-db-9.10.14.3.(1)",
+                      "description": "Except for the purpose of applying <building-code-modal reference='v2-db-9.10.14.4'>Sentences 9.10.14.4.</building-code-modal> <building-code-modal reference='v2-db-9.10.14.4.(2)'>(2)</building-code-modal>, <building-code-modal reference='v2-db-9.10.14.4.(3)'>(3)</building-code-modal>, <building-code-modal reference='v2-db-9.10.14.4.(8)'>(8)</building-code-modal> and <building-code-modal reference='v2-db-9.10.14.4.(9)'>(9)</building-code-modal>, and <pdf-download-link named-dest='9.10.14.5. Construction of Exposing Building Face and Walls above Exposing Building Face'>Sentences 9.10.14.5.(3)</pdf-download-link>, <pdf-download-link named-dest='9.10.14.5. Construction of Exposing Building Face and Walls above Exposing Building Face'>(8)</pdf-download-link> and <pdf-download-link named-dest='9.10.14.5. Construction of Exposing Building Face and Walls above Exposing Building Face'>(13)</pdf-download-link>, a <defined-term>limiting distance</defined-term> equal to half the actual <defined-term>limiting distance</defined-term> shall be used as input to the requirements of this Subsection, where (<pdf-download-link named-dest='A-3.2.3. Fire Protection Related to Limiting Distance versus Separation Between Buildings.'>See Notes A-3.2.3.</pdf-download-link> and <pdf-download-link named-dest='A-3.2.3.1.(8) Intervention Time and Limiting Distance.'>A-3.2.3.1.(8).</pdf-download-link></pdf-download-link>)",
+                      "clauses": [
+                        {
+                          "numberReference": "v2-db-9.10.14.3.(1)(a)",
+                          "description": "the time from receipt of notification of a fire by the fire department until the first fire department vehicle arrives at the <defined-term>building</defined-term> exceeds 10 min in 10% or more of all calls to the building, and"
+                        },
+                        {
+                          "numberReference": "v2-db-9.10.14.3.(1)(b)",
+                          "description": "any storey in the <defined-term>building</defined-term> is not <defined-term>sprinklered</defined-term>."
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "numberReference": "v2-db-9.10.14.4.",
+                  "title": "Openings in Exposing Building Face",
+                  "sentences": [
+                    {
+                      "numberReference": "v2-db-9.10.14.4.(1)",
+                      "description": "Except as provided in <building-code-modal reference='v2-db-9.10.14.4.(6)'>Sentences (6)</building-code-modal> to <building-code-modal reference='v2-db-9.10.14.4.(10)'>(10)</building-code-modal>, the maximum aggregate area of <defined-term>unprotected openings</defined-term> in an <defined-term>exposing building face</defined-term> shall",
+                      "clauses": [
+                        {
+                          "numberReference": "v2-db-9.10.14.4.(1)(a)",
+                          "description": "conform to <building-code-modal reference='v2-db-9.10.14.4.-a'>Table 9.10.14.4.-A</building-code-modal>,"
+                        },
+                        {
+                          "numberReference": "v2-db-9.10.14.4.(1)(b)",
+                          "description": "conform to <pdf-download-link named-dest='3.2.3. Spatial Separation and Exposure Protection'>Subsection 3.2.3.</pdf-download-link>, or"
+                        },
+                        {
+                          "numberReference": "v2-db-9.10.14.4.(1)(c)",
+                          "description": "where the <defined-term>limiting distance</defined-term> is not less than 1.2 m, be equal to or less than",
+                          "subClauses": [
+                            "the <defined-term>limiting distance</defined-term> squared, for <defined-term override-term='residential occupancy'>residential occupancies</defined-term>, <defined-term override-term='business and personal services occupancy'>business and personal services occupancies</defined-term> and <defined-term override-term='low-hazard industrial occupancy'>low-hazard industrial occupancies</defined-term>, and",
+                            "half the <defined-term>limiting distance</defined-term> squared, for <defined-term override-term='mercantile occupancy'>mercantile occupancies</defined-term> and <defined-term-glossary override-term='medium-hazard industrial occupancy'>medium hazard industrial occupancies</defined-term-glossary>."
+                          ]
+                        }
+                      ],
+                      "image": {
+                        "fileName": "table-9.10.14.4.-a.png",
+                        "tableName": "Table: 9.10.14.4.-A",
+                        "numberReference": "v2-db-9.10.14.4.-a",
+                        "title": "Maximum Aggregate Area of Unprotected Openings in Exterior Walls <sup>(1)</sup>",
+                        "imageReference": "Forming Part of <building-code-modal reference='v2-db-9.10.14.4.(1)'>Sentence 9.10.14.4.(1)</building-code-modal>",
+                        "imageNotes": "<building-code-modal reference='v2-db-9.10.14.4.(1)'>(1)</building-code-modal> See also Sentences <building-code-modal reference='v2-db-9.10.14.4.(6)'>(6)</building-code-modal> and <building-code-modal reference='v2-db-9.10.14.4.(7)'>(7)</building-code-modal> to calculate the maximum permitted area of <defined-term>unprotected openings</defined-term> in <defined-term>sprinklered</defined-term> <defined-term override-term='building'>buildings</defined-term> or where wired glass or glass blocks are used.",
+                        "imageTable": "<table class='u-screen-reader-only'><thead><tr><th scope='col' rowSpan='3'>Occupancy Classification of Building</th><th scope='col' rowSpan='3'>Maximum Total Area of Exposing Building Face, in meters squared</th><th scope='col' colSpan='12'>Maximum Aggregate Area of Unprotected Openings, as a % ofExposing Building Face Area</th></tr><tr><th scope='col' colSpan='12'>Limiting Distance in meters</th></tr><tr><th scope='col'>Less than 1.2</th><th scope='col'>1.2</th><th scope='col'>1.5</th><th scope='col'>2.0</th><th scope='col'>4.0</th><th scope='col'>6.0</th><th scope='col'>8.0</th><th scope='col'>10.0</th><th scope='col'>12.0</th><th scope='col'>16.0</th><th scope='col'>20.0</th><th scope='col'>25.0</th></tr></thead><tbody><tr><th scope='row' rowSpan='5'>Residential, business and personal services, and low-hazard industrial</th><th scope='row'>30</th><td>0</td><td>7</td><td>9</td><td>12</td><td>39</td><td>88</td><td>100</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><th scope='row'>40</th><td>0</td><td>7</td><td>8</td><td>11</td><td>32</td><td>69</td><td>100</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><th scope='row'>50</th><td>0</td><td>7</td><td>8</td><td>10</td><td>28</td><td>57</td><td>100</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><th scope='row'>100</th><td>0</td><td>7</td><td>8</td><td>9</td><td>18</td><td>34</td><td>56</td><td>84</td><td>100</td><td>-</td><td>-</td><td>-</td></tr><tr><th scope='row'>Over 100</th><td>0</td><td>7</td><td>7</td><td>8</td><td>12</td><td>19</td><td>28</td><td>40</td><td>55</td><td>92</td><td>100</td><td>-</td></tr><tr><th scope='row' rowSpan='5'>Mercantile and medium-hazard industrial</th><th scope='row'>30</th><td>0</td><td>4</td><td>4</td><td>6</td><td>20</td><td>44</td><td>80</td><td>100</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><th scope='row'>40</th><td>0</td><td>4</td><td>4</td><td>6</td><td>16</td><td>34</td><td>61</td><td>97</td><td>100</td><td>-</td><td>-</td><td>-</td></tr><tr><th scope='row'>50</th><td>0</td><td>4</td><td>4</td><td>5</td><td>14</td><td>29</td><td>50</td><td>79</td><td>100</td><td>-</td><td>-</td><td>-</td></tr><tr><th scope='row'>100</th><td>0</td><td>4</td><td>4</td><td>4</td><td>9</td><td>17</td><td>28</td><td>42</td><td>60</td><td>100</td><td>-</td><td>-</td></tr><tr><th scope='row'>Over 100</th><td>0</td><td>4</td><td>4</td><td>4</td><td>6</td><td>10</td><td>14</td><td>20</td><td>27</td><td>46</td><td>70</td><td>100</td></tr></tbody></table>",
+                        "imageLabel": "Maximum Aggregate Area of Unprotected Openings in Exterior Walls"
                       }
-                    ]
-                  },
-                  {
-                    "numberReference": "v2-db-9.10.14.4.(5)",
-                    "description": "For the purpose of  <building-code-modal reference='v2-db-9.10.14.4.(4)'>Sentence (4)</building-code-modal>, “single room or space” shall mean",
-                    "clauses": [
-                      {
-                        "numberReference": "v2-db-9.10.14.4.(5)(a)",
-                        "description": "two or more adjacent spaces having a full-height separating wall extending less than 1.5m from the interior face of the exterior wall, or"
-                      },
-                      {
-                        "numberReference": "v2-db-9.10.14.4.(5)(b)",
-                        "description": "two or more stacked spaces that are on the same <defined-term>storey</defined-term>."
+                    },
+                    {
+                      "numberReference": "v2-db-9.10.14.4.(2)",
+                      "description": "Openings in a wall having a <defined-term>limiting distance</defined-term> of less than 1.2m shall be protected by <defined-term override-term='closure'>closures</defined-term>, of other than wired glass or glass block, whose <defined-term>fire-protection rating</defined-term> is in conformance with the <defined-term>fire-resistance rating</defined-term> required for the wall. (<pdf-download-link named-dest='9.10.13.1. Closures'>See Table 9.10.13.1.</pdf-download-link>)"
+                    },
+                    {
+                      "numberReference": "v2-db-9.10.14.4.(3)",
+                      "description": "Except for <defined-term override-term='building'>buildings</defined-term> that are <defined-term>sprinklered</defined-term> and for openable windows having an unobstructed opening equal to 0.35 m<sup>2</sup> installed in accordance with <pdf-download-link named-dest='9.9.10.1. Egress Windows or Doors for Bedrooms'>Sentences 9.9.10.1.(1)</pdf-download-link> and <pdf-download-link named-dest='9.9.10.1. Egress Windows or Doors for Bedrooms'>(2)</pdf-download-link>, where the <defined-term>limiting distance</defined-term> is 2m or less, individual <defined-term>unprotected openings</defined-term> shall be no greater than",
+                      "clauses": [
+                        {
+                          "numberReference": "v2-db-9.10.14.4.(3)(a)",
+                          "description": "the area stated in <building-code-modal reference='v2-db-9.10.14.4.-b'>Table 9.10.14.4.-B</building-code-modal>, or"
+                        },
+                        {
+                          "numberReference": "v2-db-9.10.14.4.(3)(b)",
+                          "description": "where the <defined-term>limiting distance</defined-term> is equal to or greater than 1.2m, the area calculated by<br/><strong>Area = 0.24(2 x LD - 1.2)<sup>2</sup></strong><br/>where<br/>Area = area of the <defined-term override-term='unprotected openings'>unprotected opening</defined-term>, and<br/>LD = <defined-term>limiting distance</defined-term>."
+                        }
+                      ],
+                      "image": {
+                        "fileName": "table-9.10.14.4.-b.png",
+                        "tableName": "Table: 9.10.14.4.-B",
+                        "numberReference": "v2-db-9.10.14.4.-b",
+                        "title": "Maximum Concentrated Area of Unprotected Openings",
+                        "imageReference": "Forming Part of <building-code-modal reference='v2-db-9.10.14.4.(3)'>Sentence 9.10.14.4.(3)</building-code-modal>",
+                        "imageTable": "<table class='u-screen-reader-only'><thead><tr><th>limiting distance in meters</th><th>Maximum Area of Individual Unprotected Openings in meters squared</th></tr></thead><tbody><tr><td>1.2</td><td>0.35</td></tr><tr><td>1.5</td><td>0.78</td></tr><tr><td>2.0</td><td>1.88</td></tr></tbody></table>",
+                        "imageLabel": "Maximum Concentrated Area of Unprotected Openings"
                       }
-                    ]
-                  },
-                  {
-                    "numberReference": "v2-db-9.10.14.4.(6)",
-                    "description": "The maximum aggregate area of <defined-term>unprotected openings</defined-term> is permitted to be up to twice the area determined according to <building-code-modal reference='v2-db-9.10.14.4.(1)'>Sentence (1)</building-code-modal>, where the <defined-term>unprotected openings</defined-term> are glazed with",
-                    "clauses": [
-                      {
-                        "numberReference": "v2-db-9.10.14.4.(6)(a)",
-                        "description": "wired glass in steel frames, as described in <pdf-download-link named-dest='9.10.13.5. Wired Glass as a Closure'>Article 9.10.13.5.</pdf-download-link>, or"
-                      },
-                      {
-                        "numberReference": "v2-db-9.10.14.4.(6)(b)",
-                        "description": "glass blocks, as described in <pdf-download-link named-dest='9.10.13.7. Glass Block as a Closure'>Article 9.10.13.7.</pdf-download-link>"
-                      }
-                    ]
-                  },
-                  {
-                    "numberReference": "v2-db-9.10.14.4.(7)",
-                    "description": "Where the <defined-term>building</defined-term> is <defined-term>sprinklered</defined-term>, the maximum aggregate area of <defined-term>unprotected openings</defined-term> is permitted to be up to twice the area determined according to <building-code-modal reference='v2-db-9.10.14.4.(1)'>Sentence (1)</building-code-modal>, provided all rooms, including closets and bathrooms, that are adjacent to the <defined-term>exposing building face</defined-term> and that have <defined-term>unprotected openings</defined-term> are <defined-term>sprinklered</defined-term>, notwithstanding any exemptions in the sprinkler standards referenced in <pdf-download-link named-dest='3.2.5.12. Automatic Sprinkler Systems'>Article 3.2.5.12.</pdf-download-link>"
-                  },
-                  {
-                    "numberReference": "v2-db-9.10.14.4.(8)",
-                    "description": "The maximum aggregate area of <defined-term>unprotected openings</defined-term> in an <defined-term>exposing building face</defined-term> of a <defined-term>storage garage</defined-term> need not comply with <building-code-modal reference='v2-db-9.10.14.4.(1)'>Sentence (1)</building-code-modal>, where",
-                    "clauses": [
-                      {
-                        "numberReference": "v2-db-9.10.14.4.(8)(a)",
-                        "description": "all <defined-term override-term='storey'>storeys</defined-term> are constructed as <defined-term override-term='open-air storey'>open-air storeys</defined-term>, and"
-                      },
-                      {
-                        "numberReference": "v2-db-9.10.14.4.(8)(b)",
-                        "description": " the <defined-term>storage garage</defined-term> has a <defined-term>limiting distance</defined-term> of not less than 3m."
-                      }
-                    ]
-                  },
-                  {
-                    "numberReference": "v2-db-9.10.14.4.(9)",
-                    "description": "The maximum aggregate area of <defined-term>unprotected openings</defined-term> in an <defined-term>exposing building face</defined-term> of a <defined-term>storey</defined-term> that faces a <defined-term>street</defined-term> and is at the same level as the <defined-term>street</defined-term> need not comply with <building-code-modal reference='v2-db-9.10.14.4.(1)'>Sentence (1)</building-code-modal>, where the <defined-term>limiting distance</defined-term> is not less than 9m."
-                  },
-                  {
-                    "numberReference": "v2-db-9.10.14.4.(10)",
-                    "description": " Except as provided in <building-code-modal reference='v2-db-9.10.14.4.(11)'>Sentence (11)</building-code-modal>, for garages or accessory <defined-term override-term='building'>buildings</defined-term> that serve a single <defined-term>dwelling unit</defined-term> only and are detached from any <defined-term>building</defined-term>, the maximum aggregate area of glazed openings shall comply with the requirements for <defined-term>unprotected openings</defined-term>."
-                  },
-                  {
-                    "numberReference": "v2-db-9.10.14.4.(11)",
-                    "description": "The limits on the area of glazed openings stated in <building-code-modal reference='v2-db-9.10.14.4.(10)'>Sentence (10)</building-code-modal> need not apply to the <defined-term>exposing building face</defined-term> of a detached garage or accessory <defined-term>building</defined-term> facing a <defined-term>dwelling unit</defined-term>, where",
-                    "clauses": [
-                      {
-                        "numberReference": "v2-db-9.10.14.4.(11)(a)",
-                        "description": "the detached garage or accessory <defined-term>building</defined-term> serves only one <defined-term>dwelling unit</defined-term>,"
-                      },
-                      {
-                        "numberReference": "v2-db-9.10.14.4.(11)(b)",
-                        "description": "the detached garage or accessory <defined-term>building</defined-term> is located on the same property as that <defined-term>dwelling unit</defined-term>, and"
-                      },
-                      {
-                        "numberReference": "v2-db-9.10.14.4.(11)(c)",
-                        "description": "the <defined-term>dwelling unit</defined-term> served by the detached garage or accessory <defined-term>building</defined-term> is the only <defined-term>major occupancy</defined-term> on the property."
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    ]
-  }
-]
+                    },
+                    {
+                      "numberReference": "v2-db-9.10.14.4.(4)",
+                      "description": "The spacing between individual <defined-term>unprotected openings</defined-term> described in <building-code-modal reference='v2-db-9.10.14.4.(3)'>Sentence (3)</building-code-modal> that serve a single room or space described in <building-code-modal reference='v2-db-9.10.14.4.(5)'>Sentence (5)</building-code-modal> shall be not less than",
+                      "clauses": [
+                        {
+                          "numberReference": "v2-db-9.10.14.4.(4)(a)",
+                          "description": "2m horizontally of another <defined-term override-term='unprotected openings'>unprotected opening</defined-term> that is on the same <defined-term>exposing building face</defined-term> and serves the single room or space, or"
+                        },
+                        {
+                          "numberReference": "v2-db-9.10.14.4.(4)(b)",
+                          "description": "2m vertically of another <defined-term override-term='unprotected openings'>unprotected opening</defined-term> that serves the single room or space, or another room or space on the same <defined-term>storey</defined-term>."
+                        }
+                      ]
+                    },
+                    {
+                      "numberReference": "v2-db-9.10.14.4.(5)",
+                      "description": "For the purpose of  <building-code-modal reference='v2-db-9.10.14.4.(4)'>Sentence (4)</building-code-modal>, “single room or space” shall mean",
+                      "clauses": [
+                        {
+                          "numberReference": "v2-db-9.10.14.4.(5)(a)",
+                          "description": "two or more adjacent spaces having a full-height separating wall extending less than 1.5m from the interior face of the exterior wall, or"
+                        },
+                        {
+                          "numberReference": "v2-db-9.10.14.4.(5)(b)",
+                          "description": "two or more stacked spaces that are on the same <defined-term>storey</defined-term>."
+                        }
+                      ]
+                    },
+                    {
+                      "numberReference": "v2-db-9.10.14.4.(6)",
+                      "description": "The maximum aggregate area of <defined-term>unprotected openings</defined-term> is permitted to be up to twice the area determined according to <building-code-modal reference='v2-db-9.10.14.4.(1)'>Sentence (1)</building-code-modal>, where the <defined-term>unprotected openings</defined-term> are glazed with",
+                      "clauses": [
+                        {
+                          "numberReference": "v2-db-9.10.14.4.(6)(a)",
+                          "description": "wired glass in steel frames, as described in <pdf-download-link named-dest='9.10.13.5. Wired Glass as a Closure'>Article 9.10.13.5.</pdf-download-link>, or"
+                        },
+                        {
+                          "numberReference": "v2-db-9.10.14.4.(6)(b)",
+                          "description": "glass blocks, as described in <pdf-download-link named-dest='9.10.13.7. Glass Block as a Closure'>Article 9.10.13.7.</pdf-download-link>"
+                        }
+                      ]
+                    },
+                    {
+                      "numberReference": "v2-db-9.10.14.4.(7)",
+                      "description": "Where the <defined-term>building</defined-term> is <defined-term>sprinklered</defined-term>, the maximum aggregate area of <defined-term>unprotected openings</defined-term> is permitted to be up to twice the area determined according to <building-code-modal reference='v2-db-9.10.14.4.(1)'>Sentence (1)</building-code-modal>, provided all rooms, including closets and bathrooms, that are adjacent to the <defined-term>exposing building face</defined-term> and that have <defined-term>unprotected openings</defined-term> are <defined-term>sprinklered</defined-term>, notwithstanding any exemptions in the sprinkler standards referenced in <pdf-download-link named-dest='3.2.5.12. Automatic Sprinkler Systems'>Article 3.2.5.12.</pdf-download-link>"
+                    },
+                    {
+                      "numberReference": "v2-db-9.10.14.4.(8)",
+                      "description": "The maximum aggregate area of <defined-term>unprotected openings</defined-term> in an <defined-term>exposing building face</defined-term> of a <defined-term>storage garage</defined-term> need not comply with <building-code-modal reference='v2-db-9.10.14.4.(1)'>Sentence (1)</building-code-modal>, where",
+                      "clauses": [
+                        {
+                          "numberReference": "v2-db-9.10.14.4.(8)(a)",
+                          "description": "all <defined-term override-term='storey'>storeys</defined-term> are constructed as <defined-term override-term='open-air storey'>open-air storeys</defined-term>, and"
+                        },
+                        {
+                          "numberReference": "v2-db-9.10.14.4.(8)(b)",
+                          "description": " the <defined-term>storage garage</defined-term> has a <defined-term>limiting distance</defined-term> of not less than 3m."
+                        }
+                      ]
+                    },
+                    {
+                      "numberReference": "v2-db-9.10.14.4.(9)",
+                      "description": "The maximum aggregate area of <defined-term>unprotected openings</defined-term> in an <defined-term>exposing building face</defined-term> of a <defined-term>storey</defined-term> that faces a <defined-term>street</defined-term> and is at the same level as the <defined-term>street</defined-term> need not comply with <building-code-modal reference='v2-db-9.10.14.4.(1)'>Sentence (1)</building-code-modal>, where the <defined-term>limiting distance</defined-term> is not less than 9m."
+                    },
+                    {
+                      "numberReference": "v2-db-9.10.14.4.(10)",
+                      "description": " Except as provided in <building-code-modal reference='v2-db-9.10.14.4.(11)'>Sentence (11)</building-code-modal>, for garages or accessory <defined-term override-term='building'>buildings</defined-term> that serve a single <defined-term>dwelling unit</defined-term> only and are detached from any <defined-term>building</defined-term>, the maximum aggregate area of glazed openings shall comply with the requirements for <defined-term>unprotected openings</defined-term>."
+                    },
+                    {
+                      "numberReference": "v2-db-9.10.14.4.(11)",
+                      "description": "The limits on the area of glazed openings stated in <building-code-modal reference='v2-db-9.10.14.4.(10)'>Sentence (10)</building-code-modal> need not apply to the <defined-term>exposing building face</defined-term> of a detached garage or accessory <defined-term>building</defined-term> facing a <defined-term>dwelling unit</defined-term>, where",
+                      "clauses": [
+                        {
+                          "numberReference": "v2-db-9.10.14.4.(11)(a)",
+                          "description": "the detached garage or accessory <defined-term>building</defined-term> serves only one <defined-term>dwelling unit</defined-term>,"
+                        },
+                        {
+                          "numberReference": "v2-db-9.10.14.4.(11)(b)",
+                          "description": "the detached garage or accessory <defined-term>building</defined-term> is located on the same property as that <defined-term>dwelling unit</defined-term>, and"
+                        },
+                        {
+                          "numberReference": "v2-db-9.10.14.4.(11)(c)",
+                          "description": "the <defined-term>dwelling unit</defined-term> served by the detached garage or accessory <defined-term>building</defined-term> is the only <defined-term>major occupancy</defined-term> on the property."
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/data/json/terms.json
+++ b/packages/data/json/terms.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../schema/terms.schema.json",
   "access to exit": {
     "definition": "<glossary-term>Access to exit</glossary-term> means that part of a <defined-term-glossary>means of egress</defined-term-glossary> within a <defined-term-glossary>floor area</defined-term-glossary> that provides access to an <defined-term-glossary>exit</defined-term-glossary> serving the <defined-term-glossary>floor area</defined-term-glossary>.",
     "cleanDefinition": "Access to exit means that part of a means of egress within a floor area that provides access to an exit serving the floor area."

--- a/packages/data/json/terms.test.ts
+++ b/packages/data/json/terms.test.ts
@@ -8,6 +8,8 @@ const glossary = data as unknown as BuildingGlossaryJSONType;
 
 describe("Glossary Terms Format", () => {
   Object.entries(glossary).forEach(([term, content]) => {
+    if (term === "$schema") return; // Skip schema entry
+
     describe(`Term: ${term}`, () => {
       it('should have a "definition"', () => {
         expect(content.definition).toBeDefined();

--- a/packages/data/schema/buildingCode.schema.json
+++ b/packages/data/schema/buildingCode.schema.json
@@ -1,0 +1,222 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/$defs/BuildingCode",
+  "$defs": {
+    "BuildingCode": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "$schema": {
+          "type": "string"
+        },
+        "data": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Type_Part"
+          }
+        }
+      },
+      "required": [
+        "data"
+      ]
+    },
+    "Type_Part": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "numberReference": {
+          "$ref": "#/$defs/Property_NumberReference"
+        },
+        "title": {
+          "$ref": "#/$defs/Property_Title"
+        },
+        "sections": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Type_Section"
+          }
+        }
+      },
+      "required": [
+        "numberReference",
+        "title",
+        "sections"
+      ]
+    },
+    "Type_Section": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "numberReference": {
+          "$ref": "#/$defs/Property_NumberReference"
+        },
+        "title": {
+          "$ref": "#/$defs/Property_Title"
+        },
+        "subsections": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Type_SubSection"
+          }
+        }
+      },
+      "required": [
+        "numberReference",
+        "title",
+        "subsections"
+      ]
+    },
+    "Type_SubSection": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "numberReference": {
+          "$ref": "#/$defs/Property_NumberReference"
+        },
+        "title": {
+          "$ref": "#/$defs/Property_Title"
+        },
+        "articles": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Type_Article"
+          }
+        }
+      },
+      "required": [
+        "numberReference",
+        "title",
+        "articles"
+      ]
+    },
+    "Type_Article": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "numberReference": {
+          "$ref": "#/$defs/Property_NumberReference"
+        },
+        "title": {
+          "$ref": "#/$defs/Property_Title"
+        },
+        "sentences": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Type_Sentence"
+          }
+        }
+      },
+      "required": [
+        "numberReference",
+        "title",
+        "sentences"
+      ]
+    },
+    "Type_Sentence": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "numberReference": {
+          "$ref": "#/$defs/Property_NumberReference"
+        },
+        "description": {
+          "$ref": "#/$defs/Property_Description"
+        },
+        "clauses": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Type_Clause"
+          }
+        },
+        "image": {
+          "$ref": "#/$defs/Type_Image"
+        }
+      },
+      "required": [
+        "numberReference",
+        "description"
+      ]
+    },
+    "Type_Clause": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "numberReference": {
+          "$ref": "#/$defs/Property_NumberReference"
+        },
+        "description": {
+          "$ref": "#/$defs/Property_Description"
+        },
+        "subClauses": {
+          "$ref": "#/$defs/Type_SubClause"
+        }
+      },
+      "required": [
+        "numberReference",
+        "description"
+      ]
+    },
+    "Type_SubClause": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "description": "Can include HTML that will be parsed and rendered."
+      }
+    },
+    "Type_Image": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "fileName": {
+          "type": "string",
+          "description": "Name of image to display. Looks in the public/assets/images folder in the web application."
+        },
+        "tableName": {
+          "type": "string"
+        },
+        "numberReference": {
+          "$ref": "#/$defs/Property_NumberReference"
+        },
+        "title": {
+          "$ref": "#/$defs/Property_Title",
+          "description": "Can include HTML that will be parsed and rendered."
+        },
+        "imageReference": {
+          "type": "string",
+          "description": "Can include HTML that will be parsed and rendered."
+        },
+        "imageNotes": {
+          "type": "string",
+          "description": "Can include HTML that will be parsed and rendered."
+        },
+        "imageTable": {
+          "type": "string",
+          "description": "Hidden HTML for the image that a screen reader will use."
+        },
+        "imageLabel": {
+          "type": "string",
+          "description": "Aria-label for the image."
+        }
+      },
+      "required": [
+        "fileName",
+        "tableName",
+        "numberReference",
+        "title",
+        "imageReference",
+        "imageTable",
+        "imageLabel"
+      ]
+    },
+    "Property_NumberReference": {
+      "type": "string"
+    },
+    "Property_Title": {
+      "type": "string"
+    },
+    "Property_Description": {
+      "type": "string",
+      "description": "Can include HTML that will be parsed and rendered."
+    }
+  }
+}

--- a/packages/data/schema/terms.schema.json
+++ b/packages/data/schema/terms.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string"
+    }
+  },
+  "patternProperties": {
+    "^[a-zA-Z0-9 -]+$": {
+      "$ref": "#/$defs/Type_Term"
+    }
+  },
+  "$defs": {
+    "Type_Term": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "definition": {
+          "$ref": "#/$defs/Property_Definition"
+        },
+        "cleanDefinition": {
+          "type": "string",
+          "description": "A clean version of the definition without HTML."
+        },
+        "definitionList": {
+          "$ref": "#/$defs/Type_DefinitionList"
+        },
+        "hideTerm": {
+          "type": "boolean",
+          "description": "Used to hide the term from the glossary (Used for major occupancy groups currently)",
+          "default": false
+        }
+      },
+      "required": [
+        "definition",
+        "cleanDefinition"
+      ]
+    },
+    "Type_DefinitionList": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "definition": {
+            "$ref": "#/$defs/Property_Definition"
+          },
+          "definitionList": {
+            "$ref": "#/$defs/Type_DefinitionList"
+          }
+        },
+        "required": [
+          "definition"
+        ]
+      }
+    },
+    "Property_Definition": {
+      "type": "string",
+      "description": "Can include HTML that will be parsed and rendered."
+    }
+  }
+}

--- a/packages/data/schema/walkthrough.schema.json
+++ b/packages/data/schema/walkthrough.schema.json
@@ -1,0 +1,659 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/$defs/WalkthroughJSONInterface",
+  "$defs": {
+    "WalkthroughJSONInterface": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "$schema": {
+          "type": "string"
+        },
+        "info": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "title": {
+              "type": "string"
+            },
+            "subtitle": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "startingSectionId": {
+              "type": "string",
+              "pattern": "^\\d+_[a-zA-Z0-9]+$",
+              "description": "MUST be a key in the sections object."
+            },
+            "walkthroughTitle": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "description",
+            "startingSectionId",
+            "subtitle",
+            "title",
+            "walkthroughTitle"
+          ],
+          "title": "Info"
+        },
+        "sections": {
+          "type": "object",
+          "patternProperties": {
+            "^\\d+_[a-zA-Z0-9]+$": {
+              "$ref": "#/$defs/Section"
+            }
+          },
+          "additionalProperties": false
+        },
+        "questions": {
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "^P\\d+[a-zA-Z0-9]*$": {
+              "$ref": "#/$defs/Question"
+            }
+          }
+        },
+        "results": {
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "^R\\d+$": {
+              "$ref": "#/$defs/Result"
+            }
+          }
+        }
+      },
+      "required": ["info", "sections", "questions", "results", "$schema"],
+      "title": "WalkthroughJSONInterface"
+    },
+    "Section": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "sectionTitle": {
+          "type": "string"
+        },
+        "sectionQuestions": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^P\\d+$",
+            "description": "Keys of the questions in the questions object. Include only the keys you want to show in the step tracker display."
+          }
+        }
+      },
+      "required": ["sectionTitle", "sectionQuestions"],
+      "title": "Section"
+    },
+    "Question": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/QuestionTypeMultiChoice"
+        },
+        {
+          "$ref": "#/$defs/QuestionTypeMultiChoiceMultiple"
+        },
+        {
+          "$ref": "#/$defs/QuestionTypeVariable"
+        },
+        {
+          "$ref": "#/$defs/QuestionTypeNumberFloat"
+        }
+      ]
+    },
+    "QuestionTypeMultiChoice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "walkthroughItemType": {
+          "const": "multiChoice"
+        },
+        "questionText": {
+          "$ref": "#/$defs/QuestionQuestionText"
+        },
+        "questionSubtext": {
+          "$ref": "#/$defs/QuestionQuestionSubtext"
+        },
+        "questionCodeReference": {
+          "$ref": "#/$defs/QuestionQuestionCodeReference"
+        },
+        "possibleAnswers": {
+          "$ref": "#/$defs/QuestionPossibleAnswers"
+        },
+        "nextNavigationLogic": {
+          "$ref": "#/$defs/NextNavigationLogic"
+        }
+      },
+      "required": ["walkthroughItemType", "questionText", "possibleAnswers", "nextNavigationLogic"],
+      "title": "QuestionTypeMultiChoice"
+    },
+    "QuestionTypeMultiChoiceMultiple": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "walkthroughItemType": {
+          "const": "multiChoiceMultiple"
+        },
+        "questionText": {
+          "$ref": "#/$defs/QuestionQuestionText"
+        },
+        "questionSubtext": {
+          "$ref": "#/$defs/QuestionQuestionSubtext"
+        },
+        "questionCodeReference": {
+          "$ref": "#/$defs/QuestionQuestionCodeReference"
+        },
+        "possibleAnswers": {
+          "$ref": "#/$defs/QuestionPossibleAnswers"
+        },
+        "possibleInvalidAnswers": {
+          "$ref": "#/$defs/QuestionPossibleInvalidAnswers"
+        },
+        "nextNavigationLogic": {
+          "$ref": "#/$defs/NextNavigationLogic"
+        },
+        "answersAreDynamic": {
+          "type": "boolean"
+        },
+        "storeAnswerAsObject": {
+          "type": "boolean"
+        },
+        "isNotRequired": {
+          "type": "boolean"
+        }
+      },
+      "required": ["walkthroughItemType", "questionText", "possibleAnswers", "nextNavigationLogic"],
+      "title": "QuestionTypeMultiChoiceMultiple"
+    },
+    "QuestionTypeVariable": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "walkthroughItemType": {
+          "const": "variable"
+        },
+        "variableToSet": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "variableType": {
+              "type": "string",
+              "enum": ["string", "object", "copy", "number"]
+            },
+            "variableName": {
+              "type": "string"
+            },
+            "variableValue": {
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/$defs/QuestionVariableValueLogic"
+                  }
+                },
+                {
+                  "type": "object",
+                  "patternProperties": {
+                    "^\\w+$": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/$defs/QuestionVariableValueLogic"
+                      }
+                    }
+                  }
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                }
+              ]
+            }
+          },
+          "required": ["variableType", "variableName", "variableValue"]
+        },
+        "nextNavigationLogic": {
+          "$ref": "#/$defs/NextNavigationLogic"
+        }
+      },
+      "required": ["walkthroughItemType", "variableToSet", "nextNavigationLogic"],
+      "title": "QuestionTypeVariable"
+    },
+    "QuestionTypeNumberFloat": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "walkthroughItemType": {
+          "const": "numberFloat"
+        },
+        "questionText": {
+          "$ref": "#/$defs/QuestionQuestionText"
+        },
+        "questionSubtext": {
+          "$ref": "#/$defs/QuestionQuestionSubtext"
+        },
+        "questionCodeReference": {
+          "$ref": "#/$defs/QuestionQuestionCodeReference"
+        },
+        "placeholder": {
+          "type": "string",
+          "description": "Placeholder text for numberFloat fields."
+        },
+        "unit": {
+          "type": "string",
+          "description": "Unit of measurement for numberFloat fields. Will display in the UI after input field. Can include HTML."
+        },
+        "nextNavigationLogic": {
+          "$ref": "#/$defs/NextNavigationLogic"
+        }
+      },
+      "required": ["walkthroughItemType", "questionText", "placeholder", "nextNavigationLogic"],
+      "title": "QuestionTypeNumberFloat"
+    },
+    "QuestionQuestionText": {
+      "type": "string",
+      "description": "Can include HTML that the application will parse. Can also include references to specific parsed elements used in the parsing function in string.tsx."
+    },
+    "QuestionQuestionSubtext": {
+      "type": "string",
+      "description": "Optional subtext that can provide additional context to the question. Can include HTML."
+    },
+    "QuestionQuestionCodeReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "displayString": {
+          "type": "string",
+          "description": "A human-readable string that references the code. Will be displayed in the UI below the question text."
+        },
+        "codeNumber": {
+          "type": "string",
+          "description": "Used to scroll the modal to the correct building code item."
+        }
+      },
+      "required": ["displayString", "codeNumber"]
+    },
+    "QuestionPossibleAnswers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "answerDisplayText": {
+            "type": "string"
+          },
+          "answerValue": {
+            "type": "string",
+            "description": "A unique value for the answer. Stored in the state. Can be used for navigation logic or calculations."
+          }
+        },
+        "required": ["answerDisplayText", "answerValue"]
+      }
+    },
+    "QuestionPossibleInvalidAnswers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "invalidAnswerType": {
+            "type": "string",
+            "enum": ["contains", "doesNotContain", "maxNumberOfAnswers"]
+          },
+          "answerValue": {
+            "type": "string"
+          },
+          "invalidAnswerLogic": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "invalidAnswerLogicType": {
+                  "type": "string",
+                  "enum": ["maxNumberOfAnswers"]
+                },
+                "invalidAnswerLogicValue": {
+                  "type": "integer"
+                }
+              },
+              "required": ["invalidAnswerLogicType", "invalidAnswerLogicValue"]
+            }
+          },
+          "errorMessage": {
+            "type": "string"
+          }
+        },
+        "required": ["invalidAnswerType", "answerValue", "errorMessage"]
+      }
+    },
+    "QuestionVariableValueLogic": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "variableValueLogicType": {
+          "$ref": "#/$defs/VariableValueLogicTypeEnum"
+        },
+        "answerToCheck": {
+          "$ref": "#/$defs/VariableValueLogicAnswerToCheck"
+        },
+        "answerValue": {
+          "$ref": "#/$defs/VariableValueLogicAnswerValue"
+        },
+        "answerValues": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/VariableValueLogicAnswerValue"
+          }
+        },
+        "variableValueToSet": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "variableValueToSetCalculation": {
+          "$ref": "#/$defs/VariableValueToSetCalculation"
+        },
+        "valuesToCheck": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/VariableValuesToCheck"
+          }
+        }
+      },
+      "required": ["variableValueLogicType"]
+    },
+    "NextNavigationLogicType": {
+      "type": "string",
+      "enum": [
+        "equal",
+        "notEqual",
+        "doesNotContain",
+        "containsAny",
+        "containsOnly",
+        "and",
+        "or",
+        "lessThan",
+        "greaterThan",
+        "fallback"
+      ]
+    },
+    "NextNavigationLogic": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "nextLogicType": {
+            "$ref": "#/$defs/NextNavigationLogicType"
+          },
+          "answerToCheck": {
+            "type": "string"
+          },
+          "answerValue": {
+            "type": "string"
+          },
+          "valuesToCheck": {
+            "type": "array",
+            "items": {
+              "$ref": "#/$defs/NextValuesToCheckType"
+            }
+          },
+          "answerValues": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "An answerValue from possibleAnswers."
+            }
+          },
+          "nextNavigateTo": {
+            "type": "string",
+            "description": "The key of the next question or result."
+          }
+        },
+        "required": ["nextLogicType"]
+      }
+    },
+    "NextValuesToCheckType": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "nextLogicType": {
+          "$ref": "#/$defs/NextNavigationLogicType"
+        },
+        "answerToCheck": {
+          "type": "string"
+        },
+        "answerValue": {
+          "type": "string"
+        },
+        "answerValues": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "An answerValue from possibleAnswers."
+          }
+        },
+        "valuesToCheck": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/NextValuesToCheckType"
+          }
+        }
+      },
+      "required": ["nextLogicType"]
+    },
+    "VariableValueLogicTypeEnum": {
+      "type": "string",
+      "enum": [
+        "equals",
+        "and",
+        "or",
+        "lessThan",
+        "greaterThan",
+        "containsOnly",
+        "fallback"
+      ]
+    },
+    "VariableValueLogicAnswerToCheck": {
+      "type": "string"
+    },
+    "VariableValueLogicAnswerValue": {
+      "type": "string"
+    },
+    "VariableValuesToCheck": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "variableValueLogicType": {
+          "$ref": "#/$defs/VariableValueLogicTypeEnum"
+        },
+        "answerToCheck": {
+          "$ref": "#/$defs/VariableValueLogicAnswerToCheck"
+        },
+        "answerValue": {
+          "$ref": "#/$defs/VariableValueLogicAnswerValue"
+        },
+        "valuesToCheck": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/VariableValuesToCheck"
+          }
+        }
+      },
+      "required": ["variableValueLogicType"]
+    },
+    "VariableValueCalculationTypeEnum": {
+      "type": "string",
+      "enum": [
+        "square",
+        "divide",
+        "multiply",
+        "maxValue",
+        "then"
+      ]
+    },
+    "VariableValueToSetItemCalculations": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "variableValueCalculationType": {
+          "$ref": "#/$defs/VariableValueCalculationTypeEnum"
+        },
+        "calculationValueToUse": {
+          "type": "number"
+        }
+      },
+      "required": ["variableValueCalculationType"]
+    },
+    "VariableValueToSetCalculation": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "variableValueCalculationType": {
+          "$ref": "#/$defs/VariableValueCalculationTypeEnum"
+        },
+        "calculationValueToUse": {
+          "type": "number"
+        },
+        "variableValueToSetItemCalculations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/VariableValueToSetItemCalculations"
+          }
+        },
+        "answerToUse": {
+          "type": "string"
+        }
+      },
+      "required": ["variableValueCalculationType", "answerToUse"]
+    },
+    "Result": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resultDisplayMessage": {
+          "type": "string"
+        },
+        "relatedBuildingType": {
+          "type": "string",
+          "description": "Optional reference to a related building type. MUST be one of the supported building types from the EnumBuildingTypes."
+        },
+        "resultCalculations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ResultCalculationItem"
+          }
+        }
+      },
+      "required": ["resultDisplayMessage"]
+    },
+    "ResultCalculationTypeEnum": {
+      "type": "string",
+      "enum": [
+        "maxBetween",
+        "minBetween",
+        "divide",
+        "multiply",
+        "minus",
+        "square",
+        "answer",
+        "number",
+        "logic"
+      ]
+    },
+    "ResultLogicTypeEnum": {
+      "type": "string",
+      "enum": [
+        "fallback",
+        "greaterThanOrEqual"
+      ]
+    },
+    "ResultLogicItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resultLogicType": {
+          "$ref": "#/$defs/ResultLogicTypeEnum"
+        },
+        "answerToCheck": {
+          "type": "string"
+        },
+        "answerValue": {
+          "type": "number"
+        },
+        "valueToUse": {
+          "type": "number"
+        }
+      },
+      "required": ["resultLogicType", "valueToUse"]
+    },
+    "ResultCalculationValue": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resultCalculationType": {
+          "$ref": "#/$defs/ResultCalculationTypeEnum"
+        },
+        "calculationValuesToUse": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ResultCalculationValue"
+          }
+        },
+        "answerToUse": {
+          "type": "string"
+        },
+        "calculationValueToUse": {
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/$defs/ResultCalculationValue"
+            }
+          ]
+        },
+        "defaultValue": {
+          "type": "number"
+        },
+        "resultLogicItems": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ResultLogicItem"
+          }
+        }
+      },
+      "required": ["resultCalculationType"]
+    },
+    "ResultCalculationItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resultCalculationType": {
+          "$ref": "#/$defs/ResultCalculationTypeEnum"
+        },
+        "calculationValuesToUse": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ResultCalculationValue"
+          }
+        },
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": ["resultCalculationType", "id", "calculationValuesToUse"]
+    }
+  }
+}

--- a/packages/data/src/useGlossaryData.ts
+++ b/packages/data/src/useGlossaryData.ts
@@ -37,18 +37,18 @@ export type SubsectionType = {
 
 export type ArticleType = {
   numberReference: string;
-  title?: string;
+  title: string;
   sentences: SentenceType[];
 };
 
 export type SentenceType = {
   numberReference: string;
   description: string;
-  clauses?: SubClauseType[];
+  clauses?: ClauseType[];
   image?: ImageModalType;
 };
 
-export type SubClauseType = {
+export type ClauseType = {
   numberReference: string;
   description: string;
   subClauses?: string[];
@@ -82,15 +82,25 @@ export type ModalSideDataType = {
 
 const GlossaryJSONData = glossary as unknown as BuildingGlossaryJSONType;
 
-export const BuildingCodeJSONData = buildingCode as unknown as PartType[];
+export interface BuildingCodeJSONType {
+  data: PartType[];
+}
+export const BuildingCodeJSONData = buildingCode as BuildingCodeJSONType;
 
 export default function transformGlossaryData(
   data: BuildingGlossaryJSONType,
 ): GlossaryType[] {
-  return Object.entries(data).map(([term, content]) => ({
-    reference: term.toLocaleLowerCase(),
-    content,
-  }));
+  return Object.entries(data).reduce((terms, [term, content]) => {
+    // Skip schema entry
+    if (term === "$schema") return terms;
+
+    terms.push({
+      reference: term.toLocaleLowerCase(),
+      content,
+    });
+
+    return terms;
+  }, [] as GlossaryType[]);
 }
 
 function setMappedGlossaryData(
@@ -107,7 +117,7 @@ function setMappedGlossaryData(
 function setStaticData(): ModalSideDataType {
   return {
     [ModalSideDataEnum.GLOSSARY]: transformGlossaryData(GlossaryJSONData),
-    [ModalSideDataEnum.BUILDING_CODE]: BuildingCodeJSONData,
+    [ModalSideDataEnum.BUILDING_CODE]: BuildingCodeJSONData.data,
   };
 }
 
@@ -177,7 +187,7 @@ export const findBuildingCodeNumberTypeByReferenceNumber = (
     return null;
   };
 
-  for (const part of BuildingCodeJSONData) {
+  for (const part of BuildingCodeJSONData.data) {
     if (part.numberReference === numberReference) {
       return part;
     } else {

--- a/packages/ui/src/modal-building-code-content/ModalBuildingCodeContent.tsx
+++ b/packages/ui/src/modal-building-code-content/ModalBuildingCodeContent.tsx
@@ -3,7 +3,7 @@
 import React, { useRef } from "react";
 import {
   ArticleType,
-  SubClauseType,
+  ClauseType,
   PartType,
   SentenceType,
   SectionType,
@@ -76,7 +76,7 @@ const BuildingCodeContent: React.FC<BuildingCodeContentProps> = ({
     );
   };
 
-  const renderClauses = (clauses: SubClauseType[]) => {
+  const renderClauses = (clauses: ClauseType[]) => {
     return (
       <ol className="ui-ModalSide--Clauses">
         {clauses.map((data, index) => (


### PR DESCRIPTION
[HOUSNAV-225](https://hous-bssb.atlassian.net/browse/HOUSNAV-225)

## Overview & Purpose
Create a schema for the walkthrough, building code, and terms json

## Summary of Changes
- Added a schema for the walkthrough, building code, and terms json based on our current TypeScript definitions
- Update JSONS to use the schema and add a check to the tests
- Updated the README
- Updated the documentation in [Confluence](https://hous-bssb.atlassian.net/wiki/spaces/HOUSNAV/pages/149880834/JSON+Data) to highlight our multi-pronged approach to data validation.

- NOTE: the wt-building-code-analysis.json will need to be updated in a similar manner once [PR-134](https://github.com/bcgov/House-Innovations-HOUSNAV/pull/134) is merged

## Checklist
- [x] I have written or updated vitests for this work
- [x] I have reviewed the [accessibility guidelines](https://digital.gov.bc.ca/wcag/home/) relevant to this work
- [x] I have reviewed this work with at least one screen reader (when applicable)
- [x] I have added/updated any related documentation
