### PR TITLE
HOUSNAV-238: adding test to validate that the answer from P5 propagates to P18

### DIFF
--- a/apps/web/cypress/e2e/multi-dwelling/multi-dwelling-9.9.9-walkthrough.cy.ts
+++ b/apps/web/cypress/e2e/multi-dwelling/multi-dwelling-9.9.9-walkthrough.cy.ts
@@ -3,8 +3,16 @@ import {
   EnumBuildingTypes,
   EnumWalkthroughIds,
 } from "@repo/constants/src/constants";
-import { runWalkthrough } from "../../support/helpers";
-import { GET_TESTID_STEP_TRACKER_WALKTHROUGH_HEADER } from "@repo/constants/src/testids";
+import {
+  answerCurrentQuestion,
+  getWalkthrough,
+  navigateToNextQuestion,
+  runWalkthrough,
+} from "../../support/helpers";
+import {
+  GET_TESTID_STEP_TRACKER_WALKTHROUGH_HEADER,
+  TESTID_QUESTION,
+} from "@repo/constants/src/testids";
 import { walkthroughs } from "../../fixtures/multi-dwelling/multi-dwelling-9.9.9-test-data.json";
 import { results } from "../../fixtures/results-data.json";
 
@@ -28,6 +36,26 @@ describe("multi dwelling: 9.9.9 walkthrough", () => {
     cy.getByTestID(
       GET_TESTID_STEP_TRACKER_WALKTHROUGH_HEADER(EnumWalkthroughIds._9_9_9),
     ).should("be.hidden");
+  });
+
+  it.only("validate p18 shows value from previous question p5", () => {
+    // This walkthrough should hit both P5 and P18
+    const walkthroughContainingP5P18 = getWalkthrough(walkthroughs, 1);
+    let p5AnswerValue = "";
+
+    for (const step of walkthroughContainingP5P18.steps) {
+      if (step.question === "P5") {
+        p5AnswerValue = step.answer;
+      }
+      if (step.question === "P18") {
+        cy.getByTestID(TESTID_QUESTION).contains(
+          `Does this dwelling unit have separate and direct access from each storey to a balcony on storey(s): ${p5AnswerValue}?`,
+        );
+        break;
+      }
+      answerCurrentQuestion(step);
+      navigateToNextQuestion();
+    }
   });
 
   it("default state should be accessible", () => {

--- a/apps/web/cypress/e2e/multi-dwelling/multi-dwelling-9.9.9-walkthrough.cy.ts
+++ b/apps/web/cypress/e2e/multi-dwelling/multi-dwelling-9.9.9-walkthrough.cy.ts
@@ -48,14 +48,16 @@ describe("multi dwelling: 9.9.9 walkthrough", () => {
         p5AnswerValue = step.answer;
       }
       if (step.question === "P18") {
-        cy.getByTestID(TESTID_QUESTION).contains(
-          `Does this dwelling unit have separate and direct access from each storey to a balcony on storey(s): ${p5AnswerValue}?`,
-        );
         break;
       }
       answerCurrentQuestion(step);
       navigateToNextQuestion();
     }
+    //we should always break on P18 so if this fails either we have the wrong number in the question or we're
+    //not breaking on P18
+    cy.getByTestID(TESTID_QUESTION).contains(
+      `Does this dwelling unit have separate and direct access from each storey to a balcony on storey(s): ${p5AnswerValue}?`,
+    );
   });
 
   it("default state should be accessible", () => {

--- a/apps/web/cypress/e2e/multi-dwelling/multi-dwelling-9.9.9-walkthrough.cy.ts
+++ b/apps/web/cypress/e2e/multi-dwelling/multi-dwelling-9.9.9-walkthrough.cy.ts
@@ -38,7 +38,7 @@ describe("multi dwelling: 9.9.9 walkthrough", () => {
     ).should("be.hidden");
   });
 
-  it.only("validate p18 shows value from previous question p5", () => {
+  it("validate p18 shows value from previous question p5", () => {
     // This walkthrough should hit both P5 and P18
     const walkthroughContainingP5P18 = getWalkthrough(walkthroughs, 1);
     let p5AnswerValue = "";


### PR DESCRIPTION
<!-- You may remove any sections that are not applicable -->

[HOUSNAV-238](https://hous-bssb.atlassian.net/browse/HOUSNAV-238)

## Overview & Purpose
Adding test to validate existing behavior for taking the value from the answer to p5 and putting it into the question for p18 works

## Summary of Changes
one new cypress test
