### PR TITLE
HOUSNAV-168: Result Page Notes for PDF

### DIFF
--- a/apps/web/components/result-content/ResultContent.css
+++ b/apps/web/components/result-content/ResultContent.css
@@ -9,8 +9,7 @@
 
 .web-ResultContent {
   padding-bottom: var(--layout-padding-xxlarge);
-  border-bottom: var(--layout-border-width-small) solid
-    var(--surface-color-border-default);
+  border-bottom: var(--result-content-border-bottom);
 }
 
 .web-ResultContent,

--- a/apps/web/components/result/Result.css
+++ b/apps/web/components/result/Result.css
@@ -7,6 +7,29 @@
   justify-content: center;
 }
 
+.web-Result--Notes {
+  margin-block: var(--layout-margin-xxlarge);
+  padding-block-end: var(--layout-padding-xxlarge);
+  border-block-end: var(--result-content-border-bottom);
+}
+
+.web-Result--Notes p {
+  font: var(--typography-regular-large-body);
+}
+
+.web-Result--NotesTextArea {
+  resize: none;
+  width: 100%;
+  min-height: 200px;
+  overflow: hidden;
+  padding: var(--layout-padding-medium);
+  border: var(--layout-border-width-small) solid
+    var(--surface-color-border-default);
+  border-radius: var(--layout-border-radius-medium);
+  font: var(--typography-regular-body);
+  margin-block-start: var(--layout-margin-medium);
+}
+
 .web-Result--Related {
   margin-block: var(--layout-margin-xxlarge);
 }
@@ -20,4 +43,12 @@
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(330px, 1fr));
   gap: var(--layout-padding-large);
+}
+
+/* Print styles that only need to apply when print window is open */
+@media print {
+  .web-Result--Notes {
+    padding-block-end: 0;
+    border-block-end: none;
+  }
 }

--- a/apps/web/components/result/Result.tsx
+++ b/apps/web/components/result/Result.tsx
@@ -1,6 +1,6 @@
 // 3rd party
 import { JSX } from "react";
-import { Heading } from "react-aria-components";
+import { Heading, TextArea } from "react-aria-components";
 import { observer } from "mobx-react-lite";
 import { useParams } from "next/navigation";
 // repo
@@ -24,6 +24,7 @@ import { useWalkthroughState } from "../../stores/WalkthroughRootStore";
 import "./Result.css";
 
 const Result = observer((): JSX.Element => {
+  const textAreaCharacterLimit = 1000;
   // get related walkthroughs by building type from url pathing
   const params = useParams<Record<string, string>>();
   const relatedBuildingTypes = useBuildingTypeData({
@@ -71,6 +72,28 @@ const Result = observer((): JSX.Element => {
             >
               Return to Home
             </Link>
+          </div>
+        )}
+        {!hidePDF && (
+          <div className="web-Result--Notes">
+            <Heading level={2} className="h4" id="notes">
+              Notes
+              <p className="p-hide">
+                Type any notes in to the following textarea and they will be
+                added to the PDF when printed or downloaded. Limit of{" "}
+                {textAreaCharacterLimit} characters.
+              </p>
+            </Heading>
+            <TextArea
+              className="web-Result--NotesTextArea"
+              maxLength={textAreaCharacterLimit}
+              onInput={(event) => {
+                event.currentTarget.style.height = "";
+                event.currentTarget.style.height =
+                  event.currentTarget.scrollHeight + "px";
+              }}
+              aria-labelledby="notes"
+            ></TextArea>
           </div>
         )}
         {relatedBuildingTypes.length > 0 && !hideRelatedItems && (

--- a/apps/web/cypress/e2e/multi-dwelling/multi-dwelling-combined-results.cy.ts
+++ b/apps/web/cypress/e2e/multi-dwelling/multi-dwelling-combined-results.cy.ts
@@ -10,9 +10,11 @@ import {
 import { walkthroughs } from "../../fixtures/multi-dwelling/multi-dwelling-combined-test-data.json";
 import {
   GET_TESTID_RESULT_CONTENT_ITEM,
+  GET_TESTID_RESULT_PDF_RESULT_CONTENT,
   GET_TESTID_RESULT_PRINT_CONTENT_WALKTHROUGH,
   GET_TESTID_RESULT_RELATED_ITEM,
   TESTID_BREADCRUMBS,
+  TESTID_RESULT_NOTES,
 } from "@repo/constants/src/testids";
 
 describe("multi dwelling: 9.9.9 and 9.10.14 walkthrough results", () => {
@@ -53,6 +55,12 @@ describe("multi dwelling: 9.9.9 and 9.10.14 walkthrough results", () => {
     cy.getByTestID(
       GET_TESTID_RESULT_PRINT_CONTENT_WALKTHROUGH(EnumWalkthroughIds._9_10_14),
     ).should("be.hidden");
+    cy.getByTestID(
+      GET_TESTID_RESULT_CONTENT_ITEM(
+        GET_TESTID_RESULT_PDF_RESULT_CONTENT(EnumWalkthroughIds._9_10_14),
+      ),
+    ).should("be.hidden");
+    cy.getByTestID(TESTID_RESULT_NOTES).should("be.visible");
   });
 
   it("should be able to navigate to related item landing page", () => {

--- a/apps/web/cypress/e2e/multi-dwelling/multi-dwelling-combined-results.cy.ts
+++ b/apps/web/cypress/e2e/multi-dwelling/multi-dwelling-combined-results.cy.ts
@@ -44,7 +44,7 @@ describe("multi dwelling: 9.9.9 and 9.10.14 walkthrough results", () => {
       GET_TESTID_RESULT_RELATED_ITEM(EnumBuildingTypes.SINGLE_DWELLING),
     ).scrollIntoView();
     cy.getByTestID(
-      GET_TESTID_RESULT_CONTENT_ITEM(EnumWalkthroughIds._9_10_14),
+      GET_TESTID_RESULT_RELATED_ITEM(EnumBuildingTypes.SINGLE_DWELLING),
     ).should("be.visible");
     //should display correct print content
     cy.getByTestID(

--- a/apps/web/cypress/e2e/single-dwelling/single-dwelling-9.9.9-results.cy.ts
+++ b/apps/web/cypress/e2e/single-dwelling/single-dwelling-9.9.9-results.cy.ts
@@ -10,9 +10,11 @@ import {
 import { walkthroughs } from "../../fixtures/single-dwelling/single-dwelling-9.9.9-test-data.json";
 import {
   GET_TESTID_RESULT_CONTENT_ITEM,
+  GET_TESTID_RESULT_PDF_RESULT_CONTENT,
   GET_TESTID_RESULT_PRINT_CONTENT_WALKTHROUGH,
   GET_TESTID_RESULT_RELATED_ITEM,
   TESTID_BREADCRUMBS,
+  TESTID_RESULT_NOTES,
 } from "@repo/constants/src/testids";
 
 describe("single dwelling: 9.9.9 walkthrough results", () => {
@@ -39,6 +41,12 @@ describe("single dwelling: 9.9.9 walkthrough results", () => {
     cy.getByTestID(
       GET_TESTID_RESULT_PRINT_CONTENT_WALKTHROUGH(EnumWalkthroughIds._9_9_9),
     ).should("be.hidden");
+    cy.getByTestID(
+      GET_TESTID_RESULT_CONTENT_ITEM(
+        GET_TESTID_RESULT_PDF_RESULT_CONTENT(EnumWalkthroughIds._9_9_9),
+      ),
+    ).should("be.hidden");
+    cy.getByTestID(TESTID_RESULT_NOTES).should("be.visible");
   });
 
   it("should be able to navigate to related item landing page", () => {

--- a/packages/constants/src/testids.ts
+++ b/packages/constants/src/testids.ts
@@ -47,6 +47,7 @@ export const GET_TESTID_RESULT_BANNER = (id = "welcome") =>
   `result-banner-${id}`;
 export const TESTID_RESULT_PDF_BUTTON = "result-pdf-button";
 export const TESTID_RESULT_RETURN_TO_HOME = "result-return-to-home";
+export const TESTID_RESULT_NOTES = "result-notes";
 export const TESTID_RESULT_CONTENT_CONTINUE = "result-continue";
 export const GET_TESTID_RESULT_CONTENT_ITEM = (id: string) =>
   `result-item-${id}`;

--- a/packages/ui/src/variables.css
+++ b/packages/ui/src/variables.css
@@ -297,6 +297,8 @@
   --modal-bc-sentence-padding-end: calc(var(--layout-margin-small) * 2);
   --modal-bc-indent: 114px;
   --modal-side-number-padding: 8%;
+  --result-content-border-bottom: var(--layout-border-width-small) solid
+    var(--surface-color-border-default);
   --print-content-table-th-td-border: 2px solid #000;
   --pdf-result-download-image-border-radius: 8px 0px 0px 8px;
   --pdf-result-download-container-border: 1px solid


### PR DESCRIPTION
[HOUSNAV-168](https://hous-bssb.atlassian.net/browse/HOUSNAV-168)

## Overview & Purpose
Give the user the ability to add some notes to their downloadable/printable PDF

## Summary of Changes
- Adding helper CSS style for the bottom border line to use across components
- Adding the notes textarea and user instructions
- Making sure the textarea resizes as the user types AND the full content of what the user types in displays in the PDF

## Testing
- Run through a walkthrough. Type Notes into the Notes area. Click the Download button to see the PDF and see the notes added at the tope of the PDF.
- Verify that only 1000 characters can be added to the Notes section

## Checklist
- [x] I have written or updated vitests for this work
- [x] I have reviewed the [accessibility guidelines](https://digital.gov.bc.ca/wcag/home/) relevant to this work
- [x] I have reviewed this work with at least one screen reader (when applicable)
- [x] I have added/updated any related documentation
