### PR TITLE
HOUSNAV-229: Adding results content to pdf download

### DIFF
--- a/apps/web/components/breadcrumbs/Breadcrumbs.tsx
+++ b/apps/web/components/breadcrumbs/Breadcrumbs.tsx
@@ -30,7 +30,7 @@ const Breadcrumbs = () => {
   }
 
   return (
-    <nav className="web-Breadcrumbs" aria-label="Breadcrumb">
+    <nav className="web-Breadcrumbs p-hide" aria-label="Breadcrumb">
       <ReactAriaBreadcrumbs
         key={segments.join("_")}
         className="u-container web-Breadcrumbs--Container"

--- a/apps/web/components/result-banner/ResultBanner.css
+++ b/apps/web/components/result-banner/ResultBanner.css
@@ -1,0 +1,15 @@
+.web-ResultBanner {
+  border-radius: var(--layout-border-radius-large);
+  border: var(--layout-border-width-small) solid
+    var(--support-border-color-success);
+  background: var(--support-surface-color-success);
+  display: flex;
+  align-items: center;
+  padding: var(--layout-margin-small) 16px;
+  gap: var(--layout-padding-medium);
+  margin-top: var(--layout-margin-xxlarge);
+}
+
+.web-ResultBanner .ui-Icon {
+  color: var(--icons-color-success);
+}

--- a/apps/web/components/result-banner/ResultBanner.test.tsx
+++ b/apps/web/components/result-banner/ResultBanner.test.tsx
@@ -1,0 +1,17 @@
+// 3rd party
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+// local
+import ResultBanner from "./ResultBanner";
+
+describe("ResultBanner", () => {
+  it("Renders and passes through custom prop", () => {
+    const DISPLAY_TEXT = "Success!";
+    const TESTID = "custom-testid";
+    const { getByTestId } = render(
+      <ResultBanner text={DISPLAY_TEXT} data-testid={TESTID} />,
+    );
+
+    expect(getByTestId(TESTID)).toHaveTextContent(DISPLAY_TEXT);
+  });
+});

--- a/apps/web/components/result-banner/ResultBanner.tsx
+++ b/apps/web/components/result-banner/ResultBanner.tsx
@@ -1,0 +1,13 @@
+// repo
+import Icon from "@repo/ui/icon";
+// local
+import "./ResultBanner.css";
+
+const ResultBanner = ({ text, ...props }: { text: string }) => (
+  <p className="web-ResultBanner h4" {...props}>
+    <Icon type={"checkCircle"} />
+    {text}
+  </p>
+);
+
+export default ResultBanner;

--- a/apps/web/components/result-content/ResultContent.css
+++ b/apps/web/components/result-content/ResultContent.css
@@ -1,0 +1,54 @@
+.web-ResultContent--Header {
+  font-weight: bold;
+  margin-top: var(--layout-margin-xxlarge);
+}
+
+.web-ResultContent--Header.--hasBanner {
+  margin-bottom: var(--layout-margin-xxlarge);
+}
+
+.web-ResultContent {
+  padding-bottom: var(--layout-padding-xxlarge);
+  border-bottom: var(--layout-border-width-small) solid
+    var(--surface-color-border-default);
+}
+
+.web-ResultContent,
+.web-ResultContent button {
+  font: var(--typography-regular-large-body);
+}
+
+.web-ResultContent strong button {
+  font: var(--typography-bold-large-body);
+}
+
+.web-ResultContent sup {
+  line-height: 0;
+}
+
+.web-ResultContent ul {
+  padding: var(--layout-padding-medium) var(--layout-padding-medium)
+    var(--layout-padding-medium) var(--layout-padding-xlarge);
+}
+
+.web-ResultContent.--hideBottomBorder {
+  border-bottom: none;
+}
+
+.web-ResultContent--Continue {
+  display: flex;
+  justify-content: center;
+  margin-bottom: var(--layout-margin-large);
+}
+
+/* Print styles that only need to apply when print window is open */
+@media print {
+  .web-ResultContent--Header,
+  .web-ResultContent--Continue {
+    display: none;
+  }
+
+  .web-ResultContent {
+    border-bottom: none;
+  }
+}

--- a/apps/web/components/result-content/ResultContent.tsx
+++ b/apps/web/components/result-content/ResultContent.tsx
@@ -1,0 +1,96 @@
+// 3rd party
+import { Heading } from "react-aria-components";
+import { observer } from "mobx-react-lite";
+// repo
+import {
+  GET_TESTID_RESULT_BANNER,
+  GET_TESTID_RESULT_CONTENT_ITEM,
+  TESTID_RESULT_CONTENT_CONTINUE,
+} from "@repo/constants/src/testids";
+import Link from "@repo/ui/link";
+import useBuildingTypeData from "@repo/data/useBuildingTypeData";
+import { URLS_GET_BUILDING_TYPE } from "@repo/constants/src/urls";
+// local
+import ResultBanner from "../result-banner/ResultBanner";
+import { parseStringToComponents } from "../../utils/string";
+import { useWalkthroughState } from "../../stores/WalkthroughRootStore";
+import "./ResultContent.css";
+
+const ResultContent = observer(
+  ({ walkthroughId }: { walkthroughId: string }) => {
+    // get information from store
+    const {
+      getWalkthroughData,
+      results,
+      resultsDisplay: { showReturnToHome },
+    } = useWalkthroughState();
+    const resultId = results[walkthroughId];
+    const walkthroughData = getWalkthroughData(walkthroughId);
+    if (!resultId || !walkthroughData) return null;
+
+    const displayMessage =
+      walkthroughData.results[resultId]?.resultDisplayMessage;
+    if (!displayMessage) return null;
+
+    let resultRelatedBuildingTypeTitle;
+    let continueButtonHref;
+    const resultRelatedBuildingType =
+      walkthroughData.results[resultId]?.relatedBuildingType;
+    if (resultRelatedBuildingType) {
+      resultRelatedBuildingTypeTitle = useBuildingTypeData({
+        buildingType: resultRelatedBuildingType,
+      })?.title;
+      continueButtonHref = URLS_GET_BUILDING_TYPE(resultRelatedBuildingType);
+    }
+    // determine if we should show the heading - based off of the design logic
+    // shown when there is no Return to Home button or when there is one AND there is a related building type title
+    const showHeading =
+      !showReturnToHome || (showReturnToHome && resultRelatedBuildingTypeTitle);
+    // determine if we should hide the bottom border
+    // hidden when there is a continue button or a Return to Home button
+    const hideBottomBorder = continueButtonHref || showReturnToHome;
+
+    return (
+      <div
+        key={`${walkthroughId}-result-content`}
+        data-testid={GET_TESTID_RESULT_CONTENT_ITEM(walkthroughId)}
+      >
+        {showHeading && (
+          <Heading
+            level={3}
+            className={`web-ResultContent--Header h5 ${resultRelatedBuildingTypeTitle ? "--hasBanner" : ""}`}
+          >
+            {resultRelatedBuildingTypeTitle ? (
+              <ResultBanner
+                text={resultRelatedBuildingTypeTitle}
+                data-testid={GET_TESTID_RESULT_BANNER(walkthroughId)}
+              />
+            ) : (
+              <>{walkthroughData.info.title}</>
+            )}
+          </Heading>
+        )}
+        <div
+          className={`web-ResultContent ${hideBottomBorder ? "--hideBottomBorder" : ""}`}
+        >
+          {parseStringToComponents(displayMessage)}
+        </div>
+        {continueButtonHref && (
+          <div className="web-ResultContent--Continue">
+            <Link
+              href={continueButtonHref}
+              variant="primary"
+              showAsButton
+              isLargeButton
+              data-testid={TESTID_RESULT_CONTENT_CONTINUE}
+            >
+              Continue
+            </Link>
+          </div>
+        )}
+      </div>
+    );
+  },
+);
+
+export default ResultContent;

--- a/apps/web/components/result-content/ResultContent.tsx
+++ b/apps/web/components/result-content/ResultContent.tsx
@@ -17,7 +17,13 @@ import { useWalkthroughState } from "../../stores/WalkthroughRootStore";
 import "./ResultContent.css";
 
 const ResultContent = observer(
-  ({ walkthroughId }: { walkthroughId: string }) => {
+  ({
+    walkthroughId,
+    "data-testid": testid = "",
+  }: {
+    walkthroughId: string;
+    "data-testid"?: string;
+  }) => {
     // get information from store
     const {
       getWalkthroughData,
@@ -53,7 +59,7 @@ const ResultContent = observer(
     return (
       <div
         key={`${walkthroughId}-result-content`}
-        data-testid={GET_TESTID_RESULT_CONTENT_ITEM(walkthroughId)}
+        data-testid={GET_TESTID_RESULT_CONTENT_ITEM(testid || walkthroughId)}
       >
         {showHeading && (
           <Heading

--- a/apps/web/components/result/Result.css
+++ b/apps/web/components/result/Result.css
@@ -2,65 +2,6 @@
   overflow: auto;
 }
 
-.web-Result--Banner {
-  border-radius: var(--layout-border-radius-large);
-  border: var(--layout-border-width-small) solid
-    var(--support-border-color-success);
-  background: var(--support-surface-color-success);
-  display: flex;
-  align-items: center;
-  padding: var(--layout-margin-small) 16px;
-  gap: var(--layout-padding-medium);
-  margin-top: var(--layout-margin-xxlarge);
-}
-
-.web-Result--Banner .ui-Icon {
-  color: var(--icons-color-success);
-}
-
-.web-Result--ContentHeader {
-  font-weight: bold;
-  margin-top: var(--layout-margin-xxlarge);
-}
-
-.web-Result--ContentHeader.--hasBanner {
-  margin-bottom: var(--layout-margin-xxlarge);
-}
-
-.web-Result--Content {
-  padding-bottom: var(--layout-padding-xxlarge);
-  border-bottom: var(--layout-border-width-small) solid
-    var(--surface-color-border-default);
-}
-
-.web-Result--Content,
-.web-Result--Content button {
-  font: var(--typography-regular-large-body);
-}
-
-.web-Result--Content strong button {
-  font: var(--typography-bold-large-body);
-}
-
-.web-Result--Content sup {
-  line-height: 0;
-}
-
-.web-Result--Content ul {
-  padding: var(--layout-padding-medium) var(--layout-padding-medium)
-    var(--layout-padding-medium) var(--layout-padding-xlarge);
-}
-
-.web-Result--Content.--hideBottomBorder {
-  border-bottom: none;
-}
-
-.web-Result--Continue {
-  display: flex;
-  justify-content: center;
-  margin-bottom: var(--layout-margin-large);
-}
-
 .web-Result--ReturnToHome {
   display: flex;
   justify-content: center;

--- a/apps/web/components/result/Result.tsx
+++ b/apps/web/components/result/Result.tsx
@@ -5,32 +5,23 @@ import { observer } from "mobx-react-lite";
 import { useParams } from "next/navigation";
 // repo
 import {
-  GET_TESTID_RESULT_ITEM,
   GET_TESTID_RESULT_RELATED_ITEM,
   TESTID_RESULT,
   GET_TESTID_RESULT_BANNER,
   TESTID_RESULT_RETURN_TO_HOME,
-  TESTID_RESULT_CONTINUE,
 } from "@repo/constants/src/testids";
 import { EnumBuildingTypes } from "@repo/constants/src/constants";
 import { URLS_GET_BUILDING_TYPE } from "@repo/constants/src/urls";
 import useBuildingTypeData from "@repo/data/useBuildingTypeData";
-import Icon from "@repo/ui/icon";
 import Link from "@repo/ui/link";
 import LinkCard from "@repo/ui/link-card";
 import ResultPDFButton from "@repo/ui/result-pdf-button";
 import ResultPDFPrintContent from "@repo/ui/result-pdf-print-content";
 // local
-import { parseStringToComponents } from "../../utils/string";
+import ResultBanner from "../result-banner/ResultBanner";
+import ResultContent from "../result-content/ResultContent";
 import { useWalkthroughState } from "../../stores/WalkthroughRootStore";
 import "./Result.css";
-
-const ResultBanner = ({ text, ...props }: { text: string }) => (
-  <p className="web-Result--Banner h4" {...props}>
-    <Icon type={"checkCircle"} />
-    {text}
-  </p>
-);
 
 const Result = observer((): JSX.Element => {
   // get related walkthroughs by building type from url pathing
@@ -42,8 +33,6 @@ const Result = observer((): JSX.Element => {
   // get information from store
   const {
     walkthroughsOrder,
-    getWalkthroughData,
-    results,
     resultsDisplay: { hideRelatedItems, hidePDF, hideBanner, showReturnToHome },
   } = useWalkthroughState();
 
@@ -62,78 +51,16 @@ const Result = observer((): JSX.Element => {
           )}
         </header>
         {!hidePDF && <ResultPDFButton />}
-        {walkthroughsOrder.map((walkthroughId) => {
-          const resultId = results[walkthroughId];
-          const walkthroughData = getWalkthroughData(walkthroughId);
-          if (!resultId || !walkthroughData) return null;
-
-          const displayMessage =
-            walkthroughData.results[resultId]?.resultDisplayMessage;
-          if (!displayMessage) return null;
-
-          let resultRelatedBuildingTypeTitle;
-          let continueButtonHref;
-          const resultRelatedBuildingType =
-            walkthroughData.results[resultId]?.relatedBuildingType;
-          if (resultRelatedBuildingType) {
-            resultRelatedBuildingTypeTitle = useBuildingTypeData({
-              buildingType: resultRelatedBuildingType,
-            })?.title;
-            continueButtonHref = URLS_GET_BUILDING_TYPE(
-              resultRelatedBuildingType,
+        <div className="p-hide">
+          {walkthroughsOrder.map((walkthroughId) => {
+            return (
+              <ResultContent
+                walkthroughId={walkthroughId}
+                key={`${walkthroughId}-result-content-component`}
+              />
             );
-          }
-          // determine if we should show the heading - based off of the design logic
-          // shown when there is no Return to Home button or when there is one AND there is a related building type title
-          const showHeading =
-            !showReturnToHome ||
-            (showReturnToHome && resultRelatedBuildingTypeTitle);
-          // determine if we should hide the bottom border
-          // hidden when there is a continue button or a Return to Home button
-          const hideBottomBorder = continueButtonHref || showReturnToHome;
-
-          return (
-            <div
-              key={`${walkthroughId}-result-content`}
-              data-testid={GET_TESTID_RESULT_ITEM(walkthroughId)}
-              className="p-hide"
-            >
-              {showHeading && (
-                <Heading
-                  level={3}
-                  className={`web-Result--ContentHeader h5 ${resultRelatedBuildingTypeTitle ? "--hasBanner" : ""}`}
-                >
-                  {resultRelatedBuildingTypeTitle ? (
-                    <ResultBanner
-                      text={resultRelatedBuildingTypeTitle}
-                      data-testid={GET_TESTID_RESULT_BANNER(walkthroughId)}
-                    />
-                  ) : (
-                    <>{walkthroughData.info.title}</>
-                  )}
-                </Heading>
-              )}
-              <div
-                className={`web-Result--Content ${hideBottomBorder ? "--hideBottomBorder" : ""}`}
-              >
-                {parseStringToComponents(displayMessage)}
-              </div>
-              {continueButtonHref && (
-                <div className="web-Result--Continue p-hide">
-                  <Link
-                    href={continueButtonHref}
-                    variant="primary"
-                    showAsButton
-                    isLargeButton
-                    data-testid={TESTID_RESULT_CONTINUE}
-                  >
-                    Continue
-                  </Link>
-                </div>
-              )}
-            </div>
-          );
-        })}
+          })}
+        </div>
         {showReturnToHome && (
           <div className="web-Result--ReturnToHome p-hide">
             <Link

--- a/apps/web/cypress/e2e/building-type-analysis.cy.ts
+++ b/apps/web/cypress/e2e/building-type-analysis.cy.ts
@@ -9,7 +9,7 @@ import {
   GET_TESTID_BUTTON,
   GET_TESTID_LINK,
   GET_TESTID_RESULT_BANNER,
-  TESTID_RESULT_CONTINUE,
+  TESTID_RESULT_CONTENT_CONTINUE,
   TESTID_RESULT_RETURN_TO_HOME,
   TESTID_WALKTHROUGH_FOOTER_START_OVER,
 } from "@repo/constants/src/testids";
@@ -35,7 +35,7 @@ describe("building type analysis tests", () => {
     cy.getByTestID(GET_TESTID_LINK(TESTID_RESULT_RETURN_TO_HOME)).should(
       "be.visible",
     );
-    cy.getByTestID(GET_TESTID_LINK(TESTID_RESULT_CONTINUE)).should(
+    cy.getByTestID(GET_TESTID_LINK(TESTID_RESULT_CONTENT_CONTINUE)).should(
       "be.visible",
     );
     cy.getByTestID(

--- a/apps/web/cypress/e2e/multi-dwelling/multi-dwelling-9.10-14-results.cy.ts
+++ b/apps/web/cypress/e2e/multi-dwelling/multi-dwelling-9.10-14-results.cy.ts
@@ -9,7 +9,7 @@ import {
   EnumBuildingTypes,
   EnumWalkthroughIds,
 } from "@repo/constants/src/constants";
-import { GET_TESTID_RESULT_ITEM } from "@repo/constants/src/testids";
+import { GET_TESTID_RESULT_CONTENT_ITEM } from "@repo/constants/src/testids";
 
 describe("multi dwelling: 9.10.14 results", () => {
   beforeEach(() => {
@@ -32,14 +32,14 @@ describe("multi dwelling: 9.10.14 results", () => {
     const unobstructedOpeningArea = 333;
     const totalAllowedWindowArea = 133.2;
     const validationString = `Based on your selections, the maximum aggregate percentage of unprotected openings in this exposing building face is 40%*, based on an exposing building face of ${unobstructedOpeningArea} m2, the maximum area would be ${totalAllowedWindowArea} m2 per Table 9.10.14.4.-A and Sentence 9.10.14.4.(1)`;
-    cy.getByTestID(GET_TESTID_RESULT_ITEM(EnumWalkthroughIds._9_10_14)).should(
-      "be.visible",
-    );
     cy.getByTestID(
-      GET_TESTID_RESULT_ITEM(EnumWalkthroughIds._9_10_14),
+      GET_TESTID_RESULT_CONTENT_ITEM(EnumWalkthroughIds._9_10_14),
+    ).should("be.visible");
+    cy.getByTestID(
+      GET_TESTID_RESULT_CONTENT_ITEM(EnumWalkthroughIds._9_10_14),
     ).scrollIntoView();
     cy.getByTestID(
-      GET_TESTID_RESULT_ITEM(EnumWalkthroughIds._9_10_14),
+      GET_TESTID_RESULT_CONTENT_ITEM(EnumWalkthroughIds._9_10_14),
     ).contains(validationString);
   });
 
@@ -55,14 +55,14 @@ describe("multi dwelling: 9.10.14 results", () => {
     const exposedBuildingFace = 333;
     const totalAllowedArea = 253.08;
     const validationString = `Based on your selections, the maximum percentage of unprotected openings in this exposing building face (exterior wall) is 76%*, based on an exposing building face of ${exposedBuildingFace} m2, the maximum total area of the exposing building face would be: ${totalAllowedArea} m2.`;
-    cy.getByTestID(GET_TESTID_RESULT_ITEM(EnumWalkthroughIds._9_10_14)).should(
-      "be.visible",
-    );
     cy.getByTestID(
-      GET_TESTID_RESULT_ITEM(EnumWalkthroughIds._9_10_14),
+      GET_TESTID_RESULT_CONTENT_ITEM(EnumWalkthroughIds._9_10_14),
+    ).should("be.visible");
+    cy.getByTestID(
+      GET_TESTID_RESULT_CONTENT_ITEM(EnumWalkthroughIds._9_10_14),
     ).scrollIntoView();
     cy.getByTestID(
-      GET_TESTID_RESULT_ITEM(EnumWalkthroughIds._9_10_14),
+      GET_TESTID_RESULT_CONTENT_ITEM(EnumWalkthroughIds._9_10_14),
     ).contains(validationString);
   });
 });

--- a/apps/web/cypress/e2e/multi-dwelling/multi-dwelling-combined-results.cy.ts
+++ b/apps/web/cypress/e2e/multi-dwelling/multi-dwelling-combined-results.cy.ts
@@ -9,7 +9,7 @@ import {
 } from "../../support/helpers";
 import { walkthroughs } from "../../fixtures/multi-dwelling/multi-dwelling-combined-test-data.json";
 import {
-  GET_TESTID_RESULT_ITEM,
+  GET_TESTID_RESULT_CONTENT_ITEM,
   GET_TESTID_RESULT_PRINT_CONTENT_WALKTHROUGH,
   GET_TESTID_RESULT_RELATED_ITEM,
   TESTID_BREADCRUMBS,
@@ -29,23 +29,23 @@ describe("multi dwelling: 9.9.9 and 9.10.14 walkthrough results", () => {
   it("should display correct ui elements", () => {
     cy.getByTestID(TESTID_BREADCRUMBS).should("be.visible");
 
-    cy.getByTestID(GET_TESTID_RESULT_ITEM(EnumWalkthroughIds._9_9_9)).should(
-      "be.visible",
-    );
+    cy.getByTestID(
+      GET_TESTID_RESULT_CONTENT_ITEM(EnumWalkthroughIds._9_9_9),
+    ).should("be.visible");
     //this might need to be changed if the viewport changes since what is on versus what is off
     // the screen which requires scrolling is dependent on the screen size
     cy.getByTestID(
-      GET_TESTID_RESULT_ITEM(EnumWalkthroughIds._9_10_14),
+      GET_TESTID_RESULT_CONTENT_ITEM(EnumWalkthroughIds._9_10_14),
     ).scrollIntoView();
-    cy.getByTestID(GET_TESTID_RESULT_ITEM(EnumWalkthroughIds._9_10_14)).should(
-      "be.visible",
-    );
+    cy.getByTestID(
+      GET_TESTID_RESULT_CONTENT_ITEM(EnumWalkthroughIds._9_10_14),
+    ).should("be.visible");
     cy.getByTestID(
       GET_TESTID_RESULT_RELATED_ITEM(EnumBuildingTypes.SINGLE_DWELLING),
     ).scrollIntoView();
-    cy.getByTestID(GET_TESTID_RESULT_ITEM(EnumWalkthroughIds._9_10_14)).should(
-      "be.visible",
-    );
+    cy.getByTestID(
+      GET_TESTID_RESULT_CONTENT_ITEM(EnumWalkthroughIds._9_10_14),
+    ).should("be.visible");
     //should display correct print content
     cy.getByTestID(
       GET_TESTID_RESULT_PRINT_CONTENT_WALKTHROUGH(EnumWalkthroughIds._9_9_9),

--- a/apps/web/cypress/e2e/single-dwelling/single-dwelling-9.9.9-results.cy.ts
+++ b/apps/web/cypress/e2e/single-dwelling/single-dwelling-9.9.9-results.cy.ts
@@ -9,7 +9,7 @@ import {
 } from "../../support/helpers";
 import { walkthroughs } from "../../fixtures/single-dwelling/single-dwelling-9.9.9-test-data.json";
 import {
-  GET_TESTID_RESULT_ITEM,
+  GET_TESTID_RESULT_CONTENT_ITEM,
   GET_TESTID_RESULT_PRINT_CONTENT_WALKTHROUGH,
   GET_TESTID_RESULT_RELATED_ITEM,
   TESTID_BREADCRUMBS,
@@ -26,9 +26,9 @@ describe("single dwelling: 9.9.9 walkthrough results", () => {
   it("should display correct ui elements", () => {
     cy.getByTestID(TESTID_BREADCRUMBS).should("be.visible");
 
-    cy.getByTestID(GET_TESTID_RESULT_ITEM(EnumWalkthroughIds._9_9_9)).should(
-      "be.visible",
-    );
+    cy.getByTestID(
+      GET_TESTID_RESULT_CONTENT_ITEM(EnumWalkthroughIds._9_9_9),
+    ).should("be.visible");
     cy.getByTestID(
       GET_TESTID_RESULT_RELATED_ITEM(EnumBuildingTypes.MULTI_DWELLING),
     ).scrollIntoView();

--- a/packages/constants/src/testids.ts
+++ b/packages/constants/src/testids.ts
@@ -55,6 +55,8 @@ export const GET_TESTID_RESULT_RELATED_ITEM = (id: string) =>
 export const TESTID_RESULT_PRINT_CONTENT = "result-print-content";
 export const GET_TESTID_RESULT_PRINT_CONTENT_WALKTHROUGH = (id: string) =>
   `result-print-content-walkthrough-${id}`;
+export const GET_TESTID_RESULT_PDF_RESULT_CONTENT = (id: string) =>
+  `result-pdf-result-content-${id}`;
 export const TESTID_HEADER = "header";
 export const TESTID_HEADER_MOBILE_NAV = "header-mobile-nav";
 export const TESTID_HEADER_MOBILE_NAV_BUTTON = "header-mobile-nav-button";

--- a/packages/constants/src/testids.ts
+++ b/packages/constants/src/testids.ts
@@ -47,8 +47,9 @@ export const GET_TESTID_RESULT_BANNER = (id = "welcome") =>
   `result-banner-${id}`;
 export const TESTID_RESULT_PDF_BUTTON = "result-pdf-button";
 export const TESTID_RESULT_RETURN_TO_HOME = "result-return-to-home";
-export const TESTID_RESULT_CONTINUE = "result-continue";
-export const GET_TESTID_RESULT_ITEM = (id: string) => `result-item-${id}`;
+export const TESTID_RESULT_CONTENT_CONTINUE = "result-continue";
+export const GET_TESTID_RESULT_CONTENT_ITEM = (id: string) =>
+  `result-item-${id}`;
 export const GET_TESTID_RESULT_RELATED_ITEM = (id: string) =>
   `result-related-item-${id}`;
 export const TESTID_RESULT_PRINT_CONTENT = "result-print-content";

--- a/packages/ui/src/result-pdf-print-content/ResultPDFPrintContent.tsx
+++ b/packages/ui/src/result-pdf-print-content/ResultPDFPrintContent.tsx
@@ -11,6 +11,7 @@ import {
   SectionData,
 } from "@repo/data/useWalkthroughsData";
 import {
+  GET_TESTID_RESULT_PDF_RESULT_CONTENT,
   GET_TESTID_RESULT_PRINT_CONTENT_WALKTHROUGH,
   TESTID_RESULT_PRINT_CONTENT,
 } from "@repo/constants/src/testids";
@@ -311,7 +312,10 @@ export default function ResultPDFPrintContent() {
             <h3 className="ui-ResultPDFPrintContent--walkthroughTitle">
               {walkthroughsById[walkthroughId]?.info.walkthroughTitle}
             </h3>
-            <ResultContent walkthroughId={walkthroughId} />
+            <ResultContent
+              walkthroughId={walkthroughId}
+              data-testid={GET_TESTID_RESULT_PDF_RESULT_CONTENT(walkthroughId)}
+            />
             {Object.entries(printSectionDataBySectionTitle).map(
               ([, printSectionData], sectionIndex) => (
                 <table

--- a/packages/ui/src/result-pdf-print-content/ResultPDFPrintContent.tsx
+++ b/packages/ui/src/result-pdf-print-content/ResultPDFPrintContent.tsx
@@ -27,6 +27,7 @@ import {
   AnswerStoreGetAnswerValueFunctionType,
 } from "web/stores/AnswerStore";
 import { isNumber } from "web/utils/typeChecking";
+import ResultContent from "web/components/result-content/ResultContent";
 import BuildingCodeContent from "../modal-building-code-content/ModalBuildingCodeContent";
 import "./ResultPDFPrintContent.css";
 
@@ -310,6 +311,7 @@ export default function ResultPDFPrintContent() {
             <h3 className="ui-ResultPDFPrintContent--walkthroughTitle">
               {walkthroughsById[walkthroughId]?.info.walkthroughTitle}
             </h3>
+            <ResultContent walkthroughId={walkthroughId} />
             {Object.entries(printSectionDataBySectionTitle).map(
               ([, printSectionData], sectionIndex) => (
                 <table


### PR DESCRIPTION
[HOUSNAV-229](https://hous-bssb.atlassian.net/browse/HOUSNAV-229)

## Overview & Purpose
Adding text result content to the PDF download

## Summary of Changes
- Quick fix for hiding breadcrumbs while printing
- Moved the ResultsBanner and ResultsContent into their own components for easier use across different spots
- Added ResultsContent to the ResultPDFPrintContent
- Updated some testid names based on the new component names
- NOTE: I did not add unit tests for the ResultContent component as we test most of the specific content of that during UI tests already as it is tied to the results messages themselves.

## Testing
- Work through a walkthrough or 2 and verify the results messages/content appear when clicking to download the PDF

## Checklist
- [x] I have written or updated vitests for this work
- [x] I have reviewed the [accessibility guidelines](https://digital.gov.bc.ca/wcag/home/) relevant to this work
- [x] I have reviewed this work with at least one screen reader (when applicable)
- [x] I have added/updated any related documentation
