### PR TITLE
HOUSNAV-249: Building Code Broken Defined Terms

### DIFF
--- a/packages/data/json/buildingCode.json
+++ b/packages/data/json/buildingCode.json
@@ -221,7 +221,7 @@
                     },
                     {
                       "numberReference": "v2-db-9.10.14.2.(4)",
-                      "description": "If a <defined-term>building</defined-term> is divided by <defined-term override-term='fire separation'>fire separations</defined-term> into <defined-term-glossary override-term='fire compartment'>fire compartments</defined-term-glossary>, the area of <defined-term>exposing building face</defined-term> is permitted to be calculated for each <defined-term-glossary>fire compartment</defined-term-glossary>, provided the <defined-term override-term='fire separation'>fire separations</defined-term> have a <defined-term>fire-resistance rating</defined-term> not less than 45 min."
+                      "description": "If a <defined-term>building</defined-term> is divided by <defined-term override-term='fire separation'>fire separations</defined-term> into <defined-term override-term='fire compartment'>fire compartments</defined-term>, the area of <defined-term>exposing building face</defined-term> is permitted to be calculated for each <defined-term>fire compartment</defined-term>, provided the <defined-term override-term='fire separation'>fire separations</defined-term> have a <defined-term>fire-resistance rating</defined-term> not less than 45 min."
                     }
                   ]
                 },
@@ -267,7 +267,7 @@
                           "description": "where the <defined-term>limiting distance</defined-term> is not less than 1.2 m, be equal to or less than",
                           "subClauses": [
                             "the <defined-term>limiting distance</defined-term> squared, for <defined-term override-term='residential occupancy'>residential occupancies</defined-term>, <defined-term override-term='business and personal services occupancy'>business and personal services occupancies</defined-term> and <defined-term override-term='low-hazard industrial occupancy'>low-hazard industrial occupancies</defined-term>, and",
-                            "half the <defined-term>limiting distance</defined-term> squared, for <defined-term override-term='mercantile occupancy'>mercantile occupancies</defined-term> and <defined-term-glossary override-term='medium-hazard industrial occupancy'>medium hazard industrial occupancies</defined-term-glossary>."
+                            "half the <defined-term>limiting distance</defined-term> squared, for <defined-term override-term='mercantile occupancy'>mercantile occupancies</defined-term> and <defined-term override-term='medium-hazard industrial occupancy'>medium hazard industrial occupancies</defined-term>."
                           ]
                         }
                       ],


### PR DESCRIPTION
[HOUSNAV-249](https://hous-bssb.atlassian.net/browse/HOUSNAV-249)

## Overview & Purpose
2 defined terms in the building code modal did not open the defined terms modal when clicked. This is the fix for that.

## Summary of Changes
Updated the tags from `defined-term-glossary` to `defined-term`

## Testing
- Navigate to a walkthrough and open up the building code modal
- Navigate to 
  - 9.10.14.2.(4) - fire compartments and fire compartment
  - 9.10.14.4.(1)(c)(ii) - medium hazard industrial occupancies
- Click and observe the defined terms modal opening

## Checklist
- [x] I have written or updated vitests for this work
- [x] I have reviewed the [accessibility guidelines](https://digital.gov.bc.ca/wcag/home/) relevant to this work
- [x] I have reviewed this work with at least one screen reader (when applicable)
- [x] I have added/updated any related documentation
