### PR TITLE
HOUSNAV-238: Updated P17 logic after SME feedback

### DIFF
--- a/apps/web/cypress/fixtures/multi-dwelling/multi-dwelling-9.9.9-test-data.json
+++ b/apps/web/cypress/fixtures/multi-dwelling/multi-dwelling-9.9.9-test-data.json
@@ -1,7 +1,7 @@
 {
   "walkthroughs": [
     {
-      "title": "Questions p2-p18, p20, p28, Result R1_3",
+      "title": "Questions p2-p17, p19, p20, p28, Result R1_3",
       "steps": [
         {
           "question": "P2",
@@ -79,7 +79,7 @@
           "answer": "true"
         },
         {
-          "question": "P18",
+          "question": "P19",
           "type": "radio",
           "answer": "true"
         },
@@ -97,7 +97,7 @@
       "result": "R1_3"
     },
     {
-    "title": "Questions p19, p21, Result R1_2",
+    "title": "Questions p18, p21, Result R1_2",
       "steps": [
         {
           "question": "P2",
@@ -112,7 +112,7 @@
         {
           "question": "P5",
           "type": "checkbox",
-          "answer": ""
+          "answer": "3"
         },
         {
           "question": "P6",
@@ -120,17 +120,12 @@
           "answer": "false"
         },
         {
-          "question": "P7",
-          "type": "checkbox",
-          "answer": "3"
-        },
-        {
-          "question": "P8",
-          "type": "checkbox",
-          "answer": "3"
-        },
-        {
           "question": "P9",
+          "type": "checkbox",
+          "answer": ""
+        },
+        {
+          "question": "P10",
           "type": "checkbox",
           "answer": "1"
         },
@@ -167,10 +162,10 @@
         {
           "question": "P17",
           "type": "radio",
-          "answer": "true"
+          "answer": "false"
         },
         {
-          "question": "P19",
+          "question": "P18",
           "type": "radio",
           "answer": "true"
         },

--- a/packages/data/json/building-types/multi-dwelling/wt-multi-dwelling-9.9.9.json
+++ b/packages/data/json/building-types/multi-dwelling/wt-multi-dwelling-9.9.9.json
@@ -1567,36 +1567,71 @@
           "nextNavigateTo": "P22"
         },
         {
+          "nextLogicType": "and",
+          "valuesToCheck": [
+            {
+              "nextLogicType": "equal",
+              "answerToCheck": "P17",
+              "answerValue": "false"
+            },
+            {
+              "nextLogicType": "or",
+              "valuesToCheck": [
+                {
+                  "nextLogicType": "equal",
+                  "answerToCheck": "P10.B",
+                  "answerValue": "true"
+                },
+                {
+                  "nextLogicType": "equal",
+                  "answerToCheck": "P10.1",
+                  "answerValue": "true"
+                },
+                {
+                  "nextLogicType": "equal",
+                  "answerToCheck": "P10.2",
+                  "answerValue": "true"
+                },
+                {
+                  "nextLogicType": "equal",
+                  "answerToCheck": "P10.3",
+                  "answerValue": "true"
+                }
+              ]
+            },
+            {
+              "nextLogicType": "or",
+              "valuesToCheck": [
+                {
+                  "nextLogicType": "equal",
+                  "answerToCheck": "P5.B",
+                  "answerValue": "true"
+                },
+                {
+                  "nextLogicType": "equal",
+                  "answerToCheck": "P5.1",
+                  "answerValue": "true"
+                },
+                {
+                  "nextLogicType": "equal",
+                  "answerToCheck": "P5.2",
+                  "answerValue": "true"
+                },
+                {
+                  "nextLogicType": "equal",
+                  "answerToCheck": "P5.3",
+                  "answerValue": "true"
+                }
+              ]
+            }
+          ],
+          "nextNavigateTo": "P18"
+        },
+        {
           "nextLogicType": "equal",
           "answerToCheck": "P17",
           "answerValue": "false",
           "nextNavigateTo": "R1_2"
-        },
-        {
-          "nextLogicType": "or",
-          "valuesToCheck": [
-            {
-              "nextLogicType": "equal",
-              "answerToCheck": "P10.B",
-              "answerValue": "true"
-            },
-            {
-              "nextLogicType": "equal",
-              "answerToCheck": "P10.1",
-              "answerValue": "true"
-            },
-            {
-              "nextLogicType": "equal",
-              "answerToCheck": "P10.2",
-              "answerValue": "true"
-            },
-            {
-              "nextLogicType": "equal",
-              "answerToCheck": "P10.3",
-              "answerValue": "true"
-            }
-          ],
-          "nextNavigateTo": "P18"
         },
         {
           "nextLogicType": "or",


### PR DESCRIPTION
[HOUSNAV-238](https://hous-bssb.atlassian.net/browse/HOUSNAV-238)

## Overview & Purpose
Updated the logic and Cypress tests after the response from the SME about an issue with P18 not having P5 values to display. Google Spreadsheet has been updated with new logic and comments.

[Connected Experience](https://docs.google.com/spreadsheets/d/1Xwb0jg_NPF6fI20vE1rTmLKSnwtqtTWE/edit?gid=932386520#gid=932386520)

## Summary of Changes
- Update check of **P17 == true and P10.contains(true)** to **P17 == false and P10.contains(true)**
- Move updated case above **P17 == false** case because otherwise it would be unreachable
- Add additional check to updated check for **P5.contains(true)**
- Updated Cypress tests based on new logic

## Testing
- Check that answering P17 false, with P10 and P5 containing a true sends the user to P18
- Verify display of P18 with P5 values
- Verify that answering P17 false, with P10 containing true and P5 NOT containing a true sends the user to R1.2

## Checklist
- [x] I have written or updated vitests for this work
- [x] I have reviewed the [accessibility guidelines](https://digital.gov.bc.ca/wcag/home/) relevant to this work
- [x] I have reviewed this work with at least one screen reader (when applicable)
- [x] I have added/updated any related documentation
