### PR TITLE
HOUSNAV-193: Breadcrumbs

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -16,6 +16,7 @@ import { STR_WEBSITE_NAME } from "@repo/constants/src/constants";
 // local
 import { ClientProviders } from "./ClientProviders";
 import "./globals.css";
+import Breadcrumbs from "../components/breadcrumbs/Breadcrumbs";
 
 export const metadata: Metadata = {
   title: `BC Gov - ${STR_WEBSITE_NAME} - Walkthroughs`,
@@ -50,7 +51,10 @@ export default function RootLayout({
             ]}
             logoSrc={"bc-logo.png"}
           />
-          <main id={ID_MAIN_CONTENT}>{children}</main>
+          <main id={ID_MAIN_CONTENT}>
+            <Breadcrumbs />
+            {children}
+          </main>
         </ClientProviders>
       </body>
     </html>

--- a/apps/web/components/breadcrumbs/Breadcrumbs.css
+++ b/apps/web/components/breadcrumbs/Breadcrumbs.css
@@ -1,0 +1,53 @@
+.web-Breadcrumbs {
+  border-bottom: var(--layout-border-width-small) solid
+    var(--surface-color-border-default);
+  height: var(--breadcrumbs-height);
+}
+
+.web-Breadcrumbs--Container.u-container {
+  display: flex;
+  list-style: none;
+  width: 100%;
+  overflow-x: auto;
+  height: 100%;
+  align-items: center;
+}
+
+.web-Breadcrumbs--Breadcrumb {
+  position: relative;
+  padding-inline-end: var(--layout-padding-large);
+  flex-shrink: 0;
+}
+
+.web-Breadcrumbs--Breadcrumb:after {
+  content: "›";
+  position: absolute;
+  right: 0;
+  width: var(--layout-padding-large);
+  text-align: center;
+}
+
+.web-Breadcrumbs--Breadcrumb:first-child {
+  padding-inline-start: var(--breadcrumbs-first-padding-start);
+}
+
+.web-Breadcrumbs--Breadcrumb:last-child {
+  padding-inline-end: 0;
+}
+
+.web-Breadcrumbs--Breadcrumb:last-child:after {
+  content: none;
+}
+
+.web-Breadcrumbs--Breadcrumb a {
+  font: var(--typography-regular-small-body);
+  text-decoration: none;
+}
+
+.web-Breadcrumbs--Breadcrumb a[data-hovered] {
+  text-decoration: underline;
+}
+
+.web-Breadcrumbs--Breadcrumb span {
+  font: var(--typography-bold-small-body);
+}

--- a/apps/web/components/breadcrumbs/Breadcrumbs.test.tsx
+++ b/apps/web/components/breadcrumbs/Breadcrumbs.test.tsx
@@ -4,15 +4,12 @@ import * as NextNavigation from "next/navigation";
 // repo
 import {
   GET_TESTID_BREADCRUMBS_BREADCRUMB,
+  TESTID_BREADCRUMB_HOME,
   TESTID_BREADCRUMB_LAST,
   TESTID_BREADCRUMBS,
 } from "@repo/constants/src/testids";
 import { EnumBuildingTypes } from "@repo/constants/src/constants";
-import {
-  GET_PAGE_NAME,
-  URL_HOME_TITLE,
-  URL_PATH_WALKTHROUGH,
-} from "@repo/constants/src/urls";
+import { URL_PATH_WALKTHROUGH } from "@repo/constants/src/urls";
 // local
 import { renderWithWalkthroughProvider } from "../../tests/utils";
 import Breadcrumbs from "./Breadcrumbs";
@@ -34,13 +31,9 @@ describe("Breadcrumbs", () => {
 
     expect(getByTestId(TESTID_BREADCRUMBS)).toBeInTheDocument();
     expect(getByTestId(TESTID_BREADCRUMBS).children).toHaveLength(3);
+    expect(getByTestId(TESTID_BREADCRUMB_HOME)).toBeInTheDocument();
     expect(
-      getByTestId(GET_TESTID_BREADCRUMBS_BREADCRUMB(URL_HOME_TITLE)),
-    ).toBeInTheDocument();
-    expect(
-      getByTestId(
-        GET_TESTID_BREADCRUMBS_BREADCRUMB(GET_PAGE_NAME(URL_BUILDING_TYPE)),
-      ),
+      getByTestId(GET_TESTID_BREADCRUMBS_BREADCRUMB(URL_BUILDING_TYPE)),
     ).toBeInTheDocument();
     expect(getByTestId(TESTID_BREADCRUMB_LAST)).toBeInTheDocument();
   });
@@ -56,9 +49,7 @@ describe("Breadcrumbs", () => {
 
     expect(getByTestId(TESTID_BREADCRUMBS)).toBeInTheDocument();
     expect(getByTestId(TESTID_BREADCRUMBS).children).toHaveLength(2);
-    expect(
-      getByTestId(GET_TESTID_BREADCRUMBS_BREADCRUMB(URL_HOME_TITLE)),
-    ).toBeInTheDocument();
+    expect(getByTestId(TESTID_BREADCRUMB_HOME)).toBeInTheDocument();
     expect(getByTestId(TESTID_BREADCRUMB_LAST)).toBeInTheDocument();
   });
   it("doesn't render with empty segments", () => {

--- a/apps/web/components/breadcrumbs/Breadcrumbs.test.tsx
+++ b/apps/web/components/breadcrumbs/Breadcrumbs.test.tsx
@@ -1,0 +1,73 @@
+// 3rd party
+import { describe, expect, it, vi } from "vitest";
+import * as NextNavigation from "next/navigation";
+// repo
+import {
+  GET_TESTID_BREADCRUMBS_BREADCRUMB,
+  TESTID_BREADCRUMB_LAST,
+  TESTID_BREADCRUMBS,
+} from "@repo/constants/src/testids";
+import { EnumBuildingTypes } from "@repo/constants/src/constants";
+import {
+  GET_PAGE_NAME,
+  URL_HOME_TITLE,
+  URL_PATH_WALKTHROUGH,
+} from "@repo/constants/src/urls";
+// local
+import { renderWithWalkthroughProvider } from "../../tests/utils";
+import Breadcrumbs from "./Breadcrumbs";
+
+// mock next/navigation
+vi.mock("next/navigation");
+
+describe("Breadcrumbs", () => {
+  it("renders 3 items", () => {
+    const URL_BUILDING_TYPE = EnumBuildingTypes.SINGLE_DWELLING;
+    vi.mocked(NextNavigation.useSelectedLayoutSegments).mockReturnValueOnce([
+      URL_BUILDING_TYPE,
+      URL_PATH_WALKTHROUGH,
+    ]);
+
+    const { getByTestId } = renderWithWalkthroughProvider({
+      ui: <Breadcrumbs />,
+    });
+
+    expect(getByTestId(TESTID_BREADCRUMBS)).toBeInTheDocument();
+    expect(getByTestId(TESTID_BREADCRUMBS).children).toHaveLength(3);
+    expect(
+      getByTestId(GET_TESTID_BREADCRUMBS_BREADCRUMB(URL_HOME_TITLE)),
+    ).toBeInTheDocument();
+    expect(
+      getByTestId(
+        GET_TESTID_BREADCRUMBS_BREADCRUMB(GET_PAGE_NAME(URL_BUILDING_TYPE)),
+      ),
+    ).toBeInTheDocument();
+    expect(getByTestId(TESTID_BREADCRUMB_LAST)).toBeInTheDocument();
+  });
+  it("renders 2 items", () => {
+    const URL_BUILDING_TYPE = EnumBuildingTypes.MULTI_DWELLING;
+    vi.mocked(NextNavigation.useSelectedLayoutSegments).mockReturnValueOnce([
+      URL_BUILDING_TYPE,
+    ]);
+
+    const { getByTestId } = renderWithWalkthroughProvider({
+      ui: <Breadcrumbs />,
+    });
+
+    expect(getByTestId(TESTID_BREADCRUMBS)).toBeInTheDocument();
+    expect(getByTestId(TESTID_BREADCRUMBS).children).toHaveLength(2);
+    expect(
+      getByTestId(GET_TESTID_BREADCRUMBS_BREADCRUMB(URL_HOME_TITLE)),
+    ).toBeInTheDocument();
+    expect(getByTestId(TESTID_BREADCRUMB_LAST)).toBeInTheDocument();
+  });
+  it("doesn't render with empty segments", () => {
+    vi.mocked(NextNavigation.useSelectedLayoutSegments).mockReturnValueOnce([]);
+
+    const { queryByTestId } = renderWithWalkthroughProvider({
+      ui: <Breadcrumbs />,
+    });
+
+    expect(queryByTestId(TESTID_BREADCRUMBS)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/components/breadcrumbs/Breadcrumbs.tsx
+++ b/apps/web/components/breadcrumbs/Breadcrumbs.tsx
@@ -1,0 +1,71 @@
+"use client";
+// 3rd party
+import { useSelectedLayoutSegments } from "next/navigation";
+import {
+  Breadcrumbs as ReactAriaBreadcrumbs,
+  Breadcrumb as ReactAriaBreadcrumb,
+} from "react-aria-components";
+// repo
+import Link from "@repo/ui/link";
+import {
+  GET_PAGE_NAME,
+  URL_HOME_TITLE,
+  URL_PATH_HOME,
+} from "@repo/constants/src/urls";
+import {
+  GET_TESTID_BREADCRUMBS_BREADCRUMB,
+  TESTID_BREADCRUMB_LAST,
+  TESTID_BREADCRUMBS,
+} from "@repo/constants/src/testids";
+// local
+import "./Breadcrumbs.css";
+
+const Breadcrumbs = () => {
+  const segments = useSelectedLayoutSegments();
+
+  // segments will have no length when the user is on the home page where we don't want to show breadcrumbs
+  if (!segments.length) {
+    return null;
+  }
+
+  return (
+    <nav className="web-Breadcrumbs" aria-label="Breadcrumb">
+      <ReactAriaBreadcrumbs
+        key={segments.join("_")}
+        className="u-container web-Breadcrumbs--Container"
+        data-testid={TESTID_BREADCRUMBS}
+      >
+        <ReactAriaBreadcrumb
+          className="web-Breadcrumbs--Breadcrumb"
+          data-testid={GET_TESTID_BREADCRUMBS_BREADCRUMB(URL_HOME_TITLE)}
+        >
+          <Link href={URL_PATH_HOME}>{URL_HOME_TITLE}</Link>
+        </ReactAriaBreadcrumb>
+        {segments.map((segment, index) => {
+          const isLast = index === segments.length - 1;
+          const dataTestid = isLast
+            ? TESTID_BREADCRUMB_LAST
+            : GET_TESTID_BREADCRUMBS_BREADCRUMB(GET_PAGE_NAME(segment));
+
+          return (
+            <ReactAriaBreadcrumb
+              key={index}
+              className="web-Breadcrumbs--Breadcrumb"
+              data-testid={dataTestid}
+            >
+              {isLast ? (
+                <span aria-current="page">{GET_PAGE_NAME(segment)}</span>
+              ) : (
+                <Link href={`/${segments.slice(0, index + 1).join("/")}`}>
+                  {GET_PAGE_NAME(segment)}
+                </Link>
+              )}
+            </ReactAriaBreadcrumb>
+          );
+        })}
+      </ReactAriaBreadcrumbs>
+    </nav>
+  );
+};
+
+export default Breadcrumbs;

--- a/apps/web/components/breadcrumbs/Breadcrumbs.tsx
+++ b/apps/web/components/breadcrumbs/Breadcrumbs.tsx
@@ -14,6 +14,7 @@ import {
 } from "@repo/constants/src/urls";
 import {
   GET_TESTID_BREADCRUMBS_BREADCRUMB,
+  TESTID_BREADCRUMB_HOME,
   TESTID_BREADCRUMB_LAST,
   TESTID_BREADCRUMBS,
 } from "@repo/constants/src/testids";
@@ -37,7 +38,7 @@ const Breadcrumbs = () => {
       >
         <ReactAriaBreadcrumb
           className="web-Breadcrumbs--Breadcrumb"
-          data-testid={GET_TESTID_BREADCRUMBS_BREADCRUMB(URL_HOME_TITLE)}
+          data-testid={TESTID_BREADCRUMB_HOME}
         >
           <Link href={URL_PATH_HOME}>{URL_HOME_TITLE}</Link>
         </ReactAriaBreadcrumb>
@@ -45,7 +46,7 @@ const Breadcrumbs = () => {
           const isLast = index === segments.length - 1;
           const dataTestid = isLast
             ? TESTID_BREADCRUMB_LAST
-            : GET_TESTID_BREADCRUMBS_BREADCRUMB(GET_PAGE_NAME(segment));
+            : GET_TESTID_BREADCRUMBS_BREADCRUMB(segment);
 
           return (
             <ReactAriaBreadcrumb

--- a/apps/web/components/result/Result.css
+++ b/apps/web/components/result/Result.css
@@ -38,6 +38,10 @@
   font: var(--typography-regular-large-body);
 }
 
+.web-Result--Content strong button {
+  font: var(--typography-bold-large-body);
+}
+
 .web-Result--Content sup {
   line-height: 0;
 }

--- a/apps/web/cypress/e2e/multi-dwelling/multi-dwelling-9.10.14-walkthrough.cy.ts
+++ b/apps/web/cypress/e2e/multi-dwelling/multi-dwelling-9.10.14-walkthrough.cy.ts
@@ -1,6 +1,5 @@
 import { URLS_GET_WALKTHROUGH } from "@repo/constants/src/urls";
 import {
-  EnumBreadcrumbIds,
   EnumBuildingTypes,
   EnumWalkthroughIds,
 } from "@repo/constants/src/constants";
@@ -8,6 +7,8 @@ import { runWalkthrough } from "../../support/helpers";
 import {
   GET_TESTID_BREADCRUMBS_BREADCRUMB,
   GET_TESTID_STEP_TRACKER_WALKTHROUGH_HEADER,
+  TESTID_BREADCRUMB_HOME,
+  TESTID_BREADCRUMB_LAST,
   TESTID_BREADCRUMBS,
 } from "@repo/constants/src/testids";
 import { walkthroughs } from "../../fixtures/multi-dwelling/multi-dwelling-9.10.14-test-data.json";
@@ -31,15 +32,11 @@ describe("multi dwelling: 9.10.14 walkthrough", () => {
 
   it("should display all parts of breadcrumbs", () => {
     cy.getByTestID(TESTID_BREADCRUMBS).should("be.visible");
+    cy.getByTestID(TESTID_BREADCRUMB_HOME).should("be.visible");
     cy.getByTestID(
-      GET_TESTID_BREADCRUMBS_BREADCRUMB(EnumBreadcrumbIds.HOME),
+      GET_TESTID_BREADCRUMBS_BREADCRUMB(EnumBuildingTypes.MULTI_DWELLING),
     ).should("be.visible");
-    cy.getByTestID(
-      GET_TESTID_BREADCRUMBS_BREADCRUMB(EnumBreadcrumbIds.MULTI_DWELLING_UNIT),
-    ).should("be.visible");
-    cy.getByTestID(
-      GET_TESTID_BREADCRUMBS_BREADCRUMB(EnumBreadcrumbIds.LAST),
-    ).should("be.visible");
+    cy.getByTestID(TESTID_BREADCRUMB_LAST).should("be.visible");
   });
 
   it("step tracker doesn't show section headers for single section", () => {

--- a/apps/web/cypress/e2e/multi-dwelling/multi-dwelling-9.10.14-walkthrough.cy.ts
+++ b/apps/web/cypress/e2e/multi-dwelling/multi-dwelling-9.10.14-walkthrough.cy.ts
@@ -1,10 +1,15 @@
 import { URLS_GET_WALKTHROUGH } from "@repo/constants/src/urls";
 import {
+  EnumBreadcrumbIds,
   EnumBuildingTypes,
   EnumWalkthroughIds,
 } from "@repo/constants/src/constants";
 import { runWalkthrough } from "../../support/helpers";
-import { GET_TESTID_STEP_TRACKER_WALKTHROUGH_HEADER } from "@repo/constants/src/testids";
+import {
+  GET_TESTID_BREADCRUMBS_BREADCRUMB,
+  GET_TESTID_STEP_TRACKER_WALKTHROUGH_HEADER,
+  TESTID_BREADCRUMBS,
+} from "@repo/constants/src/testids";
 import { walkthroughs } from "../../fixtures/multi-dwelling/multi-dwelling-9.10.14-test-data.json";
 import { results } from "../../fixtures/results-data.json";
 
@@ -22,6 +27,19 @@ describe("multi dwelling: 9.10.14 walkthrough", () => {
     it(walkthrough.title, () => {
       runWalkthrough(walkthrough, results.multi_dwelling_workflow_91014);
     });
+  });
+
+  it("should display all parts of breadcrumbs", () => {
+    cy.getByTestID(TESTID_BREADCRUMBS).should("be.visible");
+    cy.getByTestID(
+      GET_TESTID_BREADCRUMBS_BREADCRUMB(EnumBreadcrumbIds.HOME),
+    ).should("be.visible");
+    cy.getByTestID(
+      GET_TESTID_BREADCRUMBS_BREADCRUMB(EnumBreadcrumbIds.MULTI_DWELLING_UNIT),
+    ).should("be.visible");
+    cy.getByTestID(
+      GET_TESTID_BREADCRUMBS_BREADCRUMB(EnumBreadcrumbIds.LAST),
+    ).should("be.visible");
   });
 
   it("step tracker doesn't show section headers for single section", () => {

--- a/apps/web/cypress/e2e/multi-dwelling/multi-dwelling-combined-results.cy.ts
+++ b/apps/web/cypress/e2e/multi-dwelling/multi-dwelling-combined-results.cy.ts
@@ -12,6 +12,7 @@ import {
   GET_TESTID_RESULT_ITEM,
   GET_TESTID_RESULT_PRINT_CONTENT_WALKTHROUGH,
   GET_TESTID_RESULT_RELATED_ITEM,
+  TESTID_BREADCRUMBS,
 } from "@repo/constants/src/testids";
 
 describe("multi dwelling: 9.9.9 and 9.10.14 walkthrough results", () => {
@@ -26,6 +27,8 @@ describe("multi dwelling: 9.9.9 and 9.10.14 walkthrough results", () => {
   });
 
   it("should display correct ui elements", () => {
+    cy.getByTestID(TESTID_BREADCRUMBS).should("be.visible");
+
     cy.getByTestID(GET_TESTID_RESULT_ITEM(EnumWalkthroughIds._9_9_9)).should(
       "be.visible",
     );

--- a/apps/web/cypress/e2e/multi-dwelling/multi-dwelling-landing.cy.ts
+++ b/apps/web/cypress/e2e/multi-dwelling/multi-dwelling-landing.cy.ts
@@ -3,6 +3,7 @@ import {
   GET_TESTID_BUTTON,
   GET_TESTID_CHECKBOX_CARD,
   GET_TESTID_LINK,
+  TESTID_BREADCRUMBS,
   TESTID_BUILD_WIZARD_BEGIN_WALKTHROUGH,
   TESTID_BUILD_WIZARD_SELECT_ALL,
   TESTID_BUILD_WIZARD_TOTAL_AVAILABLE,
@@ -21,20 +22,22 @@ describe("multi dwelling: landing", () => {
   });
 
   it("should display correct ui elements", () => {
+    cy.getByTestID(TESTID_BREADCRUMBS).should("be.visible");
+
     cy.getByTestID(GET_TESTID_CHECKBOX_CARD(EnumWalkthroughIds._9_9_9)).should(
-      "exist",
+      "be.visible",
     );
     cy.getByTestID(
       GET_TESTID_CHECKBOX_CARD(EnumWalkthroughIds._9_10_14),
-    ).should("exist");
+    ).should("be.visible");
     cy.getByTestID(GET_TESTID_BUTTON(TESTID_BUILD_WIZARD_SELECT_ALL)).should(
-      "exist",
+      "be.visible",
     );
     cy.getByTestID(
       GET_TESTID_LINK(TESTID_BUILD_WIZARD_BEGIN_WALKTHROUGH),
-    ).should("exist");
-    cy.getByTestID(TESTID_BUILD_WIZARD_TOTAL_AVAILABLE).should("exist");
-    cy.getByTestID(TESTID_BUILD_WIZARD_TOTAL_SELECTED).should("exist");
+    ).should("be.visible");
+    cy.getByTestID(TESTID_BUILD_WIZARD_TOTAL_AVAILABLE).should("be.visible");
+    cy.getByTestID(TESTID_BUILD_WIZARD_TOTAL_SELECTED).should("be.visible");
   });
 
   it("should update total selected when single checkbox is selected", () => {

--- a/apps/web/cypress/e2e/single-dwelling/single-dwelling-9.9.9-results.cy.ts
+++ b/apps/web/cypress/e2e/single-dwelling/single-dwelling-9.9.9-results.cy.ts
@@ -12,6 +12,7 @@ import {
   GET_TESTID_RESULT_ITEM,
   GET_TESTID_RESULT_PRINT_CONTENT_WALKTHROUGH,
   GET_TESTID_RESULT_RELATED_ITEM,
+  TESTID_BREADCRUMBS,
 } from "@repo/constants/src/testids";
 
 describe("single dwelling: 9.9.9 walkthrough results", () => {
@@ -23,6 +24,8 @@ describe("single dwelling: 9.9.9 walkthrough results", () => {
   });
 
   it("should display correct ui elements", () => {
+    cy.getByTestID(TESTID_BREADCRUMBS).should("be.visible");
+
     cy.getByTestID(GET_TESTID_RESULT_ITEM(EnumWalkthroughIds._9_9_9)).should(
       "be.visible",
     );

--- a/apps/web/cypress/e2e/single-dwelling/single-dwelling-landing.cy.ts
+++ b/apps/web/cypress/e2e/single-dwelling/single-dwelling-landing.cy.ts
@@ -1,5 +1,8 @@
 // repo
-import { GET_TESTID_LINK_CARD } from "@repo/constants/src/testids";
+import {
+  GET_TESTID_LINK_CARD,
+  TESTID_BREADCRUMBS,
+} from "@repo/constants/src/testids";
 import {
   EnumBuildingTypes,
   EnumWalkthroughIds,
@@ -12,11 +15,13 @@ describe("single dwelling: landing", () => {
   });
 
   it("should display correct ui elements", () => {
+    cy.getByTestID(TESTID_BREADCRUMBS).should("be.visible");
+
     cy.getByTestID(GET_TESTID_LINK_CARD(EnumWalkthroughIds._9_9_9)).should(
-      "exist",
+      "be.visible",
     );
     cy.getByTestID(GET_TESTID_LINK_CARD(EnumWalkthroughIds._9_10_14)).should(
-      "exist",
+      "be.visible",
     );
   });
 

--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -17,13 +17,6 @@ export enum EnumBuildingTypes {
   MULTI_DWELLING = "multi-dwelling",
 }
 
-export enum EnumBreadcrumbIds {
-  HOME = "Home",
-  LAST = "Last",
-  MULTI_DWELLING_UNIT = "Multi-Dwelling Unit",
-  SINGLE_DWELLING_UNIT = "Single-Dwelling Unit",
-}
-
 export const STR_BUILDING_TYPE_ANALYSIS_ID = "building-type-analysis";
 export const STR_WALKTHROUGH_ID = "walkthrough";
 

--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -18,6 +18,7 @@ export enum EnumBuildingTypes {
 }
 
 export const STR_BUILDING_TYPE_ANALYSIS_ID = "building-type-analysis";
+export const STR_WALKTHROUGH_ID = "walkthrough";
 
 export const SHOW_QUESTION_LABELS =
   process.env.NEXT_PUBLIC_SHOW_QUESTION_LABELS === "yes";

--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -17,6 +17,13 @@ export enum EnumBuildingTypes {
   MULTI_DWELLING = "multi-dwelling",
 }
 
+export enum EnumBreadcrumbIds {
+  HOME = "Home",
+  LAST = "Last",
+  MULTI_DWELLING_UNIT = "Multi-Dwelling Unit",
+  SINGLE_DWELLING_UNIT = "Single-Dwelling Unit",
+}
+
 export const STR_BUILDING_TYPE_ANALYSIS_ID = "building-type-analysis";
 export const STR_WALKTHROUGH_ID = "walkthrough";
 

--- a/packages/constants/src/testids.ts
+++ b/packages/constants/src/testids.ts
@@ -62,7 +62,8 @@ export const GET_TESTID_HEADER_NAV_ITEM = (title: string) =>
 export const TESTID_BREADCRUMBS = "breadcrumbs";
 export const GET_TESTID_BREADCRUMBS_BREADCRUMB = (id: string) =>
   `breadcrumb-${id}`;
-export const TESTID_BREADCRUMB_LAST = "breadcrumb-Last";
+export const TESTID_BREADCRUMB_HOME = "breadcrumb-home";
+export const TESTID_BREADCRUMB_LAST = "breadcrumb-last";
 export const TESTID_LAYOUT_FOOTER = "layout-footer";
 export const TESTID_FOOTER = "footer";
 export const TESTID_PRE_FOOTER = "pre-footer";

--- a/packages/constants/src/testids.ts
+++ b/packages/constants/src/testids.ts
@@ -59,6 +59,10 @@ export const TESTID_HEADER_MOBILE_NAV = "header-mobile-nav";
 export const TESTID_HEADER_MOBILE_NAV_BUTTON = "header-mobile-nav-button";
 export const GET_TESTID_HEADER_NAV_ITEM = (title: string) =>
   `header-nav-item-${title}`;
+export const TESTID_BREADCRUMBS = "breadcrumbs";
+export const GET_TESTID_BREADCRUMBS_BREADCRUMB = (id: string) =>
+  `breadcrumb-${id}`;
+export const TESTID_BREADCRUMB_LAST = "breadcrumb-last";
 export const TESTID_LAYOUT_FOOTER = "layout-footer";
 export const TESTID_FOOTER = "footer";
 export const TESTID_PRE_FOOTER = "pre-footer";

--- a/packages/constants/src/testids.ts
+++ b/packages/constants/src/testids.ts
@@ -62,7 +62,7 @@ export const GET_TESTID_HEADER_NAV_ITEM = (title: string) =>
 export const TESTID_BREADCRUMBS = "breadcrumbs";
 export const GET_TESTID_BREADCRUMBS_BREADCRUMB = (id: string) =>
   `breadcrumb-${id}`;
-export const TESTID_BREADCRUMB_LAST = "breadcrumb-last";
+export const TESTID_BREADCRUMB_LAST = "breadcrumb-Last";
 export const TESTID_LAYOUT_FOOTER = "layout-footer";
 export const TESTID_FOOTER = "footer";
 export const TESTID_PRE_FOOTER = "pre-footer";

--- a/packages/constants/src/urls.ts
+++ b/packages/constants/src/urls.ts
@@ -1,5 +1,12 @@
+// repo
+import { BuildingTypeJSONData } from "@repo/data/useBuildingTypeData";
+import { BuildingTypeAnalysisJSONData } from "@repo/data/useWalkthroughsData";
 // local
-import { EnumBuildingTypes, STR_BUILDING_TYPE_ANALYSIS_ID } from "./constants";
+import {
+  EnumBuildingTypes,
+  STR_BUILDING_TYPE_ANALYSIS_ID,
+  STR_WALKTHROUGH_ID,
+} from "./constants";
 
 export const URL_DOWNLOAD_BCBC_PDF =
   "https://www2.gov.bc.ca/assets/gov/farming-natural-resources-and-industry/construction-industry/building-codes-and-standards/revisions-and-mo/bcbc_2024.pdf";
@@ -7,7 +14,7 @@ export const URL_DOWNLOAD_BCBC_PDF =
 // path urls
 export const URL_PATH_HOME = "/";
 export const URL_PATH_BUILDING_TYPE_ANALYSIS = `/${STR_BUILDING_TYPE_ANALYSIS_ID}`;
-export const URL_PATH_WALKTHROUGH = "/walkthrough";
+export const URL_PATH_WALKTHROUGH = `/${STR_WALKTHROUGH_ID}`;
 
 // search param keys
 export const SEARCH_PARAM_WALKTHROUGH_ID = "wtid";
@@ -27,7 +34,7 @@ export const URLS_MAIN_NAVIGATION = [
 ];
 
 export const URLS_FOOTER = [
-  { title: "Home", href: "/" },
+  { title: URL_HOME_TITLE, href: URL_PATH_HOME },
   {
     title: "Contact us",
     href: "mailto:Julia.leggett@gov.bc.ca",
@@ -75,3 +82,17 @@ export const TEMP_GET_URL_SINGLE_DWELLING_WALKTHROUGH = (
   walkthroughId: string,
 ) =>
   `${URLS_GET_BUILDING_TYPE(EnumBuildingTypes.SINGLE_DWELLING)}${URL_PATH_WALKTHROUGH}?${SEARCH_PARAM_WALKTHROUGH_ID}=${walkthroughId}`;
+
+export const GET_PAGE_NAME = (segment: string) => {
+  // first check if it's a building type
+  if (Object.values(EnumBuildingTypes).includes(segment as EnumBuildingTypes)) {
+    return BuildingTypeJSONData[segment as EnumBuildingTypes].title;
+  } else if (segment === STR_BUILDING_TYPE_ANALYSIS_ID) {
+    // else it's the building type analysis page
+    return BuildingTypeAnalysisJSONData.info.title;
+  } else if (segment === STR_WALKTHROUGH_ID) {
+    // else it's the walkthrough page
+    return "Walkthrough";
+  }
+  return "";
+};

--- a/packages/ui/src/variables.css
+++ b/packages/ui/src/variables.css
@@ -242,12 +242,17 @@
   --button-gap: var(--layout-padding-12);
   --header-height: 60px;
   --header-border-width: var(--layout-border-width-small);
-  --header-height-full: calc(var(--header-height) + var(--header-border-width));
+  --header-height-full: calc(
+    var(--header-height) + var(--header-border-width) +
+      var(--breadcrumbs-height)
+  );
   --header-nav-mobile-padding: var(--layout-padding-medium);
   --header-link-hover-background-color: rgba(34, 34, 34, 0.05);
   --footer-margin-block: var(--layout-margin-large);
   --footer-main-direction: column;
   --footer-main-margin-bottom: var(--layout-margin-large);
+  --breadcrumbs-height: 52px;
+  --breadcrumbs-first-padding-start: var(--layout-padding-small);
   --walkthrough-side-nav-width: 0;
   --question-container-max-width: 46.875rem; /* 750px */
   --question-container-padding-y: var(--layout-padding-medium);
@@ -359,6 +364,7 @@
 /* DESKTOP - LARGE - 1504px */
 @media (min-width: 94rem) {
   :root {
+    --breadcrumbs-first-padding-start: 0;
     --walkthrough-side-nav-width: 27.5rem; /* 440px */
     --question-container-max-width: 53.5rem; /* 856px */
   }


### PR DESCRIPTION
[HOUSNAV-193](https://hous-bssb.atlassian.net/browse/HOUSNAV-193)

## Overview & Purpose
Adding breadcrumbs to match the design

## Summary of Changes
Created Breadcrumbs component and added it to the root layout

## Testing
- Navigate to the home page - notice no breadcrumbs
- Navigate to all lower pages (building type analysis, single dwelling, multi dwelling, walkthroughs) and notice the breadcrumbs

## Checklist
- [x] I have written or updated vitests for this work
- [x] I have reviewed the [accessibility guidelines](https://digital.gov.bc.ca/wcag/home/) relevant to this work
- [x] I have reviewed this work with at least one screen reader (when applicable)
- [x] I have added/updated any related documentation
